### PR TITLE
Fix issue with errors in function values crashing hydra

### DIFF
--- a/src/GeneratorFactory.js
+++ b/src/GeneratorFactory.js
@@ -60,7 +60,14 @@ function formatArguments (userArgs, defaultArgs) {
       if (userArgs[index].transform) typedArg.isUniform = false
 
       if (typeof userArgs[index] === 'function') {
-        typedArg.value = (context, props, batchId) => (userArgs[index](props))
+        typedArg.value = (context, props, batchId) => {
+          try {
+            return userArgs[index](props)
+          } catch (e) {
+            console.log('ERROR', e)
+            return input.default
+          }
+        }
       } else if (userArgs[index].constructor === Array) {
       //  console.log("is Array")
         typedArg.value = (context, props, batchId) => seq(userArgs[index])(props)


### PR DESCRIPTION
So I had a quick look into issue https://github.com/ojack/hydra/issues/51 on the hydra repo that @zachkrall tagged me in.
As best I can tell, the problem is that whilst all the javascript that gets evaluated is within a try/catch block, any functions passed in as arguments don't get run within this and so errors won't get caught.

I *think* this change will fix it by adding try/catch statements around the functions when they're run, but I'm not actually able to build hydra-synth for some reason and so don't know yet 😅 

I'll see about having another go later today, but thought I'd throw this up here now.