### PR TITLE
adding back in the seq function

### DIFF
--- a/src/GeneratorFactory.js
+++ b/src/GeneratorFactory.js
@@ -36,7 +36,12 @@ function generateGlsl (inputs) {
   })
   return str
 }
-
+// timing function that accepts a sequence of values as an array
+const seq = (arr = []) => ({time, bpm}) =>
+{
+   let speed = arr.speed ? arr.speed : 1
+   return arr[Math.floor(time * speed * (bpm / 60) % (arr.length))]
+}
 // when possible, reformats arguments to be the correct type
 // creates unique names for variables requiring a uniform to be passed in (i.e. a texture)
 // returns an object that contains the type and value of each argument


### PR DESCRIPTION
one of the timing function calls held on after being torn out, so to honor its tenacity, we should support it with an implementation once again!

tested it by running the current master branch in my node modules and browserifying my js