### PR TITLE
Make .fast accept functions as well

### DIFF
--- a/src/GeneratorFactory.js
+++ b/src/GeneratorFactory.js
@@ -39,8 +39,18 @@ function generateGlsl (inputs) {
 // timing function that accepts a sequence of values as an array
 const seq = (arr = []) => ({time, bpm}) =>
 {
-   let speed = arr.speed ? arr.speed({time, bpm}) : 1
-   return arr[Math.floor(time * speed * (bpm / 60) % (arr.length))]
+  let speed;
+  if(arr.speed){
+    try {
+      speed = arr.speed({time, bpm, arr})
+      speed = speed * 1 // force numeric conversion
+    }
+    catch(e){
+      console.log('ERROR',e)
+    }
+  }
+  speed = speed ? speed : 1
+  return arr[Math.floor(time * speed * (bpm / 60) % (arr.length))]
 }
 // when possible, reformats arguments to be the correct type
 // creates unique names for variables requiring a uniform to be passed in (i.e. a texture)
@@ -111,7 +121,8 @@ var GeneratorFactory = function (defaultOutput) {
   Array.prototype.fast = function(speed) {
     // always make speed a function to not have to check later
     if(typeof speed !== 'function'){
-      speed = () => speed;
+      const aspeed = speed
+      speed = () => aspeed
     }
     this.speed = speed
     return this

--- a/src/GeneratorFactory.js
+++ b/src/GeneratorFactory.js
@@ -39,7 +39,7 @@ function generateGlsl (inputs) {
 // timing function that accepts a sequence of values as an array
 const seq = (arr = []) => ({time, bpm}) =>
 {
-   let speed = arr.speed ? arr.speed : 1
+   let speed = arr.speed ? arr.speed({time, bpm}) : 1
    return arr[Math.floor(time * speed * (bpm / 60) % (arr.length))]
 }
 // when possible, reformats arguments to be the correct type
@@ -109,6 +109,10 @@ var GeneratorFactory = function (defaultOutput) {
 
   // extend Array prototype
   Array.prototype.fast = function(speed) {
+    // always make speed a function to not have to check later
+    if(typeof speed !== 'function'){
+      speed = () => speed;
+    }
     this.speed = speed
     return this
   }


### PR DESCRIPTION
Hi,

I've found that `.fast` currently does not seem to take a function as a parameter. I've made a modification to allow for this and wanted to ask if you'd consider merging it.

IMHO there's two ways to go about implementing this: 

1. Either check each time an array element is needed if `Array.speed` is a function and then call it or otherwise use a scalar value
2. Upon assignment of `speed` always make it a function, even if it only returns a simple value

I've opted for approach 2, but if you prefer 1, please let me know and I'll change it.

I also thought about using `formatArguments` but that would have introduced a lot more code, so I didn't.

Best regards, @oscons 