### PR TITLE
makeGlobal=false

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -62,7 +62,7 @@ var cosN = v => (Math.cos(v)+1)/2
 // 	.modulate(noise(3, .21))
 //   	.out(o0)
 
-  synth.setFunction('ooo', {
+  hydra.synth.setFunction('ooo', {
         type: 'src',
         inputs: [
           {

--- a/example/index.js
+++ b/example/index.js
@@ -62,7 +62,7 @@ var cosN = v => (Math.cos(v)+1)/2
 // 	.modulate(noise(3, .21))
 //   	.out(o0)
 
-  hydra.synth.setFunction('ooo', {
+  synth.setFunction('ooo', {
         type: 'src',
         inputs: [
           {

--- a/index.js
+++ b/index.js
@@ -305,6 +305,8 @@ class HydraSynth {
       }
     })
 
+    if (this.makeGlobal) window.synth = this.synth
+
    //console.log('functions', functions)
     // Object.keys(functions).forEach((key)=>{
     //   self[key] = functions[key]

--- a/index.js
+++ b/index.js
@@ -4,13 +4,12 @@ const Source = require('./src/hydra-source.js')
 //const GeneratorFactory = require('./src/GeneratorFactory.js')
 
 //const RenderPasses = require('./RenderPasses.js')
-const mouse = require('mouse-change')()
+const Mouse = require('mouse-change')()
 const Audio = require('./src/lib/audio.js')
 const VidRecorder = require('./src/lib/video-recorder.js')
 
-const synth = require('./src/create-synth.js')
+const Synth = require('./src/create-synth.js')
 
-window.synth = synth
 // to do: add ability to pass in certain uniforms and transforms
 class HydraSynth {
 
@@ -42,6 +41,8 @@ class HydraSynth {
     // if stream capture is enabled, this object contains the capture stream
     this.captureStream = null
 
+    this.synth = undefined
+
     this._initCanvas(canvas)
     this._initRegl()
     this._initOutputs(numOutputs)
@@ -49,25 +50,28 @@ class HydraSynth {
     this._generateGlslTransforms()
   // this._generateRenderPasses()
 
-    window.screencap = () => {
+    this.screencap = () => {
       this.saveFrame = true
     }
+    if (this.makeGlobal) window.screencap = this.screencap
 
     if (enableStreamCapture) {
       this.captureStream = this.canvas.captureStream(25)
 
       // to do: enable capture stream of specific sources and outputs
-      window.vidRecorder = new VidRecorder(this.captureStream)
+      this.vidRecorder = new VidRecorder(this.captureStream)
+      if (this.makeGlobal) window.vidRecorder = this.vidRecorder
     }
 
     if(detectAudio) this._initAudio()
-    //if(makeGlobal) {
-      window.mouse = mouse
-      window.time = this.time
-      window['render'] = this.render.bind(this)
-    //  window.bpm = this.bpm
-      window.bpm = this._setBpm.bind(this)
-  //  }
+
+    this.mouse = Mouse
+
+    if (makeGlobal) window.mouse = this.mouse
+    if (makeGlobal) window.time = this.time
+    if (makeGlobal) window.render = this.render.bind(this)
+    if (makeGlobal) window.bpm = this._setBpm.bind(this)
+
     if(autoLoop) loop(this.tick.bind(this)).start()
   }
 
@@ -103,8 +107,21 @@ class HydraSynth {
   }
 
   _initAudio () {
+    const that = this
     this.audio = new Audio({
-      numBins: 4
+      numBins: 4,
+      changeListener: ({audio}) => {
+        that.a = audio.bins.map((_, index) =>
+          (scale = 1, offset = 0) => () => (audio.fft[index] * scale + offset)
+        )
+
+        if (that.makeGlobal) {
+          that.a.forEach((a, index) => {
+            const aname = `a${index}`
+            window[aname] = a
+          })
+        }
+      }
     })
     if(this.makeGlobal) window.a = this.audio
   }
@@ -278,7 +295,16 @@ class HydraSynth {
     //   }
     // })
 
-    var functions = synth.init(this.o[0])
+    this.synth = new Synth(this.o[0], ({type, method, synth}) => {
+      if (this.makeGlobal) {
+        if (type === 'add') {
+          window[method] = synth.generators[method]
+        } else if (type === 'remove') {
+          delete window[method]
+        }
+      }
+    })
+
    //console.log('functions', functions)
     // Object.keys(functions).forEach((key)=>{
     //   self[key] = functions[key]
@@ -318,7 +344,7 @@ class HydraSynth {
     // this.regl.clear({
     //   color: [0, 0, 0, 1]
     // })
-    window.time = this.time
+    if (this.makeGlobal) window.time = this.time
     if(this.detectAudio === true) this.audio.tick()
     for (let i = 0; i < this.s.length; i++) {
       this.s[i].tick(this.time)
@@ -328,7 +354,7 @@ class HydraSynth {
     //  console.log('WIDTH', this.canvas.width, this.o[0].getCurrent())
       this.o[i].tick({
         time: this.time,
-        mouse: mouse,
+        mouse: this.mouse,
         bpm: this.bpm,
         resolution: [this.canvas.width, this.canvas.height]
       })

--- a/src/create-synth.js
+++ b/src/create-synth.js
@@ -1,52 +1,65 @@
 const glslTransforms = require('./glsl/composable-glsl-functions.js')
-const glslSource = require('./glsl-source.js')
-
-window.glslSource = glslSource
+const GlslSource = require('./glsl-source.js')
 
 const renderpassFunctions = require('./glsl/renderpass-functions.js')
 
-var synth = {
-  init: (defaultOutput) => {
-      synth.defaultOutput = defaultOutput
-      Array.prototype.fast = function(speed) {
-        this.speed = speed
-        return this
-      }
-      var functions = []
-      Object.keys(glslTransforms).forEach((method) => {
-        const transform = glslTransforms[method]
-        functions[method] = synth.setFunction(method, transform)
-      })
-      Object.keys(renderpassFunctions).forEach((method) => {
-        const transform = renderpassFunctions[method]
-        functions[method] = synth.setFunction(method, transform)
-      })
-      return functions
- },
+Array.prototype.fast = function (speed) {
+  this.speed = speed
+  return this
+}
 
-  glslTransforms: {},
+class Synth {
+  constructor (defaultOutput, changeListener = (() => {})) {
+    this.defaultOutput = defaultOutput
+    this.changeListener = changeListener
+    this.generators = {}
+    this.init()
+  }
+  init () {
+    this.glslTransforms = {}
+    this.generators = Object.entries(this.generators).reduce((prev, [method, transform]) => {
+      this.changeListener({type: 'remove', synth: this, method})
+      return prev
+    }, {})
 
-  setFunction: (method, transform) => {
-    synth.glslTransforms[method] = transform
-    if(transform.type === 'src'){
-      var func = (...args) => {
-    //    var obj = Object.create(glslSource.prototype)
-       var obj = new glslSource({ name: method, transform: transform, userArgs: args, defaultOutput: synth.defaultOutput, synth: synth })
-        return obj
+    this.sourceClass = (() => {
+      return class extends GlslSource {
       }
-      // to do: make not global
-      window[method] = func
+    })()
+
+    var functions = []
+    Object.keys(glslTransforms).forEach((method) => {
+      const transform = glslTransforms[method]
+      functions[method] = this.setFunction(method, transform)
+    })
+    Object.keys(renderpassFunctions).forEach((method) => {
+      const transform = renderpassFunctions[method]
+      functions[method] = this.setFunction(method, transform)
+    })
+    return functions
+ }
+
+ setFunction (method, transform) {
+    this.glslTransforms[method] = transform
+    if (transform.type === 'src') {
+      const func = (...args) => new this.sourceClass({
+        name: method,
+        transform: transform,
+        userArgs: args,
+        defaultOutput: this.defaultOutput,
+        synth: this
+      })
+      this.generators[method] = func
+      this.changeListener({type: 'add', synth: this, method})
       return func
     } else  {
-      glslSource.prototype[method] = function (...args) {
-      //  this.addTransform(this, {name: method, transform: transform, args: args})
+      this.sourceClass.prototype[method] = function (...args) {
         this.transforms.push({name: method, transform: transform, userArgs: args})
         return this
       }
     }
-
-
+    return undefined
   }
 }
 
-module.exports = synth
+module.exports = Synth

--- a/src/lib/audio.js
+++ b/src/lib/audio.js
@@ -8,13 +8,15 @@ class Audio {
     smooth = 0.4,
     max = 15,
     scale = 10,
-    isDrawing = false
+    isDrawing = false,
+    changeListener = (() => {})
   }) {
     this.vol = 0
     this.scale = scale
     this.max = max
     this.cutoff = cutoff
     this.smooth = smooth
+    this.changeListener = changeListener
     this.setBins(numBins)
 
     // beat detection from: https://github.com/therewasaguy/p5-music-viz/blob/gh-pages/demos/01d_beat_detect_amplitude/sketch.js
@@ -148,10 +150,11 @@ class Audio {
       scale: this.scale,
       smooth: this.smooth
     }))
-    // to do: what to do in non-global mode?
-    this.bins.forEach((bin, index) => {
-      window['a' + index] = (scale = 1, offset = 0) => () => (a.fft[index] * scale + offset)
-    })
+
+    if (this.changeListener) {
+      this.changeListener({type: 'reconfig', audio: this})
+    }
+
     console.log(this.settings)
   }
 


### PR DESCRIPTION
Hi @ojack ,

at the risk of getting on your nerves, here's another pull :) This time it's for getting `makeGlobal=false` working.

Most of the changes were in `create-synth` to make it a proper class, which it was somehow behaving like anyway. Both `Synth` and `Audio` needed some sort of listener argument, so that `Hydra` would be the central place where `makeGlobal` is being taken care of.

I've tried to take are to not break the existing behavior when `makeGlobal=true` and tested with the current `hydra` server code, which works fine for me.

To test `makeGlobal=false` I've added the changes [my debugging/testing/sandbox environment](https://oscons.github.io/hydra-synth/#eNqrVkpVslKKyUsqyNUwNDLQjMmLySvOSCxI1dCoBorVairY2in4JpZk6KXl5OcXaQDF9A0NNDX1ivJLEktSNQx0FAz0TDX18ktLNPIh2mPylGoBsOwbMQ==). The only thing that, by design, does not work as before is that `bpm` now needs to be a function. The bound property trick does not work anymore if bpm is not accessed via an object.

I'm not sure if I missed any other obstacles regarding makeGlobal that you encountered in the past, just let me know.

Regards, @oscons

p.s.: This pull conflicts with #23 . If you choose to merge both I'll update one or the other to resolve the conflicts