### PR TITLE
Support using transforms as arguments

### DIFF
--- a/src/create-synth.js
+++ b/src/create-synth.js
@@ -32,6 +32,9 @@ class Synth {
     const addTransforms = (transforms) =>
       Object.entries(transforms).forEach(([method, transform]) => {
         functions[method] = transform
+        if (typeof transform.glsl_return_type === 'undefined' && transform.glsl) {
+          transform.glsl_return_type = transform.glsl.replace(new RegExp(`^(?:[\\s\\S]*\\W)?(\\S+)\\s+${method}\\s*[(][\\s\\S]*`, 'ugsmi'), '$1')
+        }
       })
 
     addTransforms(glslTransforms)

--- a/src/create-synth.js
+++ b/src/create-synth.js
@@ -32,9 +32,6 @@ class Synth {
     const addTransforms = (transforms) =>
       Object.entries(transforms).forEach(([method, transform]) => {
         functions[method] = transform
-        if (typeof transform.glsl_return_type === 'undefined' && transform.glsl) {
-          transform.glsl_return_type = transform.glsl.replace(new RegExp(`^(?:[\\s\\S]*\\W)?(\\S+)\\s+${method}\\s*[(][\\s\\S]*`, 'ugm'), '$1')
-        }
       })
 
     addTransforms(glslTransforms)
@@ -52,6 +49,10 @@ class Synth {
     }
 
     Object.entries(functions).forEach(([method, transform]) => {
+      if (typeof transform.glsl_return_type === 'undefined' && transform.glsl) {
+        transform.glsl_return_type = transform.glsl.replace(new RegExp(`^(?:[\\s\\S]*\\W)?(\\S+)\\s+${method}\\s*[(][\\s\\S]*`, 'ugm'), '$1')
+      }
+
       functions[method] = this.setFunction(method, transform)
     })
 

--- a/src/create-synth.js
+++ b/src/create-synth.js
@@ -33,7 +33,7 @@ class Synth {
       Object.entries(transforms).forEach(([method, transform]) => {
         functions[method] = transform
         if (typeof transform.glsl_return_type === 'undefined' && transform.glsl) {
-          transform.glsl_return_type = transform.glsl.replace(new RegExp(`^(?:[\\s\\S]*\\W)?(\\S+)\\s+${method}\\s*[(][\\s\\S]*`, 'ugsmi'), '$1')
+          transform.glsl_return_type = transform.glsl.replace(new RegExp(`^(?:[\\s\\S]*\\W)?(\\S+)\\s+${method}\\s*[(][\\s\\S]*`, 'ugm'), '$1')
         }
       })
 

--- a/src/glsl-utils.js
+++ b/src/glsl-utils.js
@@ -1,5 +1,12 @@
 // converts a tree of javascript functions to a shader
 
+const DEFAULT_CONVERSIONS = {
+  float: {
+    'vec4': {name: 'sum', args: [[1, 1, 1, 1]]},
+    'vec2': {name: 'sum', args: [[1, 1]]}
+  }
+}
+
 module.exports = {
   generateGlsl: function (transforms) {
     var shaderParams = {
@@ -164,6 +171,21 @@ function formatArguments (transform, startIndex) {
     if(startIndex< 0){
     } else {
     if (typedArg.value && typedArg.value.transforms) {
+      const final_transform = typedArg.value.transforms[typedArg.value.transforms.length - 1]
+
+
+
+      if (final_transform.transform.glsl_return_type !== input.type) {
+        const defaults = DEFAULT_CONVERSIONS[input.type]
+        if (typeof defaults !== 'undefined') {
+          const default_def = defaults[final_transform.transform.glsl_return_type]
+          if (typeof default_def !== undefined) {
+            const {name, args} = default_def
+            typedArg.value = typedArg.value[name](...args)
+          }
+        }
+      }
+
       typedArg.isUniform = false
     } else if (typedArg.type === 'float' && typeof typedArg.value === 'number') {
       typedArg.value = ensure_decimal_dot(typedArg.value)

--- a/src/glsl-utils.js
+++ b/src/glsl-utils.js
@@ -179,7 +179,7 @@ function formatArguments (transform, startIndex) {
         const defaults = DEFAULT_CONVERSIONS[input.type]
         if (typeof defaults !== 'undefined') {
           const default_def = defaults[final_transform.transform.glsl_return_type]
-          if (typeof default_def !== undefined) {
+          if (typeof default_def !== 'undefined') {
             const {name, args} = default_def
             typedArg.value = typedArg.value[name](...args)
           }

--- a/src/glsl/composable-glsl-functions.js
+++ b/src/glsl/composable-glsl-functions.js
@@ -974,4 +974,59 @@ module.exports = {
     }
     `
   },
+  sum: {
+    type: 'color',
+    inputs: [
+      {
+        name: 'scale',
+        type: 'vec4',
+        default: [1, 1, 1, 1]
+      }
+    ],
+    glsl: `float sum(vec4 c0, vec4 s) {
+      vec4 v = c0 * s;
+      return v.r + v.g + v.b + v.a;
+    }
+`
+  },
+  r: {
+    type: 'color',
+    inputs: [
+      {name: 'scale', type: 'float', default: 1},
+      {name: 'offset', type: 'float', default: 0}
+    ],
+    glsl: `float r(vec4 c0, float scale, float offset) {
+      return c0.r * scale + offset;
+    }`
+  },
+  g: {
+    type: 'color',
+    inputs: [
+      {name: 'scale', type: 'float', default: 1},
+      {name: 'offset', type: 'float', default: 0}
+    ],
+    glsl: `float g(vec4 c0, float scale, float offset) {
+      return c0.g * scale + offset;
+    }`
+  },
+  b: {
+    type: 'color',
+    inputs: [
+      {name: 'scale', type: 'float', default: 1},
+      {name: 'offset', type: 'float', default: 0}
+    ],
+    glsl: `float b(vec4 c0, float scale, float offset) {
+      return c0.b * scale + offset;
+    }`
+  },
+  a: {
+    type: 'color',
+    inputs: [
+      {name: 'scale', type: 'float', default: 1},
+      {name: 'offset', type: 'float', default: 0}
+    ],
+    glsl: `float a(vec4 c0, float scale, float offset) {
+      return c0.a * scale + offset;
+    }`
+  }
 }

--- a/src/glsl/composable-glsl-functions.js
+++ b/src/glsl/composable-glsl-functions.js
@@ -987,7 +987,11 @@ module.exports = {
       vec4 v = c0 * s;
       return v.r + v.g + v.b + v.a;
     }
-`
+
+float sum(vec2 _st, vec4 s) { // vec4 is not a typo, because argument type is not overloaded
+  vec2 v = _st.xy * s.xy;
+  return v.x + v.y;
+}`
   },
   r: {
     type: 'color',


### PR DESCRIPTION
These changes allow using transforms as function arguments, including some default conversions between vec4 and float.

Example, based on our discussion in #24 ([live view](https://oscons.github.io/hydra-synth/#eNqVU21zmzAM/itavsRslJC0/ZLefknDpY4RCTewOb+w5XL575NtnKbX3NYAB7Z4JD16JJ9mOFvP2gbYt612MgON1mkJhj4DyzbS33vN6xalZaus0Mpyi6zMYZkVylmmyoBaLMCZVu6h7YeuFa2FuXH9fCPNgQ/INhLAaBHRQFfRu86y11UOD2XxnAMFLKv0j9d1+OWNkJeVT7aRU75lymd4j4BNg8LmU/Je1dcZacumrDmkXJVfVu/xHlM8QruO21ZJ+K30LwO04PIITae4hYFrymdRByyXNQguYYcgVL9rJX5I/JhfFQwfKg7VEo/ljZrjEi6eySVCi1XAA6UfUTxFRkQIGq36aLKaS9Mo3cdISbcUW+PwxIhAtBjVtTWTuA+mLATGP5z6h0AxQNkDBR+UMe2OTM6guYi2CqJplDXqNCaLuy/v1TgpgubTyMEpMqXt9nCsNWenWAy1Zw2nJJE9DrimGdNinidbKwdnzRpeLzrCSVLTCCdUp/Q8T25eLNrV2HBSmDyoG9NTnfPP7kbwDv/hPnXI9+eWu2oaKueL/sm9ugTad6Zbw1ucQz/T5L+CraGxD10X5bQINKd1zJkFwYJhhJ+EhO8RBT8mxEuUO5z6sdBkH4t9eO/CmxPg/BappNr8HH21F0mDkXfuSsJQzLUG5flTwYF2mNn3gqMI42VMIm8CspEKj092gzKN+d2M72Mbmfnj9B+2D+M1P/850wmixez8Fxpep1U=)):
```javascript
// using implicit 'sum'
shape(
  src(o0)
    .mult([2, -0.5, 0, 0])
    .add([2, 0, 0 ,0], 1)
).out(o1)

// modulation works on any float parameter
// and can be combined
shape(
  3,
  src(o0) 
    .mult([0.5, -0.1, 0, 0])
    .add(
       src(o0).mult([0, 0, 0.2, 0]) // vec4 paramter from vec4 transform
    , 1)
).add(
  rep4(0.5).add(solid(neg(0.5))) // example for other possible uses with custom functions rep4 and neg
).out(o2)
```

I've also added convenience functions to access the `r`,`g`,`b`, and `a` components individually.

One thing that might need changing in the future is visible in the (admittedly not very useful other than for illustration purposes) `neg` function in the example above. The function definition is:

```javascript
    neg: {
      type: 'src',
      inputs: [{name: 'v', type: 'float', default: 0}],
      glsl: `float neg(vec2 _st, float v) {
  return -v;
}`
    }
```

Ideally there would be two versions of `neg`: One of type `src` as above and one of another type, e.g. type `color` so it could be used like this as well:

```javascript

shape(src(o0).neg().add([5, 5, 0, 0],0))
```

This is currently not possible, since the transforms are stored in an object and hence there can only be one definition for a function like `neg`. What do you think of changing this, so that a function can have two definitions, one as a `src` and one as another type?