### PR TITLE
adding ability to precision precision for shaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,15 @@
-const Output = require("./src/output.js");
-const loop = require("raf-loop");
-const Source = require("./src/hydra-source.js");
-const GeneratorFactory = require("./src/GeneratorFactory.js");
-const mouse = require("mouse-change")();
-const Audio = require("./src/audio.js");
-const VidRecorder = require("./src/video-recorder.js");
+const Output = require('./src/output.js')
+const loop = require('raf-loop')
+const Source = require('./src/hydra-source.js')
+const GeneratorFactory = require('./src/GeneratorFactory.js')
+const mouse = require('mouse-change')()
+const Audio = require('./src/audio.js')
+const VidRecorder = require('./src/video-recorder.js')
 
 // to do: add ability to pass in certain uniforms and transforms
 class HydraSynth {
-  constructor({
+
+  constructor ({
     pb = null,
     width = 1280,
     height = 720,
@@ -18,139 +19,140 @@ class HydraSynth {
     autoLoop = true,
     detectAudio = true,
     enableStreamCapture = true,
-    precision = "mediump",
     canvas
   } = {}) {
-    // precision type
-    this.precision = precision;
 
-    this.bpm = 60;
-    this.pb = pb;
-    this.width = width;
-    this.height = height;
-    this.time = 0;
-    this.makeGlobal = makeGlobal;
-    this.renderAll = false;
-    this.detectAudio = detectAudio;
+    this.bpm = 60
+    this.pb = pb
+    this.width = width
+    this.height = height
+    this.time = 0
+    this.makeGlobal = makeGlobal
+    this.renderAll = false
+    this.detectAudio = detectAudio
 
     // boolean to store when to save screenshot
-    this.saveFrame = false;
+    this.saveFrame = false
 
     // if stream capture is enabled, this object contains the capture stream
-    this.captureStream = null;
+    this.captureStream = null
 
-    this._initCanvas(canvas);
-    this._initRegl();
-    this._initOutputs(numOutputs);
-    this._initSources(numSources);
-    this._generateGlslTransforms();
+    this._initCanvas(canvas)
+    this._initRegl()
+    this._initOutputs(numOutputs)
+    this._initSources(numSources)
+    this._generateGlslTransforms()
 
     window.screencap = () => {
-      this.saveFrame = true;
-    };
-
-    if (enableStreamCapture) {
-      this.captureStream = this.canvas.captureStream(25);
-
-      // to do: enable capture stream of specific sources and outputs
-      window.vidRecorder = new VidRecorder(this.captureStream);
+      this.saveFrame = true
     }
 
-    if (detectAudio) this._initAudio();
+    if (enableStreamCapture) {
+      this.captureStream = this.canvas.captureStream(25)
+
+      // to do: enable capture stream of specific sources and outputs
+      window.vidRecorder = new VidRecorder(this.captureStream)
+    }
+
+    if(detectAudio) this._initAudio()
     //if(makeGlobal) {
-    window.mouse = mouse;
-    window.time = this.time;
-    window["render"] = this.render.bind(this);
+      window.mouse = mouse
+      window.time = this.time
+      window['render'] = this.render.bind(this)
     //  window.bpm = this.bpm
-    window.bpm = this._setBpm.bind(this);
-    //  }
-    if (autoLoop) loop(this.tick.bind(this)).start();
+      window.bpm = this._setBpm.bind(this)
+  //  }
+    if(autoLoop) loop(this.tick.bind(this)).start()
   }
 
   getScreenImage(callback) {
-    this.imageCallback = callback;
-    this.saveFrame = true;
+    this.imageCallback = callback
+    this.saveFrame = true
   }
 
   resize(width, height) {
-    console.log(width, height);
-    this.canvas.width = width;
-    this.canvas.height = height;
-    this.width = width;
-    this.height = height;
-    this.regl.poll();
-    this.o.forEach(output => {
-      output.resize(width, height);
-    });
-    this.s.forEach(source => {
-      source.resize(width, height);
-    });
+    console.log(width, height)
+    this.canvas.width = width
+    this.canvas.height = height
+    this.width = width
+    this.height = height
+    this.regl.poll()
+    this.o.forEach((output) => {
+      output.resize(width, height)
+    })
+    this.s.forEach((source) => {
+      source.resize(width, height)
+    })
   }
-  canvasToImage(callback) {
-    const a = document.createElement("a");
-    a.style.display = "none";
+  canvasToImage (callback) {
+    const a = document.createElement('a')
+    a.style.display = 'none'
 
-    let d = new Date();
-    a.download = `hydra-${d.getFullYear()}-${d.getMonth() +
-      1}-${d.getDate()}-${d.getHours()}.${d.getMinutes()}.${d.getSeconds()}.png`;
-    document.body.appendChild(a);
-    var self = this;
-    this.canvas.toBlob(blob => {
+    let d = new Date()
+    a.download = `hydra-${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}-${d.getHours()}.${d.getMinutes()}.${d.getSeconds()}.png`
+    document.body.appendChild(a)
+    var self = this
+    this.canvas.toBlob( (blob) => {
       //  var url = window.URL.createObjectURL(blob)
 
-      if (self.imageCallback) {
-        self.imageCallback(blob);
-        delete self.imageCallback;
-      } else {
-        a.href = URL.createObjectURL(blob);
-        console.log(a.href);
-        a.click();
-      }
-    }, "image/png");
+        if(self.imageCallback){
+          self.imageCallback(blob)
+          delete self.imageCallback
+        } else {
+          a.href = URL.createObjectURL(blob)
+          console.log(a.href)
+          a.click()
+        }
+    }, 'image/png')
     setTimeout(() => {
       document.body.removeChild(a);
       window.URL.revokeObjectURL(a.href);
     }, 300);
   }
 
-  _initAudio() {
+  _initAudio () {
     this.audio = new Audio({
       numBins: 4
-    });
-    if (this.makeGlobal) window.a = this.audio;
+    })
+    if(this.makeGlobal) window.a = this.audio
   }
   // create main output canvas and add to screen
-  _initCanvas(canvas) {
+  _initCanvas (canvas) {
     if (canvas) {
-      this.canvas = canvas;
-      this.width = canvas.width;
-      this.height = canvas.height;
+      this.canvas = canvas
+      this.width = canvas.width
+      this.height = canvas.height
     } else {
-      this.canvas = document.createElement("canvas");
-      this.canvas.width = this.width;
-      this.canvas.height = this.height;
-      this.canvas.style.width = "100%";
-      this.canvas.style.height = "100%";
-      document.body.appendChild(this.canvas);
+      this.canvas = document.createElement('canvas')
+      this.canvas.width = this.width
+      this.canvas.height = this.height
+      this.canvas.style.width = '100%'
+      this.canvas.style.height = '100%'
+      document.body.appendChild(this.canvas)
     }
   }
 
-  _initRegl() {
-    this.regl = require("regl")({
+  _initRegl () {
+    this.regl = require('regl')({
       canvas: this.canvas,
       pixelRatio: 1,
-      extensions: ["oes_texture_half_float", "oes_texture_half_float_linear"],
-      optionalExtensions: ["oes_texture_float", "oes_texture_float_linear"]
-    });
+      extensions: [
+        'oes_texture_half_float',
+        'oes_texture_half_float_linear'
+      ],
+      optionalExtensions: [
+        'oes_texture_float',
+        'oes_texture_float_linear'
+      ]})
 
     // This clears the color buffer to black and the depth buffer to 1
     this.regl.clear({
       color: [0, 0, 0, 1]
-    });
+    })
 
     this.renderAll = this.regl({
       frag: `
-      precision ${this.precision} float;
+      precision highp float;
       varying vec2 uv;
       uniform sampler2D tex0;
       uniform sampler2D tex1;
@@ -178,7 +180,7 @@ class HydraSynth {
       }
       `,
       vert: `
-      precision ${this.precision} float;
+      precision highp float;
       attribute vec2 position;
       varying vec2 uv;
 
@@ -187,21 +189,25 @@ class HydraSynth {
         gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
       }`,
       attributes: {
-        position: [[-2, 0], [0, -2], [2, 2]]
+        position: [
+          [-2, 0],
+          [0, -2],
+          [2, 2]
+        ]
       },
       uniforms: {
-        tex0: this.regl.prop("tex0"),
-        tex1: this.regl.prop("tex1"),
-        tex2: this.regl.prop("tex2"),
-        tex3: this.regl.prop("tex3")
+        tex0: this.regl.prop('tex0'),
+        tex1: this.regl.prop('tex1'),
+        tex2: this.regl.prop('tex2'),
+        tex3: this.regl.prop('tex3')
       },
       count: 3,
       depth: { enable: false }
-    });
+    })
 
     this.renderFbo = this.regl({
       frag: `
-      precision ${this.precision} float;
+      precision highp float;
       varying vec2 uv;
       uniform vec2 resolution;
       uniform sampler2D tex0;
@@ -211,7 +217,7 @@ class HydraSynth {
       }
       `,
       vert: `
-      precision ${this.precision} float;
+      precision highp float;
       attribute vec2 position;
       varying vec2 uv;
 
@@ -220,106 +226,99 @@ class HydraSynth {
         gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
       }`,
       attributes: {
-        position: [[-2, 0], [0, -2], [2, 2]]
+        position: [
+          [-2, 0],
+          [0, -2],
+          [2, 2]
+        ]
       },
       uniforms: {
-        tex0: this.regl.prop("tex0"),
-        resolution: this.regl.prop("resolution")
+        tex0: this.regl.prop('tex0'),
+        resolution: this.regl.prop('resolution')
       },
       count: 3,
       depth: { enable: false }
-    });
+    })
   }
 
-  _initOutputs(numOutputs) {
-    const self = this;
-    this.o = Array(numOutputs)
-      .fill()
-      .map((el, index) => {
-        var o = new Output({
-          regl: this.regl,
-          width: this.width,
-          height: this.height,
-          precision: this.precision
-        });
-        o.render();
-        o.id = index;
-        if (self.makeGlobal) window["o" + index] = o;
-        return o;
-      });
+  _initOutputs (numOutputs) {
+    const self = this
+    this.o = (Array(numOutputs)).fill().map((el, index) => {
+      var o = new Output({regl: this.regl, width: this.width, height: this.height})
+      o.render()
+      o.id = index
+      if (self.makeGlobal) window['o' + index] = o
+      return o
+    })
 
     // set default output
-    this.output = this.o[0];
+    this.output = this.o[0]
   }
 
-  _initSources(numSources) {
-    this.s = [];
-    for (var i = 0; i < numSources; i++) {
-      this.createSource();
+  _initSources (numSources) {
+    this.s = []
+    for(var i = 0; i < numSources; i++) {
+      this.createSource()
     }
   }
 
   _setBpm(bpm) {
-    this.bpm = bpm;
+    this.bpm = bpm
   }
 
-  createSource() {
-    let s = new Source({
-      regl: this.regl,
-      pb: this.pb,
-      width: this.width,
-      height: this.height
-    });
-    if (this.makeGlobal) {
-      window["s" + this.s.length] = s;
+  createSource () {
+    let s = new Source({regl: this.regl, pb: this.pb, width: this.width, height: this.height})
+    if(this.makeGlobal) {
+      window['s' + this.s.length] = s
     }
-    this.s.push(s);
-    return s;
+    this.s.push(s)
+    return s
   }
 
-  _generateGlslTransforms() {
-    const self = this;
-    const gen = new GeneratorFactory(this.o[0], this.precision);
-    window.generator = gen;
-    Object.keys(gen.functions).forEach(key => {
-      self[key] = gen.functions[key];
-      if (self.makeGlobal === true) {
-        window[key] = gen.functions[key];
+  _generateGlslTransforms () {
+    const self = this
+    const gen = new GeneratorFactory(this.o[0])
+    window.generator = gen
+    Object.keys(gen.functions).forEach((key)=>{
+      self[key] = gen.functions[key]
+      if(self.makeGlobal === true) {
+        window[key] = gen.functions[key]
       }
-    });
+    })
   }
 
-  render(output) {
+  render (output) {
     if (output) {
-      this.output = output;
-      this.isRenderingAll = false;
+      this.output = output
+      this.isRenderingAll = false
     } else {
-      this.isRenderingAll = true;
+      this.isRenderingAll = true
     }
   }
 
-  tick(dt, uniforms) {
-    //  if(self.detectAudio === true) self.fft = self.audio.frequencies()
-    // this.regl.frame(function () {
-    this.time += dt * 0.001;
+  tick (dt, uniforms) {
+
+  //  if(self.detectAudio === true) self.fft = self.audio.frequencies()
+  // this.regl.frame(function () {
+    this.time += dt * 0.001
     // console.log(this.time)
     // this.regl.clear({
     //   color: [0, 0, 0, 1]
     // })
-    window.time = this.time;
-    if (this.detectAudio === true) this.audio.tick();
+    window.time = this.time
+    if(this.detectAudio === true) this.audio.tick()
     for (let i = 0; i < this.s.length; i++) {
-      this.s[i].tick(this.time);
+      this.s[i].tick(this.time)
     }
 
     for (let i = 0; i < this.o.length; i++) {
-      //  console.log('WIDTH', this.canvas.width, this.o[0].getCurrent())
+    //  console.log('WIDTH', this.canvas.width, this.o[0].getCurrent())
       this.o[i].tick({
         time: this.time,
         mouse: mouse,
         bpm: this.bpm,
         resolution: [this.canvas.width, this.canvas.height]
-      });
+      })
     }
 
     // console.log("looping", self.o[0].fbo)
@@ -330,19 +329,21 @@ class HydraSynth {
         tex2: this.o[2].getCurrent(),
         tex3: this.o[3].getCurrent(),
         resolution: [this.canvas.width, this.canvas.height]
-      });
+      })
     } else {
-      //  console.log('out', self.output.id)
+    //  console.log('out', self.output.id)
       this.renderFbo({
         tex0: this.output.getCurrent(),
         resolution: [this.canvas.width, this.canvas.height]
-      });
+      })
     }
-    if (this.saveFrame === true) {
-      this.canvasToImage();
-      this.saveFrame = false;
+    if(this.saveFrame === true) {
+      this.canvasToImage()
+      this.saveFrame = false
     }
   }
+
+
 }
 
-module.exports = HydraSynth;
+module.exports = HydraSynth

--- a/index.js
+++ b/index.js
@@ -1,15 +1,14 @@
-const Output = require('./src/output.js')
-const loop = require('raf-loop')
-const Source = require('./src/hydra-source.js')
-const GeneratorFactory = require('./src/GeneratorFactory.js')
-const mouse = require('mouse-change')()
-const Audio = require('./src/audio.js')
-const VidRecorder = require('./src/video-recorder.js')
+const Output = require("./src/output.js");
+const loop = require("raf-loop");
+const Source = require("./src/hydra-source.js");
+const GeneratorFactory = require("./src/GeneratorFactory.js");
+const mouse = require("mouse-change")();
+const Audio = require("./src/audio.js");
+const VidRecorder = require("./src/video-recorder.js");
 
 // to do: add ability to pass in certain uniforms and transforms
 class HydraSynth {
-
-  constructor ({
+  constructor({
     pb = null,
     width = 1280,
     height = 720,
@@ -19,140 +18,139 @@ class HydraSynth {
     autoLoop = true,
     detectAudio = true,
     enableStreamCapture = true,
+    precision = "mediump",
     canvas
   } = {}) {
+    // precision type
+    this.precision = precision;
 
-    this.bpm = 60
-    this.pb = pb
-    this.width = width
-    this.height = height
-    this.time = 0
-    this.makeGlobal = makeGlobal
-    this.renderAll = false
-    this.detectAudio = detectAudio
+    this.bpm = 60;
+    this.pb = pb;
+    this.width = width;
+    this.height = height;
+    this.time = 0;
+    this.makeGlobal = makeGlobal;
+    this.renderAll = false;
+    this.detectAudio = detectAudio;
 
     // boolean to store when to save screenshot
-    this.saveFrame = false
+    this.saveFrame = false;
 
     // if stream capture is enabled, this object contains the capture stream
-    this.captureStream = null
+    this.captureStream = null;
 
-    this._initCanvas(canvas)
-    this._initRegl()
-    this._initOutputs(numOutputs)
-    this._initSources(numSources)
-    this._generateGlslTransforms()
+    this._initCanvas(canvas);
+    this._initRegl();
+    this._initOutputs(numOutputs);
+    this._initSources(numSources);
+    this._generateGlslTransforms();
 
     window.screencap = () => {
-      this.saveFrame = true
-    }
+      this.saveFrame = true;
+    };
 
     if (enableStreamCapture) {
-      this.captureStream = this.canvas.captureStream(25)
+      this.captureStream = this.canvas.captureStream(25);
 
       // to do: enable capture stream of specific sources and outputs
-      window.vidRecorder = new VidRecorder(this.captureStream)
+      window.vidRecorder = new VidRecorder(this.captureStream);
     }
 
-    if(detectAudio) this._initAudio()
+    if (detectAudio) this._initAudio();
     //if(makeGlobal) {
-      window.mouse = mouse
-      window.time = this.time
-      window['render'] = this.render.bind(this)
+    window.mouse = mouse;
+    window.time = this.time;
+    window["render"] = this.render.bind(this);
     //  window.bpm = this.bpm
-      window.bpm = this._setBpm.bind(this)
-  //  }
-    if(autoLoop) loop(this.tick.bind(this)).start()
+    window.bpm = this._setBpm.bind(this);
+    //  }
+    if (autoLoop) loop(this.tick.bind(this)).start();
   }
 
   getScreenImage(callback) {
-    this.imageCallback = callback
-    this.saveFrame = true
+    this.imageCallback = callback;
+    this.saveFrame = true;
   }
 
   resize(width, height) {
-    console.log(width, height)
-    this.canvas.width = width
-    this.canvas.height = height
-    this.width = width
-    this.height = height
-    this.regl.poll()
-    this.o.forEach((output) => {
-      output.resize(width, height)
-    })
-    this.s.forEach((source) => {
-      source.resize(width, height)
-    })
+    console.log(width, height);
+    this.canvas.width = width;
+    this.canvas.height = height;
+    this.width = width;
+    this.height = height;
+    this.regl.poll();
+    this.o.forEach(output => {
+      output.resize(width, height);
+    });
+    this.s.forEach(source => {
+      source.resize(width, height);
+    });
   }
-  canvasToImage (callback) {
-    const a = document.createElement('a')
-    a.style.display = 'none'
+  canvasToImage(callback) {
+    const a = document.createElement("a");
+    a.style.display = "none";
 
-    let d = new Date()
-    a.download = `hydra-${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}-${d.getHours()}.${d.getMinutes()}.${d.getSeconds()}.png`
-    document.body.appendChild(a)
-    var self = this
-    this.canvas.toBlob( (blob) => {
+    let d = new Date();
+    a.download = `hydra-${d.getFullYear()}-${d.getMonth() +
+      1}-${d.getDate()}-${d.getHours()}.${d.getMinutes()}.${d.getSeconds()}.png`;
+    document.body.appendChild(a);
+    var self = this;
+    this.canvas.toBlob(blob => {
       //  var url = window.URL.createObjectURL(blob)
 
-        if(self.imageCallback){
-          self.imageCallback(blob)
-          delete self.imageCallback
-        } else {
-          a.href = URL.createObjectURL(blob)
-          console.log(a.href)
-          a.click()
-        }
-    }, 'image/png')
+      if (self.imageCallback) {
+        self.imageCallback(blob);
+        delete self.imageCallback;
+      } else {
+        a.href = URL.createObjectURL(blob);
+        console.log(a.href);
+        a.click();
+      }
+    }, "image/png");
     setTimeout(() => {
       document.body.removeChild(a);
       window.URL.revokeObjectURL(a.href);
     }, 300);
   }
 
-  _initAudio () {
+  _initAudio() {
     this.audio = new Audio({
       numBins: 4
-    })
-    if(this.makeGlobal) window.a = this.audio
+    });
+    if (this.makeGlobal) window.a = this.audio;
   }
   // create main output canvas and add to screen
-  _initCanvas (canvas) {
+  _initCanvas(canvas) {
     if (canvas) {
-      this.canvas = canvas
-      this.width = canvas.width
-      this.height = canvas.height
+      this.canvas = canvas;
+      this.width = canvas.width;
+      this.height = canvas.height;
     } else {
-      this.canvas = document.createElement('canvas')
-      this.canvas.width = this.width
-      this.canvas.height = this.height
-      this.canvas.style.width = '100%'
-      this.canvas.style.height = '100%'
-      document.body.appendChild(this.canvas)
+      this.canvas = document.createElement("canvas");
+      this.canvas.width = this.width;
+      this.canvas.height = this.height;
+      this.canvas.style.width = "100%";
+      this.canvas.style.height = "100%";
+      document.body.appendChild(this.canvas);
     }
   }
 
-  _initRegl () {
-    this.regl = require('regl')({
+  _initRegl() {
+    this.regl = require("regl")({
       canvas: this.canvas,
       pixelRatio: 1,
-      extensions: [
-        'oes_texture_half_float',
-        'oes_texture_half_float_linear'
-      ],
-      optionalExtensions: [
-        'oes_texture_float',
-        'oes_texture_float_linear'
-      ]})
+      extensions: ["oes_texture_half_float", "oes_texture_half_float_linear"],
+      optionalExtensions: ["oes_texture_float", "oes_texture_float_linear"]
+    });
 
     // This clears the color buffer to black and the depth buffer to 1
     this.regl.clear({
       color: [0, 0, 0, 1]
-    })
+    });
 
     this.renderAll = this.regl({
       frag: `
-      precision highp float;
+      precision ${this.precision} float;
       varying vec2 uv;
       uniform sampler2D tex0;
       uniform sampler2D tex1;
@@ -180,7 +178,7 @@ class HydraSynth {
       }
       `,
       vert: `
-      precision highp float;
+      precision ${this.precision} float;
       attribute vec2 position;
       varying vec2 uv;
 
@@ -189,25 +187,21 @@ class HydraSynth {
         gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
       }`,
       attributes: {
-        position: [
-          [-2, 0],
-          [0, -2],
-          [2, 2]
-        ]
+        position: [[-2, 0], [0, -2], [2, 2]]
       },
       uniforms: {
-        tex0: this.regl.prop('tex0'),
-        tex1: this.regl.prop('tex1'),
-        tex2: this.regl.prop('tex2'),
-        tex3: this.regl.prop('tex3')
+        tex0: this.regl.prop("tex0"),
+        tex1: this.regl.prop("tex1"),
+        tex2: this.regl.prop("tex2"),
+        tex3: this.regl.prop("tex3")
       },
       count: 3,
       depth: { enable: false }
-    })
+    });
 
     this.renderFbo = this.regl({
       frag: `
-      precision highp float;
+      precision ${this.precision} float;
       varying vec2 uv;
       uniform vec2 resolution;
       uniform sampler2D tex0;
@@ -217,7 +211,7 @@ class HydraSynth {
       }
       `,
       vert: `
-      precision highp float;
+      precision ${this.precision} float;
       attribute vec2 position;
       varying vec2 uv;
 
@@ -226,99 +220,106 @@ class HydraSynth {
         gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
       }`,
       attributes: {
-        position: [
-          [-2, 0],
-          [0, -2],
-          [2, 2]
-        ]
+        position: [[-2, 0], [0, -2], [2, 2]]
       },
       uniforms: {
-        tex0: this.regl.prop('tex0'),
-        resolution: this.regl.prop('resolution')
+        tex0: this.regl.prop("tex0"),
+        resolution: this.regl.prop("resolution")
       },
       count: 3,
       depth: { enable: false }
-    })
+    });
   }
 
-  _initOutputs (numOutputs) {
-    const self = this
-    this.o = (Array(numOutputs)).fill().map((el, index) => {
-      var o = new Output({regl: this.regl, width: this.width, height: this.height})
-      o.render()
-      o.id = index
-      if (self.makeGlobal) window['o' + index] = o
-      return o
-    })
+  _initOutputs(numOutputs) {
+    const self = this;
+    this.o = Array(numOutputs)
+      .fill()
+      .map((el, index) => {
+        var o = new Output({
+          regl: this.regl,
+          width: this.width,
+          height: this.height,
+          precision: this.precision
+        });
+        o.render();
+        o.id = index;
+        if (self.makeGlobal) window["o" + index] = o;
+        return o;
+      });
 
     // set default output
-    this.output = this.o[0]
+    this.output = this.o[0];
   }
 
-  _initSources (numSources) {
-    this.s = []
-    for(var i = 0; i < numSources; i++) {
-      this.createSource()
+  _initSources(numSources) {
+    this.s = [];
+    for (var i = 0; i < numSources; i++) {
+      this.createSource();
     }
   }
 
   _setBpm(bpm) {
-    this.bpm = bpm
+    this.bpm = bpm;
   }
 
-  createSource () {
-    let s = new Source({regl: this.regl, pb: this.pb, width: this.width, height: this.height})
-    if(this.makeGlobal) {
-      window['s' + this.s.length] = s
+  createSource() {
+    let s = new Source({
+      regl: this.regl,
+      pb: this.pb,
+      width: this.width,
+      height: this.height
+    });
+    if (this.makeGlobal) {
+      window["s" + this.s.length] = s;
     }
-    this.s.push(s)
-    return s
+    this.s.push(s);
+    return s;
   }
 
-  _generateGlslTransforms () {
-    const self = this
-    const gen = new GeneratorFactory(this.o[0])
-    window.generator = gen
-    Object.keys(gen.functions).forEach((key)=>{
-      self[key] = gen.functions[key]
-      if(self.makeGlobal === true) {
-        window[key] = gen.functions[key]
+  _generateGlslTransforms() {
+    const self = this;
+    const gen = new GeneratorFactory(this.o[0], this.precision);
+    window.generator = gen;
+    Object.keys(gen.functions).forEach(key => {
+      self[key] = gen.functions[key];
+      if (self.makeGlobal === true) {
+        window[key] = gen.functions[key];
       }
-    })
+    });
   }
 
-  render (output) {
+  render(output) {
     if (output) {
-      this.output = output
-      this.isRenderingAll = false
+      this.output = output;
+      this.isRenderingAll = false;
     } else {
-      this.isRenderingAll = true
+      this.isRenderingAll = true;
     }
   }
 
-  tick (dt, uniforms) {
-
-  //  if(self.detectAudio === true) self.fft = self.audio.frequencies()
-  // this.regl.frame(function () {
-    this.time += dt * 0.001
+  tick(dt, uniforms) {
+    //  if(self.detectAudio === true) self.fft = self.audio.frequencies()
+    // this.regl.frame(function () {
+    this.time += dt * 0.001;
     // console.log(this.time)
     // this.regl.clear({
     //   color: [0, 0, 0, 1]
     // })
-    window.time = this.time
-    if(this.detectAudio === true) this.audio.tick()
+    window.time = this.time;
+    if (this.detectAudio === true) this.audio.tick();
     for (let i = 0; i < this.s.length; i++) {
-      this.s[i].tick(this.time)
+      this.s[i].tick(this.time);
     }
 
     for (let i = 0; i < this.o.length; i++) {
-    //  console.log('WIDTH', this.canvas.width, this.o[0].getCurrent())
+      //  console.log('WIDTH', this.canvas.width, this.o[0].getCurrent())
       this.o[i].tick({
         time: this.time,
         mouse: mouse,
         bpm: this.bpm,
         resolution: [this.canvas.width, this.canvas.height]
-      })
+      });
     }
 
     // console.log("looping", self.o[0].fbo)
@@ -329,21 +330,19 @@ class HydraSynth {
         tex2: this.o[2].getCurrent(),
         tex3: this.o[3].getCurrent(),
         resolution: [this.canvas.width, this.canvas.height]
-      })
+      });
     } else {
-    //  console.log('out', self.output.id)
+      //  console.log('out', self.output.id)
       this.renderFbo({
         tex0: this.output.getCurrent(),
         resolution: [this.canvas.width, this.canvas.height]
-      })
+      });
     }
-    if(this.saveFrame === true) {
-      this.canvasToImage()
-      this.saveFrame = false
+    if (this.saveFrame === true) {
+      this.canvasToImage();
+      this.saveFrame = false;
     }
   }
-
-
 }
 
-module.exports = HydraSynth
+module.exports = HydraSynth;

--- a/src/GeneratorFactory.js
+++ b/src/GeneratorFactory.js
@@ -109,13 +109,13 @@ function formatArguments (userArgs, defaultArgs) {
 }
 
 
-var GeneratorFactory = function (defaultOutput) {
+var GeneratorFactory = function (defaultOutput, precision) {
 
   let self = this
   self.functions = {}
 
 
-  window.frag = shaderManager(defaultOutput)
+  window.frag = shaderManager(defaultOutput, precision)
 
   // extend Array prototype
   Array.prototype.fast = function(speed) {
@@ -159,7 +159,8 @@ var GeneratorFactory = function (defaultOutput) {
             glslString += ')'
             return glslString
           },
-          uniforms: []
+          uniforms: [],
+          precision: precision
         }
         inputs.forEach((input, index) => {
           if (input.isUniform) {
@@ -216,9 +217,9 @@ var GeneratorFactory = function (defaultOutput) {
 //   iterate through transform types and create a function for each
 //
 Generator.prototype.compile = function (pass) {
-//  console.log("compiling", pass)
+ // console.log("compiling", pass)
   var frag = `
-  precision highp float;
+  precision ${pass.precision} float;
   ${pass.uniforms.map((uniform) => {
     let type = ''
     switch (uniform.type) {
@@ -258,7 +259,7 @@ Generator.prototype.compile = function (pass) {
 // fragment shader code
 Generator.prototype.compileRenderPass = function (pass) {
   var frag = `
-      precision highp float;
+      precision ${pass.precision} float;
       ${pass.uniforms.map((uniform) => {
         let type = ''
         switch (uniform.type) {

--- a/src/GeneratorFactory.js
+++ b/src/GeneratorFactory.js
@@ -1,27 +1,25 @@
 /* globals tex */
-const glslTransforms = require("./composable-glsl-functions.js");
+const glslTransforms = require('./composable-glsl-functions.js')
 
 // in progress: implementing multiple renderpasses within a single
 // function string
-const renderPassFunctions = require("./renderpass-functions.js");
+const renderPassFunctions = require('./renderpass-functions.js')
 
-const counter = require("./counter.js");
-const shaderManager = require("./shaderManager.js");
+const counter = require('./counter.js')
+const shaderManager = require('./shaderManager.js')
 
-var Generator = function(param) {
-  return Object.create(Generator.prototype);
-};
+var Generator = function (param) {
+  return Object.create(Generator.prototype)
+}
 
 // Functions that return a new transformation function based on the existing function chain as well
 // as the new function passed in.
 const compositionFunctions = {
   coord: existingF => newF => x => existingF(newF(x)), // coord transforms added onto beginning of existing function chain
   color: existingF => newF => x => newF(existingF(x)), // color transforms added onto end of existing function chain
-  combine: existingF1 => existingF2 => newF => x =>
-    newF(existingF1(x))(existingF2(x)), //
-  combineCoord: existingF1 => existingF2 => newF => x =>
-    existingF1(newF(x)(existingF2(x)))
-};
+  combine: existingF1 => existingF2 => newF => x => newF(existingF1(x))(existingF2(x)), //
+  combineCoord: existingF1 => existingF2 => newF => x => existingF1(newF(x)(existingF2(x)))
+}
 // gl_FragColor = osc(modulate(osc(rotate(st, 10., 0.), 32., 0.1, 0.), st, 0.5), 199., 0.1, 0.);
 
 // hydra code: osc().rotate().color().repeat().out()
@@ -31,306 +29,300 @@ const compositionFunctions = {
 // gl_FragColor = osc(rotate(repeat())) + tex(repeat())
 
 // Parses javascript args to use in glsl
-function generateGlsl(inputs) {
-  var str = "";
-  inputs.forEach(input => {
-    str += ", " + input.name;
-  });
-  return str;
+function generateGlsl (inputs) {
+  var str = ''
+  inputs.forEach((input) => {
+    str += ', ' + input.name
+  })
+  return str
 }
 // timing function that accepts a sequence of values as an array
-const seq = (arr = []) => ({ time, bpm }) => {
+const seq = (arr = []) => ({time, bpm}) =>
+{
   let speed;
-  if (arr.speed) {
+  if(arr.speed){
     try {
-      speed = arr.speed({ time, bpm, arr });
-      speed = speed * 1; // force numeric conversion
-    } catch (e) {
-      console.log("ERROR", e);
+      speed = arr.speed({time, bpm, arr})
+      speed = speed * 1 // force numeric conversion
+    }
+    catch(e){
+      console.log('ERROR',e)
     }
   }
-  speed = speed ? speed : 1;
-  return arr[Math.floor((time * speed * (bpm / 60)) % arr.length)];
-};
+  speed = speed ? speed : 1
+  return arr[Math.floor(time * speed * (bpm / 60) % (arr.length))]
+}
 // when possible, reformats arguments to be the correct type
 // creates unique names for variables requiring a uniform to be passed in (i.e. a texture)
 // returns an object that contains the type and value of each argument
 // to do: add much more type checking, validation, and transformation to this part
-function formatArguments(userArgs, defaultArgs) {
+function formatArguments (userArgs, defaultArgs) {
   return defaultArgs.map((input, index) => {
-    var typedArg = {};
+    var typedArg = {}
 
     // if there is a user input at a certain index, create a uniform for this variable so that the value is passed in on each render pass
     // to do (possibly): check whether this is a function in order to only use uniforms when needed
 
-    counter.increment();
-    typedArg.name = input.name + counter.get();
-    typedArg.isUniform = true;
+    counter.increment()
+    typedArg.name = input.name + counter.get()
+    typedArg.isUniform = true
 
     if (userArgs.length > index) {
-      //  console.log("arg", userArgs[index])
-      typedArg.value = userArgs[index];
+    //  console.log("arg", userArgs[index])
+      typedArg.value = userArgs[index]
       // if argument passed in contains transform property, i.e. is of type generator, do not add uniform
-      if (userArgs[index].transform) typedArg.isUniform = false;
+      if (userArgs[index].transform) typedArg.isUniform = false
 
-      if (typeof userArgs[index] === "function") {
+      if (typeof userArgs[index] === 'function') {
         typedArg.value = (context, props, batchId) => {
           try {
-            return userArgs[index](props);
+            return userArgs[index](props)
           } catch (e) {
-            console.log("ERROR", e);
-            return input.default;
+            console.log('ERROR', e)
+            return input.default
           }
-        };
+        }
       } else if (userArgs[index].constructor === Array) {
-        //  console.log("is Array")
-        typedArg.value = (context, props, batchId) =>
-          seq(userArgs[index])(props);
+      //  console.log("is Array")
+        typedArg.value = (context, props, batchId) => seq(userArgs[index])(props)
       }
     } else {
       // use default value for argument
-      typedArg.value = input.default;
+      typedArg.value = input.default
     }
     // if input is a texture, set unique name for uniform
-    if (input.type === "texture") {
+    if (input.type === 'texture') {
       // typedArg.tex = typedArg.value
-      var x = typedArg.value;
-      typedArg.value = () => x.getTexture();
+      var x = typedArg.value
+      typedArg.value = () => (x.getTexture())
     } else {
       // if passing in a texture reference, when function asks for vec4, convert to vec4
-      if (typedArg.value.getTexture && input.type === "vec4") {
-        var x1 = typedArg.value;
-        typedArg.value = src(x1);
-        typedArg.isUniform = false;
+      if (typedArg.value.getTexture && input.type === 'vec4') {
+        var x1 = typedArg.value
+        typedArg.value = src(x1)
+        typedArg.isUniform = false
       }
     }
-    typedArg.type = input.type;
-    return typedArg;
-  });
+    typedArg.type = input.type
+    return typedArg
+  })
 }
 
-var GeneratorFactory = function(defaultOutput, precision) {
-  let self = this;
-  self.functions = {};
 
-  window.frag = shaderManager(defaultOutput, precision);
+var GeneratorFactory = function (defaultOutput) {
+
+  let self = this
+  self.functions = {}
+
+
+  window.frag = shaderManager(defaultOutput)
 
   // extend Array prototype
   Array.prototype.fast = function(speed) {
     // always make speed a function to not have to check later
-    if (typeof speed !== "function") {
-      const aspeed = speed;
-      speed = () => aspeed;
+    if(typeof speed !== 'function'){
+      const aspeed = speed
+      speed = () => aspeed
     }
-    this.speed = speed;
-    return this;
-  };
+    this.speed = speed
+    return this
+  }
 
-  Object.keys(glslTransforms).forEach(method => {
-    const transform = glslTransforms[method];
+  Object.keys(glslTransforms).forEach((method) => {
+    const transform = glslTransforms[method]
 
     // if type is a source, create a new global generator function that inherits from Generator object
-    if (transform.type === "src") {
+    if (transform.type === 'src') {
       self.functions[method] = (...args) => {
-        var obj = Object.create(Generator.prototype);
-        obj.name = method;
-        const inputs = formatArguments(args, transform.inputs);
-        obj.transform = x => {
-          var glslString = `${method}(${x}`;
-          glslString += generateGlsl(inputs);
-          glslString += ")";
-          return glslString;
-        };
-        obj.defaultOutput = defaultOutput;
-        obj.uniforms = [];
+        var obj = Object.create(Generator.prototype)
+        obj.name = method
+        const inputs = formatArguments(args, transform.inputs)
+        obj.transform = (x) => {
+          var glslString = `${method}(${x}`
+          glslString += generateGlsl(inputs)
+          glslString += ')'
+          return glslString
+        }
+        obj.defaultOutput = defaultOutput
+        obj.uniforms = []
         inputs.forEach((input, index) => {
           if (input.isUniform) {
-            obj.uniforms.push(input);
+            obj.uniforms.push(input)
           }
-        });
+        })
 
-        obj.passes = [];
+        obj.passes = []
         let pass = {
-          transform: x => {
-            var glslString = `${method}(${x}`;
-            glslString += generateGlsl(inputs);
-            glslString += ")";
-            return glslString;
+          transform: (x) => {
+            var glslString = `${method}(${x}`
+            glslString += generateGlsl(inputs)
+            glslString += ')'
+            return glslString
           },
-          uniforms: [],
-          precision: precision
-        };
+          uniforms: []
+        }
         inputs.forEach((input, index) => {
           if (input.isUniform) {
-            pass.uniforms.push(input);
+            pass.uniforms.push(input)
           }
-        });
-        obj.passes.push(pass);
-        return obj;
-      };
+        })
+        obj.passes.push(pass)
+        return obj
+      }
     } else {
-      Generator.prototype[method] = function(...args) {
-        const inputs = formatArguments(args, transform.inputs);
+      Generator.prototype[method] = function (...args) {
+        const inputs = formatArguments(args, transform.inputs)
 
-        if (transform.type === "combine" || transform.type === "combineCoord") {
-          // composition function to be executed when all transforms have been added
-          // c0 and c1 are two inputs.. (explain more)
-          var f = c0 => c1 => {
-            var glslString = `${method}(${c0}, ${c1}`;
-            glslString += generateGlsl(inputs.slice(1));
-            glslString += ")";
-            return glslString;
-          };
-          this.transform = compositionFunctions[glslTransforms[method].type](
-            this.transform
-          )(inputs[0].value.transform)(f);
+        if (transform.type === 'combine' || transform.type === 'combineCoord') {
+        // composition function to be executed when all transforms have been added
+        // c0 and c1 are two inputs.. (explain more)
+          var f = (c0) => (c1) => {
+            var glslString = `${method}(${c0}, ${c1}`
+            glslString += generateGlsl(inputs.slice(1))
+            glslString += ')'
+            return glslString
+          }
+          this.transform = compositionFunctions[glslTransforms[method].type](this.transform)(inputs[0].value.transform)(f)
 
-          this.uniforms = this.uniforms.concat(inputs[0].value.uniforms);
+          this.uniforms = this.uniforms.concat(inputs[0].value.uniforms)
 
-          var pass = this.passes[this.passes.length - 1];
-          pass.transform = this.transform;
-          pass.uniform + this.uniform;
+          var pass = this.passes[this.passes.length - 1]
+          pass.transform = this.transform
+          pass.uniform + this.uniform
         } else {
-          var f1 = x => {
-            var glslString = `${method}(${x}`;
-            glslString += generateGlsl(inputs);
-            glslString += ")";
-            return glslString;
-          };
-          this.transform = compositionFunctions[glslTransforms[method].type](
-            this.transform
-          )(f1);
-          this.passes[this.passes.length - 1].transform = this.transform;
+          var f1 = (x) => {
+            var glslString = `${method}(${x}`
+            glslString += generateGlsl(inputs)
+            glslString += ')'
+            return glslString
+          }
+          this.transform = compositionFunctions[glslTransforms[method].type](this.transform)(f1)
+          this.passes[this.passes.length - 1].transform = this.transform
         }
 
         inputs.forEach((input, index) => {
           if (input.isUniform) {
-            this.uniforms.push(input);
+            this.uniforms.push(input)
           }
-        });
-        this.passes[this.passes.length - 1].uniforms = this.uniforms;
-        return this;
-      };
+        })
+        this.passes[this.passes.length - 1].uniforms = this.uniforms
+        return this
+      }
     }
-  });
-};
+  })
+}
 
 //
 //   iterate through transform types and create a function for each
 //
-Generator.prototype.compile = function(pass) {
-  //  console.log("compiling", pass)
+Generator.prototype.compile = function (pass) {
+//  console.log("compiling", pass)
   var frag = `
-  precision ${pass.precision} float;
-  ${pass.uniforms
-    .map(uniform => {
-      let type = "";
-      switch (uniform.type) {
-        case "float":
-          type = "float";
-          break;
-        case "texture":
-          type = "sampler2D";
-          break;
-      }
-      return `
-      uniform ${type} ${uniform.name};`;
-    })
-    .join("")}
+  precision highp float;
+  ${pass.uniforms.map((uniform) => {
+    let type = ''
+    switch (uniform.type) {
+      case 'float':
+        type = 'float'
+        break
+      case 'texture':
+        type = 'sampler2D'
+        break
+    }
+    return `
+      uniform ${type} ${uniform.name};`
+  }).join('')}
   uniform float time;
   uniform vec2 resolution;
   varying vec2 uv;
 
-  ${Object.values(glslTransforms)
-    .map(transform => {
-      //  console.log(transform.glsl)
-      return `
+  ${Object.values(glslTransforms).map((transform) => {
+  //  console.log(transform.glsl)
+    return `
             ${transform.glsl}
-          `;
-    })
-    .join("")}
+          `
+  }).join('')}
 
   void main () {
     vec4 c = vec4(1, 0, 0, 1);
     //vec2 st = uv;
     vec2 st = gl_FragCoord.xy/resolution.xy;
-    gl_FragColor = ${pass.transform("st")};
+    gl_FragColor = ${pass.transform('st')};
   }
-  `;
-  return frag;
-};
+  `
+  return frag
+}
+
 
 // creates a fragment shader from an object containing uniforms and a snippet of
 // fragment shader code
-Generator.prototype.compileRenderPass = function(pass) {
+Generator.prototype.compileRenderPass = function (pass) {
   var frag = `
-      precision ${pass.precision} float;
-      ${pass.uniforms
-        .map(uniform => {
-          let type = "";
-          switch (uniform.type) {
-            case "float":
-              type = "float";
-              break;
-            case "texture":
-              type = "sampler2D";
-              break;
-          }
-          return `
-          uniform ${type} ${uniform.name};`;
-        })
-        .join("")}
+      precision highp float;
+      ${pass.uniforms.map((uniform) => {
+        let type = ''
+        switch (uniform.type) {
+          case 'float':
+            type = 'float'
+            break
+          case 'texture':
+            type = 'sampler2D'
+            break
+        }
+        return `
+          uniform ${type} ${uniform.name};`
+      }).join('')}
       uniform float time;
       uniform vec2 resolution;
       uniform sampler2D prevBuffer;
       varying vec2 uv;
 
-      ${Object.values(renderPassFunctions)
-        .filter(transform => transform.type === "renderpass_util")
-        .map(transform => {
-          //  console.log(transform.glsl)
-          return `
+      ${Object.values(renderPassFunctions).filter(transform => transform.type === 'renderpass_util')
+      .map((transform) => {
+      //  console.log(transform.glsl)
+        return `
                 ${transform.glsl}
-              `;
-        })
-        .join("")}
+              `
+      }).join('')}
 
       ${pass.glsl}
-  `;
-  return frag;
-};
+  `
+  return frag
+}
 
-Generator.prototype.glsl = function(_output) {
-  var output = _output || this.defaultOutput;
 
-  var passes = this.passes.map(pass => {
-    var uniforms = {};
-    pass.uniforms.forEach(uniform => {
-      uniforms[uniform.name] = uniform.value;
-    });
-    if (pass.hasOwnProperty("transform")) {
-      //  console.log(" rendering pass", pass)
+Generator.prototype.glsl = function (_output) {
+  var output = _output || this.defaultOutput
+
+  var passes = this.passes.map((pass) => {
+    var uniforms = {}
+    pass.uniforms.forEach((uniform) => { uniforms[uniform.name] = uniform.value })
+    if(pass.hasOwnProperty('transform')){
+    //  console.log(" rendering pass", pass)
 
       return {
         frag: this.compile(pass),
         uniforms: Object.assign(output.uniforms, uniforms)
-      };
+      }
     } else {
-      //  console.log(" not rendering pass", pass)
+    //  console.log(" not rendering pass", pass)
       return {
         frag: pass.frag,
-        uniforms: Object.assign(output.uniforms, uniforms)
-      };
+        uniforms:  Object.assign(output.uniforms, uniforms)
+      }
     }
-  });
-  return passes;
-};
+  })
+  return passes
+}
 
-Generator.prototype.out = function(_output) {
-  //  console.log('UNIFORMS', this.uniforms, output)
-  var output = _output || this.defaultOutput;
 
-  output.renderPasses(this.glsl(output));
-};
 
-module.exports = GeneratorFactory;
+Generator.prototype.out = function (_output) {
+//  console.log('UNIFORMS', this.uniforms, output)
+  var output = _output || this.defaultOutput
+
+  output.renderPasses(this.glsl(output))
+
+}
+
+module.exports = GeneratorFactory

--- a/src/GeneratorFactory.js
+++ b/src/GeneratorFactory.js
@@ -1,25 +1,27 @@
 /* globals tex */
-const glslTransforms = require('./composable-glsl-functions.js')
+const glslTransforms = require("./composable-glsl-functions.js");
 
 // in progress: implementing multiple renderpasses within a single
 // function string
-const renderPassFunctions = require('./renderpass-functions.js')
+const renderPassFunctions = require("./renderpass-functions.js");
 
-const counter = require('./counter.js')
-const shaderManager = require('./shaderManager.js')
+const counter = require("./counter.js");
+const shaderManager = require("./shaderManager.js");
 
-var Generator = function (param) {
-  return Object.create(Generator.prototype)
-}
+var Generator = function(param) {
+  return Object.create(Generator.prototype);
+};
 
 // Functions that return a new transformation function based on the existing function chain as well
 // as the new function passed in.
 const compositionFunctions = {
   coord: existingF => newF => x => existingF(newF(x)), // coord transforms added onto beginning of existing function chain
   color: existingF => newF => x => newF(existingF(x)), // color transforms added onto end of existing function chain
-  combine: existingF1 => existingF2 => newF => x => newF(existingF1(x))(existingF2(x)), //
-  combineCoord: existingF1 => existingF2 => newF => x => existingF1(newF(x)(existingF2(x)))
-}
+  combine: existingF1 => existingF2 => newF => x =>
+    newF(existingF1(x))(existingF2(x)), //
+  combineCoord: existingF1 => existingF2 => newF => x =>
+    existingF1(newF(x)(existingF2(x)))
+};
 // gl_FragColor = osc(modulate(osc(rotate(st, 10., 0.), 32., 0.1, 0.), st, 0.5), 199., 0.1, 0.);
 
 // hydra code: osc().rotate().color().repeat().out()
@@ -29,300 +31,306 @@ const compositionFunctions = {
 // gl_FragColor = osc(rotate(repeat())) + tex(repeat())
 
 // Parses javascript args to use in glsl
-function generateGlsl (inputs) {
-  var str = ''
-  inputs.forEach((input) => {
-    str += ', ' + input.name
-  })
-  return str
+function generateGlsl(inputs) {
+  var str = "";
+  inputs.forEach(input => {
+    str += ", " + input.name;
+  });
+  return str;
 }
 // timing function that accepts a sequence of values as an array
-const seq = (arr = []) => ({time, bpm}) =>
-{
+const seq = (arr = []) => ({ time, bpm }) => {
   let speed;
-  if(arr.speed){
+  if (arr.speed) {
     try {
-      speed = arr.speed({time, bpm, arr})
-      speed = speed * 1 // force numeric conversion
-    }
-    catch(e){
-      console.log('ERROR',e)
+      speed = arr.speed({ time, bpm, arr });
+      speed = speed * 1; // force numeric conversion
+    } catch (e) {
+      console.log("ERROR", e);
     }
   }
-  speed = speed ? speed : 1
-  return arr[Math.floor(time * speed * (bpm / 60) % (arr.length))]
-}
+  speed = speed ? speed : 1;
+  return arr[Math.floor((time * speed * (bpm / 60)) % arr.length)];
+};
 // when possible, reformats arguments to be the correct type
 // creates unique names for variables requiring a uniform to be passed in (i.e. a texture)
 // returns an object that contains the type and value of each argument
 // to do: add much more type checking, validation, and transformation to this part
-function formatArguments (userArgs, defaultArgs) {
+function formatArguments(userArgs, defaultArgs) {
   return defaultArgs.map((input, index) => {
-    var typedArg = {}
+    var typedArg = {};
 
     // if there is a user input at a certain index, create a uniform for this variable so that the value is passed in on each render pass
     // to do (possibly): check whether this is a function in order to only use uniforms when needed
 
-    counter.increment()
-    typedArg.name = input.name + counter.get()
-    typedArg.isUniform = true
+    counter.increment();
+    typedArg.name = input.name + counter.get();
+    typedArg.isUniform = true;
 
     if (userArgs.length > index) {
-    //  console.log("arg", userArgs[index])
-      typedArg.value = userArgs[index]
+      //  console.log("arg", userArgs[index])
+      typedArg.value = userArgs[index];
       // if argument passed in contains transform property, i.e. is of type generator, do not add uniform
-      if (userArgs[index].transform) typedArg.isUniform = false
+      if (userArgs[index].transform) typedArg.isUniform = false;
 
-      if (typeof userArgs[index] === 'function') {
+      if (typeof userArgs[index] === "function") {
         typedArg.value = (context, props, batchId) => {
           try {
-            return userArgs[index](props)
+            return userArgs[index](props);
           } catch (e) {
-            console.log('ERROR', e)
-            return input.default
+            console.log("ERROR", e);
+            return input.default;
           }
-        }
+        };
       } else if (userArgs[index].constructor === Array) {
-      //  console.log("is Array")
-        typedArg.value = (context, props, batchId) => seq(userArgs[index])(props)
+        //  console.log("is Array")
+        typedArg.value = (context, props, batchId) =>
+          seq(userArgs[index])(props);
       }
     } else {
       // use default value for argument
-      typedArg.value = input.default
+      typedArg.value = input.default;
     }
     // if input is a texture, set unique name for uniform
-    if (input.type === 'texture') {
+    if (input.type === "texture") {
       // typedArg.tex = typedArg.value
-      var x = typedArg.value
-      typedArg.value = () => (x.getTexture())
+      var x = typedArg.value;
+      typedArg.value = () => x.getTexture();
     } else {
       // if passing in a texture reference, when function asks for vec4, convert to vec4
-      if (typedArg.value.getTexture && input.type === 'vec4') {
-        var x1 = typedArg.value
-        typedArg.value = src(x1)
-        typedArg.isUniform = false
+      if (typedArg.value.getTexture && input.type === "vec4") {
+        var x1 = typedArg.value;
+        typedArg.value = src(x1);
+        typedArg.isUniform = false;
       }
     }
-    typedArg.type = input.type
-    return typedArg
-  })
+    typedArg.type = input.type;
+    return typedArg;
+  });
 }
 
+var GeneratorFactory = function(defaultOutput, precision) {
+  let self = this;
+  self.functions = {};
 
-var GeneratorFactory = function (defaultOutput) {
-
-  let self = this
-  self.functions = {}
-
-
-  window.frag = shaderManager(defaultOutput)
+  window.frag = shaderManager(defaultOutput, precision);
 
   // extend Array prototype
   Array.prototype.fast = function(speed) {
     // always make speed a function to not have to check later
-    if(typeof speed !== 'function'){
-      const aspeed = speed
-      speed = () => aspeed
+    if (typeof speed !== "function") {
+      const aspeed = speed;
+      speed = () => aspeed;
     }
-    this.speed = speed
-    return this
-  }
+    this.speed = speed;
+    return this;
+  };
 
-  Object.keys(glslTransforms).forEach((method) => {
-    const transform = glslTransforms[method]
+  Object.keys(glslTransforms).forEach(method => {
+    const transform = glslTransforms[method];
 
     // if type is a source, create a new global generator function that inherits from Generator object
-    if (transform.type === 'src') {
+    if (transform.type === "src") {
       self.functions[method] = (...args) => {
-        var obj = Object.create(Generator.prototype)
-        obj.name = method
-        const inputs = formatArguments(args, transform.inputs)
-        obj.transform = (x) => {
-          var glslString = `${method}(${x}`
-          glslString += generateGlsl(inputs)
-          glslString += ')'
-          return glslString
-        }
-        obj.defaultOutput = defaultOutput
-        obj.uniforms = []
+        var obj = Object.create(Generator.prototype);
+        obj.name = method;
+        const inputs = formatArguments(args, transform.inputs);
+        obj.transform = x => {
+          var glslString = `${method}(${x}`;
+          glslString += generateGlsl(inputs);
+          glslString += ")";
+          return glslString;
+        };
+        obj.defaultOutput = defaultOutput;
+        obj.uniforms = [];
         inputs.forEach((input, index) => {
           if (input.isUniform) {
-            obj.uniforms.push(input)
+            obj.uniforms.push(input);
           }
-        })
+        });
 
-        obj.passes = []
+        obj.passes = [];
         let pass = {
-          transform: (x) => {
-            var glslString = `${method}(${x}`
-            glslString += generateGlsl(inputs)
-            glslString += ')'
-            return glslString
+          transform: x => {
+            var glslString = `${method}(${x}`;
+            glslString += generateGlsl(inputs);
+            glslString += ")";
+            return glslString;
           },
-          uniforms: []
-        }
+          uniforms: [],
+          precision: precision
+        };
         inputs.forEach((input, index) => {
           if (input.isUniform) {
-            pass.uniforms.push(input)
+            pass.uniforms.push(input);
           }
-        })
-        obj.passes.push(pass)
-        return obj
-      }
+        });
+        obj.passes.push(pass);
+        return obj;
+      };
     } else {
-      Generator.prototype[method] = function (...args) {
-        const inputs = formatArguments(args, transform.inputs)
+      Generator.prototype[method] = function(...args) {
+        const inputs = formatArguments(args, transform.inputs);
 
-        if (transform.type === 'combine' || transform.type === 'combineCoord') {
-        // composition function to be executed when all transforms have been added
-        // c0 and c1 are two inputs.. (explain more)
-          var f = (c0) => (c1) => {
-            var glslString = `${method}(${c0}, ${c1}`
-            glslString += generateGlsl(inputs.slice(1))
-            glslString += ')'
-            return glslString
-          }
-          this.transform = compositionFunctions[glslTransforms[method].type](this.transform)(inputs[0].value.transform)(f)
+        if (transform.type === "combine" || transform.type === "combineCoord") {
+          // composition function to be executed when all transforms have been added
+          // c0 and c1 are two inputs.. (explain more)
+          var f = c0 => c1 => {
+            var glslString = `${method}(${c0}, ${c1}`;
+            glslString += generateGlsl(inputs.slice(1));
+            glslString += ")";
+            return glslString;
+          };
+          this.transform = compositionFunctions[glslTransforms[method].type](
+            this.transform
+          )(inputs[0].value.transform)(f);
 
-          this.uniforms = this.uniforms.concat(inputs[0].value.uniforms)
+          this.uniforms = this.uniforms.concat(inputs[0].value.uniforms);
 
-          var pass = this.passes[this.passes.length - 1]
-          pass.transform = this.transform
-          pass.uniform + this.uniform
+          var pass = this.passes[this.passes.length - 1];
+          pass.transform = this.transform;
+          pass.uniform + this.uniform;
         } else {
-          var f1 = (x) => {
-            var glslString = `${method}(${x}`
-            glslString += generateGlsl(inputs)
-            glslString += ')'
-            return glslString
-          }
-          this.transform = compositionFunctions[glslTransforms[method].type](this.transform)(f1)
-          this.passes[this.passes.length - 1].transform = this.transform
+          var f1 = x => {
+            var glslString = `${method}(${x}`;
+            glslString += generateGlsl(inputs);
+            glslString += ")";
+            return glslString;
+          };
+          this.transform = compositionFunctions[glslTransforms[method].type](
+            this.transform
+          )(f1);
+          this.passes[this.passes.length - 1].transform = this.transform;
         }
 
         inputs.forEach((input, index) => {
           if (input.isUniform) {
-            this.uniforms.push(input)
+            this.uniforms.push(input);
           }
-        })
-        this.passes[this.passes.length - 1].uniforms = this.uniforms
-        return this
-      }
+        });
+        this.passes[this.passes.length - 1].uniforms = this.uniforms;
+        return this;
+      };
     }
-  })
-}
+  });
+};
 
 //
 //   iterate through transform types and create a function for each
 //
-Generator.prototype.compile = function (pass) {
-//  console.log("compiling", pass)
+Generator.prototype.compile = function(pass) {
+  //  console.log("compiling", pass)
   var frag = `
-  precision highp float;
-  ${pass.uniforms.map((uniform) => {
-    let type = ''
-    switch (uniform.type) {
-      case 'float':
-        type = 'float'
-        break
-      case 'texture':
-        type = 'sampler2D'
-        break
-    }
-    return `
-      uniform ${type} ${uniform.name};`
-  }).join('')}
+  precision ${pass.precision} float;
+  ${pass.uniforms
+    .map(uniform => {
+      let type = "";
+      switch (uniform.type) {
+        case "float":
+          type = "float";
+          break;
+        case "texture":
+          type = "sampler2D";
+          break;
+      }
+      return `
+      uniform ${type} ${uniform.name};`;
+    })
+    .join("")}
   uniform float time;
   uniform vec2 resolution;
   varying vec2 uv;
 
-  ${Object.values(glslTransforms).map((transform) => {
-  //  console.log(transform.glsl)
-    return `
+  ${Object.values(glslTransforms)
+    .map(transform => {
+      //  console.log(transform.glsl)
+      return `
             ${transform.glsl}
-          `
-  }).join('')}
+          `;
+    })
+    .join("")}
 
   void main () {
     vec4 c = vec4(1, 0, 0, 1);
     //vec2 st = uv;
     vec2 st = gl_FragCoord.xy/resolution.xy;
-    gl_FragColor = ${pass.transform('st')};
+    gl_FragColor = ${pass.transform("st")};
   }
-  `
-  return frag
-}
-
+  `;
+  return frag;
+};
 
 // creates a fragment shader from an object containing uniforms and a snippet of
 // fragment shader code
-Generator.prototype.compileRenderPass = function (pass) {
+Generator.prototype.compileRenderPass = function(pass) {
   var frag = `
-      precision highp float;
-      ${pass.uniforms.map((uniform) => {
-        let type = ''
-        switch (uniform.type) {
-          case 'float':
-            type = 'float'
-            break
-          case 'texture':
-            type = 'sampler2D'
-            break
-        }
-        return `
-          uniform ${type} ${uniform.name};`
-      }).join('')}
+      precision ${pass.precision} float;
+      ${pass.uniforms
+        .map(uniform => {
+          let type = "";
+          switch (uniform.type) {
+            case "float":
+              type = "float";
+              break;
+            case "texture":
+              type = "sampler2D";
+              break;
+          }
+          return `
+          uniform ${type} ${uniform.name};`;
+        })
+        .join("")}
       uniform float time;
       uniform vec2 resolution;
       uniform sampler2D prevBuffer;
       varying vec2 uv;
 
-      ${Object.values(renderPassFunctions).filter(transform => transform.type === 'renderpass_util')
-      .map((transform) => {
-      //  console.log(transform.glsl)
-        return `
+      ${Object.values(renderPassFunctions)
+        .filter(transform => transform.type === "renderpass_util")
+        .map(transform => {
+          //  console.log(transform.glsl)
+          return `
                 ${transform.glsl}
-              `
-      }).join('')}
+              `;
+        })
+        .join("")}
 
       ${pass.glsl}
-  `
-  return frag
-}
+  `;
+  return frag;
+};
 
+Generator.prototype.glsl = function(_output) {
+  var output = _output || this.defaultOutput;
 
-Generator.prototype.glsl = function (_output) {
-  var output = _output || this.defaultOutput
-
-  var passes = this.passes.map((pass) => {
-    var uniforms = {}
-    pass.uniforms.forEach((uniform) => { uniforms[uniform.name] = uniform.value })
-    if(pass.hasOwnProperty('transform')){
-    //  console.log(" rendering pass", pass)
+  var passes = this.passes.map(pass => {
+    var uniforms = {};
+    pass.uniforms.forEach(uniform => {
+      uniforms[uniform.name] = uniform.value;
+    });
+    if (pass.hasOwnProperty("transform")) {
+      //  console.log(" rendering pass", pass)
 
       return {
         frag: this.compile(pass),
         uniforms: Object.assign(output.uniforms, uniforms)
-      }
+      };
     } else {
-    //  console.log(" not rendering pass", pass)
+      //  console.log(" not rendering pass", pass)
       return {
         frag: pass.frag,
-        uniforms:  Object.assign(output.uniforms, uniforms)
-      }
+        uniforms: Object.assign(output.uniforms, uniforms)
+      };
     }
-  })
-  return passes
-}
+  });
+  return passes;
+};
 
+Generator.prototype.out = function(_output) {
+  //  console.log('UNIFORMS', this.uniforms, output)
+  var output = _output || this.defaultOutput;
 
+  output.renderPasses(this.glsl(output));
+};
 
-Generator.prototype.out = function (_output) {
-//  console.log('UNIFORMS', this.uniforms, output)
-  var output = _output || this.defaultOutput
-
-  output.renderPasses(this.glsl(output))
-
-}
-
-module.exports = GeneratorFactory
+module.exports = GeneratorFactory;

--- a/src/output.js
+++ b/src/output.js
@@ -2,6 +2,7 @@ const transforms = require('./glsl-transforms.js')
 
 var Output = function (opts) {
   this.regl = opts.regl
+  this.precision = opts.precision
   this.positionBuffer = this.regl.buffer([
     [-2, 0],
     [0, -2],
@@ -56,7 +57,7 @@ Output.prototype.getTexture = function () {
 Output.prototype.clear = function () {
   this.transformIndex = 0
   this.fragHeader = `
-  precision highp float;
+  precision ${this.precision} float;
 
   uniform float time;
   varying vec2 uv;
@@ -68,7 +69,7 @@ Output.prototype.clear = function () {
   //   gl_FragColor = color;
   // }`
   this.vert = `
-  precision highp float;
+  precision ${this.precision} float;
   attribute vec2 position;
   varying vec2 uv;
 

--- a/src/output.js
+++ b/src/output.js
@@ -1,36 +1,38 @@
-const transforms = require('./glsl-transforms.js')
+const transforms = require("./glsl-transforms.js");
 
-var Output = function (opts) {
-  this.regl = opts.regl
-  this.positionBuffer = this.regl.buffer([
-    [-2, 0],
-    [0, -2],
-    [2, 2]
-  ])
+var Output = function(opts) {
+  this.regl = opts.regl;
+  this.positionBuffer = this.regl.buffer([[-2, 0], [0, -2], [2, 2]]);
 
-  this.clear()
-  this.pingPongIndex = 0
+  this.precision = opts.precision;
+
+  this.clear();
+  this.pingPongIndex = 0;
 
   // for each output, create two fbos to use for ping ponging
-  this.fbos = (Array(2)).fill().map(() => this.regl.framebuffer({
-    color: this.regl.texture({
-      width: opts.width,
-      height: opts.height,
-      format: 'rgba'
-    }),
-    depthStencil: false
-  }))
+  this.fbos = Array(2)
+    .fill()
+    .map(() =>
+      this.regl.framebuffer({
+        color: this.regl.texture({
+          width: opts.width,
+          height: opts.height,
+          format: "rgba"
+        }),
+        depthStencil: false
+      })
+    );
 
   // array containing render passes
-  this.passes = []
+  this.passes = [];
   // console.log("position", this.positionBuffer)
-}
+};
 
 Output.prototype.resize = function(width, height) {
-  this.fbos.forEach((fbo) => {
-    fbo.resize(width, height)
-  })
-}
+  this.fbos.forEach(fbo => {
+    fbo.resize(width, height);
+  });
+};
 
 // Object.keys(transforms).forEach((method) => {
 //   Output.prototype[method] = function (...args) {
@@ -41,49 +43,49 @@ Output.prototype.resize = function(width, height) {
 //   }
 // })
 
-Output.prototype.getCurrent = function () {
+Output.prototype.getCurrent = function() {
   // console.log("get current",this.pingPongIndex )
-  return this.fbos[this.pingPongIndex]
-}
+  return this.fbos[this.pingPongIndex];
+};
 
-Output.prototype.getTexture = function () {
-//  return this.fbos[!this.pingPongIndex]
-  var index = this.pingPongIndex ? 0 : 1
+Output.prototype.getTexture = function() {
+  //  return this.fbos[!this.pingPongIndex]
+  var index = this.pingPongIndex ? 0 : 1;
   //  console.log("get texture",index)
-  return this.fbos[index]
-}
+  return this.fbos[index];
+};
 
-Output.prototype.clear = function () {
-  this.transformIndex = 0
+Output.prototype.clear = function() {
+  this.transformIndex = 0;
   this.fragHeader = `
-  precision highp float;
+  precision ${this.precision} float;
 
   uniform float time;
   varying vec2 uv;
-  `
-  this.fragBody = ``
+  `;
+  this.fragBody = ``;
   //
   // uniform vec4 color;
   // void main () {
   //   gl_FragColor = color;
   // }`
   this.vert = `
-  precision highp float;
+  precision ${this.precision} float;
   attribute vec2 position;
   varying vec2 uv;
 
   void main () {
     uv = position;
     gl_Position = vec4(2.0 * position - 1.0, 0, 1);
-  }`
+  }`;
   this.attributes = {
     position: this.positionBuffer
-  }
+  };
   this.uniforms = {
-    time: this.regl.prop('time'),
-    resolution: this.regl.prop('resolution')
-  }
-//  this.compileFragShader()
+    time: this.regl.prop("time"),
+    resolution: this.regl.prop("resolution")
+  };
+  //  this.compileFragShader()
 
   this.frag = `
        ${this.fragHeader}
@@ -94,10 +96,9 @@ Output.prototype.clear = function () {
         ${this.fragBody}
         gl_FragColor = c;
       }
-  `
-  return this
-}
-
+  `;
+  return this;
+};
 
 // Output.prototype.compileFragShader = function () {
 //   var frag = `
@@ -114,7 +115,7 @@ Output.prototype.clear = function () {
 //   this.frag = frag
 // }
 
-Output.prototype.render = function () {
+Output.prototype.render = function() {
   this.draw = this.regl({
     frag: this.frag,
     vert: this.vert,
@@ -122,46 +123,45 @@ Output.prototype.render = function () {
     uniforms: this.uniforms,
     count: 3,
     framebuffer: () => {
-      this.pingPongIndex = this.pingPongIndex ? 0 : 1
-      return this.fbos[this.pingPongIndex]
+      this.pingPongIndex = this.pingPongIndex ? 0 : 1;
+      return this.fbos[this.pingPongIndex];
     }
-  })
-}
+  });
+};
 
 Output.prototype.renderPasses = function(passes) {
-  var self = this
-//  console.log("passes", passes)
-  this.passes = passes.map( (pass, passIndex) => {
-
+  var self = this;
+  //  console.log("passes", passes)
+  this.passes = passes.map((pass, passIndex) => {
     //  console.log("get texture",index)
-    var uniforms = Object.assign(pass.uniforms, { prevBuffer:  () =>  {
-           var index = this.pingPongIndex ? 0 : 1
+    var uniforms = Object.assign(pass.uniforms, {
+      prevBuffer: () => {
+        var index = this.pingPongIndex ? 0 : 1;
         //  console.log('pass index', passIndex, 'fbo index', index)
-         return this.fbos[this.pingPongIndex ? 0 : 1]
+        return this.fbos[this.pingPongIndex ? 0 : 1];
+      }
+    });
+
+    return {
+      draw: self.regl({
+        frag: pass.frag,
+        vert: self.vert,
+        attributes: self.attributes,
+        uniforms: uniforms,
+        count: 3,
+        framebuffer: () => {
+          self.pingPongIndex = self.pingPongIndex ? 0 : 1;
+          //  console.log('pass index', passIndex, 'render index',  self.pingPongIndex)
+          return self.fbos[self.pingPongIndex];
         }
       })
+    };
+  });
+};
 
-      return {
-        draw: self.regl({
-          frag: pass.frag,
-          vert: self.vert,
-          attributes: self.attributes,
-          uniforms: uniforms,
-          count: 3,
-          framebuffer: () => {
+Output.prototype.tick = function(props) {
+  //  this.draw(props)
+  this.passes.forEach(pass => pass.draw(props));
+};
 
-            self.pingPongIndex = self.pingPongIndex ? 0 : 1
-          //  console.log('pass index', passIndex, 'render index',  self.pingPongIndex)
-            return self.fbos[self.pingPongIndex]
-          }
-        })
-      }
-  })
-}
-
-Output.prototype.tick = function (props) {
-//  this.draw(props)
-  this.passes.forEach((pass) => pass.draw(props))
-}
-
-module.exports = Output
+module.exports = Output;

--- a/src/shaderManager.js
+++ b/src/shaderManager.js
@@ -2,11 +2,12 @@
 // 1. how to handle multi-pass renders
 // 2. how to handle vertex shaders
 
-module.exports = function (defaultOutput) {
+module.exports = function (defaultOutput, precision) {
 
   var Frag = function (shaderString) {
     var obj =  Object.create(Frag.prototype)
     obj.shaderString =   `
+    precision ${precision} float;
     void main () {
       vec2 st = gl_FragCoord.xy/resolution.xy;
       gl_FragColor = vec4(st, 1.0, 1.0);
@@ -18,7 +19,7 @@ module.exports = function (defaultOutput) {
 
   Frag.prototype.compile = function () {
     var frag = `
-    precision highp float;
+    precision ${precision} float;
     uniform float time;
     uniform vec2 resolution;
     varying vec2 uv;
@@ -34,7 +35,8 @@ module.exports = function (defaultOutput) {
     output.frag = frag
     var pass = {
       frag: frag,
-      uniforms: output.uniforms
+      uniforms: output.uniforms,
+      precision: precisionValue
     }
     console.log('rendering', pass)
     var passes = []

--- a/src/shaderManager.js
+++ b/src/shaderManager.js
@@ -2,48 +2,49 @@
 // 1. how to handle multi-pass renders
 // 2. how to handle vertex shaders
 
-module.exports = function(defaultOutput, precision) {
-  var Frag = function(shaderString) {
-    var obj = Object.create(Frag.prototype);
-    obj.shaderString = `
+module.exports = function (defaultOutput) {
+
+  var Frag = function (shaderString) {
+    var obj =  Object.create(Frag.prototype)
+    obj.shaderString =   `
     void main () {
       vec2 st = gl_FragCoord.xy/resolution.xy;
       gl_FragColor = vec4(st, 1.0, 1.0);
     }
-    `;
-    if (shaderString) obj.shaderString = shaderString;
-    return obj;
-  };
+    `
+    if(shaderString) obj.shaderString = shaderString
+    return obj
+  }
 
-  Frag.prototype.compile = function() {
+  Frag.prototype.compile = function () {
     var frag = `
-    precision ${precision} float;
+    precision highp float;
     uniform float time;
     uniform vec2 resolution;
     varying vec2 uv;
 
     ${this.shaderString}
-    `;
-    return frag;
-  };
+    `
+    return frag
+  }
 
-  Frag.prototype.out = function(_output) {
-    var output = _output || defaultOutput;
-    var frag = this.compile();
-    output.frag = frag;
+  Frag.prototype.out = function (_output) {
+    var output = _output || defaultOutput
+    var frag = this.compile()
+    output.frag = frag
     var pass = {
       frag: frag,
       uniforms: output.uniforms
-    };
-    console.log("rendering", pass);
-    var passes = [];
-    passes.push(pass);
-    output.renderPasses([pass]);
+    }
+    console.log('rendering', pass)
+    var passes = []
+    passes.push(pass)
+    output.renderPasses([pass])
     // var uniformObj = {}
     // this.uniforms.forEach((uniform) => { uniformObj[uniform.name] = uniform.value })
     // output.uniforms = Object.assign(output.uniforms, uniformObj)
-    output.render();
-  };
+    output.render()
+  }
 
-  return Frag;
-};
+  return Frag
+}

--- a/src/shaderManager.js
+++ b/src/shaderManager.js
@@ -2,49 +2,48 @@
 // 1. how to handle multi-pass renders
 // 2. how to handle vertex shaders
 
-module.exports = function (defaultOutput) {
-
-  var Frag = function (shaderString) {
-    var obj =  Object.create(Frag.prototype)
-    obj.shaderString =   `
+module.exports = function(defaultOutput, precision) {
+  var Frag = function(shaderString) {
+    var obj = Object.create(Frag.prototype);
+    obj.shaderString = `
     void main () {
       vec2 st = gl_FragCoord.xy/resolution.xy;
       gl_FragColor = vec4(st, 1.0, 1.0);
     }
-    `
-    if(shaderString) obj.shaderString = shaderString
-    return obj
-  }
+    `;
+    if (shaderString) obj.shaderString = shaderString;
+    return obj;
+  };
 
-  Frag.prototype.compile = function () {
+  Frag.prototype.compile = function() {
     var frag = `
-    precision highp float;
+    precision ${precision} float;
     uniform float time;
     uniform vec2 resolution;
     varying vec2 uv;
 
     ${this.shaderString}
-    `
-    return frag
-  }
+    `;
+    return frag;
+  };
 
-  Frag.prototype.out = function (_output) {
-    var output = _output || defaultOutput
-    var frag = this.compile()
-    output.frag = frag
+  Frag.prototype.out = function(_output) {
+    var output = _output || defaultOutput;
+    var frag = this.compile();
+    output.frag = frag;
     var pass = {
       frag: frag,
       uniforms: output.uniforms
-    }
-    console.log('rendering', pass)
-    var passes = []
-    passes.push(pass)
-    output.renderPasses([pass])
+    };
+    console.log("rendering", pass);
+    var passes = [];
+    passes.push(pass);
+    output.renderPasses([pass]);
     // var uniformObj = {}
     // this.uniforms.forEach((uniform) => { uniformObj[uniform.name] = uniform.value })
     // output.uniforms = Object.assign(output.uniforms, uniformObj)
-    output.render()
-  }
+    output.render();
+  };
 
-  return Frag
-}
+  return Frag;
+};


### PR DESCRIPTION
this is an updated solution for an issue brought up in #15 

with precision added to the constructor, the hydra-editor webpage can now pass whatever the appropriate precision float value should be

newer iOS devices seem to work better with highp but a lot of android devices seem to work best with mediump. By default it will use 'mediump'

example:
```
const Hydra = require('hydra-synth');

const canvas = document.createElement('canvas')

// ... 

let isIOS =
  (/iPad|iPhone|iPod/.test(navigator.platform) ||
    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) &&
  !window.MSStream;

let precisionValue = isIOS ? 'highp' : 'mediump';

let hydra = new Hydra({
    canvas: canvas,
    enableStreamCapture: false,
    detectAudio: false,
    // etc
    precision: precisionValue
});
```

☺️✨