### PR TITLE
iOS support: catch exception that is thrown when calling 'new MediaSource()' on iOS

### DIFF
--- a/hydra-synth.js
+++ b/hydra-synth.js
@@ -92,9 +92,14 @@ class HydraRenderer {
     }
 
     if (enableStreamCapture) {
-      this.captureStream = this.canvas.captureStream(25)
-      // to do: enable capture stream of specific sources and outputs
-      this.synth.vidRecorder = new VidRecorder(this.captureStream)
+      try {
+        this.captureStream = this.canvas.captureStream(25)
+        // to do: enable capture stream of specific sources and outputs
+        this.synth.vidRecorder = new VidRecorder(this.captureStream)
+      } catch (e) {
+        console.warn('[hydra-synth warning]\nnew MediaSource() is not currently supported on iOS.')
+        console.error(e)
+      }
     }
 
     if(detectAudio) this._initAudio()


### PR DESCRIPTION
⚙️ **Changes**

Adds try...catch block around `new VidRecorder()`

❇️ **Why**

iOS does not support `new MediaSource()` currently
https://stackoverflow.com/posts/53001487/revisions

⚠️ **Next Steps**

Now that canvas is rendering on iOS, we will have to figure out why functions are rendering inconsistently but probably better to have in a different PR.

![](https://user-images.githubusercontent.com/2532937/110146674-d5cea700-7da8-11eb-9e7f-77b595919712.png)
