### PR TITLE
Make sure eval is running in the global scope

### DIFF
--- a/src/lib/sandbox.js
+++ b/src/lib/sandbox.js
@@ -21,10 +21,11 @@ module.exports = (parent) => {
   }
 
   function createSandbox (initial) {
-    eval(initial)
+    var globalEval = eval
+    globalEval(initial)
     // optional params
     var localEval = function (code)  {
-      eval(code)
+      globalEval(code)
     }
 
     // API/data for end-user


### PR DESCRIPTION
Hi Olivia,

Trying to use Rollup to generate an hydra-synth [esm-bundle](https://medium.com/@joeldenning/an-esm-bundle-for-any-npm-package-5f850db0e04d) I got this warning:

![rollup warning](https://user-images.githubusercontent.com/1321392/130334957-ebc565a3-3fcb-4f76-baf5-0456658fb647.png)

When using the resulting bundle the browser displays the following error:

![browser error](https://user-images.githubusercontent.com/1321392/130335052-2beb1099-34d8-42be-be59-5320e2ba1c8b.png)

Apparently this has to do with [how Rollup works internally](https://rollupjs.org/guide/en/#avoiding-eval). Fortunately the solution is very simple.

This pull request is to ensure that eval runs in the global scope so that hydra-synth can be used with rollup-based bundlers.

Greetings and thank you very much for such a powerful library 💎 



