### PR TITLE
Midi option A

### DIFF
--- a/hydra-synth.js
+++ b/hydra-synth.js
@@ -8,6 +8,7 @@ const ArrayUtils = require('./src/lib/array-utils.js')
 const Sandbox = require('./src/eval-sandbox.js')
 
 const Generator = require('./src/generator-factory.js')
+const Midi = require('./src/lib/midi.js')
 
 // to do: add ability to pass in certain uniforms and transforms
 class HydraRenderer {
@@ -21,6 +22,7 @@ class HydraRenderer {
     makeGlobal = true,
     autoLoop = true,
     detectAudio = true,
+    useMidi = false,
     enableStreamCapture = true,
     canvas,
     precision = 'mediump',
@@ -98,6 +100,8 @@ class HydraRenderer {
     }
 
     if(detectAudio) this._initAudio()
+
+    if(useMidi) this._initMidi();
 
     if(autoLoop) loop(this.tick.bind(this)).start()
 
@@ -180,6 +184,11 @@ class HydraRenderer {
       //   }
       // }
     })
+  }
+
+  _initMidi () {
+    this.synth.m = new Midi();
+    this.m = this.synth.m;
   }
 
   // create main output canvas and add to screen

--- a/hydra-synth.js
+++ b/hydra-synth.js
@@ -22,7 +22,7 @@ class HydraRenderer {
     makeGlobal = true,
     autoLoop = true,
     detectAudio = true,
-    useMidi = false,
+    useMidi = true,
     enableStreamCapture = true,
     canvas,
     precision = 'mediump',

--- a/src/lib/midi.js
+++ b/src/lib/midi.js
@@ -1,0 +1,62 @@
+'use babel'
+
+export default class Midi {
+    
+    constructor() {
+        this.reset();
+    }
+
+    start() {
+        if (!this.started) {
+            console.log('Connecting to WebMIDI.');
+            this.started = true;
+            navigator.requestMIDIAccess().then(midiAccess => {
+                console.log('Connected to WebMIDI.');
+                this.midi = midiAccess;
+                this.midi.onstatechange = this.stateChange;
+                this.midi.mapInputs = this.mapInputs;
+                this.midi.ccArray = this.ccArray;
+                this.midi.mapInputs();
+            }, () => {
+                console.log('Failed to connect to WebMIDI');
+            });
+        }
+    }
+
+    reset() {
+        this.ccArray = Array(128).fill(0.5);
+        this.started = false;
+        if (this.midi != null) {
+            this.midi.onstatechange = null;
+        }
+        this.midi = null;
+    }
+
+    mapInputs()
+    {
+        Array.from(this.inputs).forEach(input => {
+            input[1].onmidimessage = (message) => {
+                var dataArray = message.data;
+                var index = dataArray[1];
+                //console.log('Midi received on cc#' + index + ' value:' + dataArray[2]);    // uncomment to monitor incoming Midi
+                var value = (dataArray[2] + 1) / 128.0;  // normalize CC values to 0.0 - 1.0
+                this.ccArray[index] = value;
+            }
+        })
+    }
+
+    stateChange(message) {
+        console.log(`MIDI device: ${message.port.name} state: ${message.port.state}`);
+        if (message.port.state === 'connected') {
+            this.mapInputs();
+        }
+    };
+
+    get cc() {
+        // we connect lazily to WebMidi
+        this.start();
+        // AKAI is cc1 - cc8
+        //console.log('Index:' + index + ' Value:' + this.cc[index]);
+        return this.ccArray;
+    }
+}

--- a/src/lib/midi.js
+++ b/src/lib/midi.js
@@ -1,6 +1,4 @@
-'use babel'
-
-export default class Midi {
+class Midi {
     
     constructor() {
         this.reset();

--- a/src/lib/midi.js
+++ b/src/lib/midi.js
@@ -5,31 +5,19 @@ class Midi {
     }
 
     start() {
-        if (!this.started && !this.shuttingDown) {
-            this.started = true;
-            navigator.requestMIDIAccess({sysex : false, software : false}).then(midiAccess => {
-                console.log('Connected to WebMIDI.');
-                this.midi = midiAccess;
-                this.midi.shuttingDown = false;
-                this.midi.onstatechange = this.stateChange;
-                this.midi.mapInputs = this.mapInputs;
-                this.midi.ccArray = this.ccArray;
-                for (let input of this.midi.inputs.values()) {
-                    input.open();
-                }
-            }, () => {
-                console.log('Failed to connect to WebMIDI, WebMIDI is not supported on all browsers yet: https://developer.mozilla.org/en-US/docs/Web/API/MIDIAccess');
-            });
-        }
-    }
-
-    reset() {
-        this.ccArray = Array(128).fill(0.5);
-        this.started = false;
-        if (this.midi != null) {
-            this.midi.onstatechange = null;
-        }
-        this.midi = null;
+        this.started = true;
+        navigator.requestMIDIAccess({sysex : false, software : false}).then(midiAccess => {
+            console.log('Connected to WebMIDI.');
+            this.midi = midiAccess;
+            this.midi.onstatechange = this.stateChange;
+            this.midi.mapInputs = this.mapInputs;
+            this.midi.ccArray = this.ccArray;
+            for (let input of this.midi.inputs.values()) {
+                input.open();
+            }
+        }, () => {
+            console.log('Failed to connect to WebMIDI, WebMIDI is not supported on all browsers yet: https://developer.mozilla.org/en-US/docs/Web/API/MIDIAccess');
+        });
     }
 
     mapInputs() {
@@ -46,10 +34,7 @@ class Midi {
 
     stateChange(message) {
         console.log(`stateChange MIDI device: '${message.port.name}', state: '${message.port.state}', connection: '${message.port.connection}'`);
-        if (this.shuttingDown) {
-            return;
-        }
-        else if (message.port.connection === 'open') {
+        if (message.port.connection === 'open') {
             this.mapInputs();
         }
         else if (message.port.connection === 'closed') {
@@ -59,7 +44,9 @@ class Midi {
 
     get cc() {
         // we connect lazily to WebMidi
-        this.start();
+        if (!this.started) {
+            this.start();
+        }
         //console.log('Index:' + index + ' Value:' + this.cc[index]);
         return this.ccArray;
     }

--- a/src/lib/midi.js
+++ b/src/lib/midi.js
@@ -47,7 +47,6 @@ class Midi {
         if (!this.started) {
             this.start();
         }
-        //console.log('Index:' + index + ' Value:' + this.cc[index]);
         return this.ccArray;
     }
 }


### PR DESCRIPTION
Adding midi capability by lazily connecting to WebMidi interface without having to load WebMidi in a browser console.

Works similarly to how audio is handled.
`osc(10,0.4, ()=>m.cc[1]).out()`

Almost identical in its use as described here:
https://github.com/ojack/hydra/blob/main/docs/midi.md

A more ambitious but less in keeping with Hydra syntax version is found here: 
