### PR TITLE
add error handler

### DIFF
--- a/dist/hydra-synth.js
+++ b/dist/hydra-synth.js
@@ -6783,15 +6783,22 @@ class HydraSource {
     if (opts.dynamic) this.dynamic = opts.dynamic
   }
 
-  initCam (index) {
+  initCam (index, errorHandler) {
     const self = this
+    if (typeof index === "function") {
+      errorHandler = index;
+      index = undefined;
+    }
+    if (errorHandler === undefined) {
+      errorHandler = err => console.log('could not get camera', err);
+    }
     Webcam(index)
       .then(response => {
         self.src = response.video
         self.dynamic = true
         self.tex = self.regl.texture(self.src)
       })
-      .catch(err => console.log('could not get camera', err))
+      .catch(errorHandler)
   }
 
   initVideo (url = '') {
@@ -6837,8 +6844,11 @@ class HydraSource {
     }
   }
 
-  initScreen () {
+  initScreen (errorHandler) {
     const self = this
+    if (errorHandler === undefined) {
+      errorHandler = err => console.log('could not get screen', err);
+    }
     Screen()
       .then(function (response) {
         self.src = response.video
@@ -6846,7 +6856,7 @@ class HydraSource {
         self.dynamic = true
         //  console.log("received screen input")
       })
-      .catch(err => console.log('could not get screen', err))
+      .catch(errorHandler)
   }
 
   resize (width, height) {

--- a/src/hydra-source.js
+++ b/src/hydra-source.js
@@ -24,15 +24,22 @@ class HydraSource {
     if (opts.dynamic) this.dynamic = opts.dynamic
   }
 
-  initCam (index) {
+  initCam (index, errorHandler) {
     const self = this
+    if (typeof index === "function") {
+      errorHandler = index;
+      index = undefined;
+    }
+    if (errorHandler === undefined) {
+      errorHandler = err => console.log('could not get camera', err);
+    }
     Webcam(index)
       .then(response => {
         self.src = response.video
         self.dynamic = true
         self.tex = self.regl.texture(self.src)
       })
-      .catch(err => console.log('could not get camera', err))
+      .catch(errorHandler)
   }
 
   initVideo (url = '') {
@@ -78,8 +85,11 @@ class HydraSource {
     }
   }
 
-  initScreen () {
+  initScreen (errorHandler) {
     const self = this
+    if (errorHandler === undefined) {
+      errorHandler = err => console.log('could not get screen', err);
+    }
     Screen()
       .then(function (response) {
         self.src = response.video
@@ -87,7 +97,7 @@ class HydraSource {
         self.dynamic = true
         //  console.log("received screen input")
       })
-      .catch(err => console.log('could not get screen', err))
+      .catch(errorHandler)
   }
 
   resize (width, height) {


### PR DESCRIPTION
feature for issue #88 - let me know if there's better implementation. maybe "init completion" handler would make sense too? it's mainly for hydra on webpage and not for live coding

for example

```javascript
s0.initCam(e=>console.error(e, "</3"))
s0.initCam(1, e=>console.error(e, "</3"))
s0.initScreen(e=>console.error(e, "</3"))
```