### PR TITLE
fix nested layers bug (alpha channel overload)

### DIFF
--- a/dist/hydra-synth.js
+++ b/dist/hydra-synth.js
@@ -2099,7 +2099,7 @@ module.exports = () => [
 
   ],
   glsl:
-`   return vec4(mix(_c0.rgb, _c1.rgb, _c1.a), _c0.a+_c1.a);`
+`   return vec4(mix(_c0.rgb, _c1.rgb, _c1.a), clamp(_c0.a + _c1.a, 0.0, 1.0));`
 },
 {
   name: 'blend',

--- a/scripts/converted-functions.js
+++ b/scripts/converted-functions.js
@@ -636,7 +636,7 @@ module.exports = [
     
   ],
   glsl:
-`   return vec4(mix(_c0.rgb, _c1.rgb, _c1.a), _c0.a+_c1.a);
+`   return vec4(mix(_c0.rgb, _c1.rgb, _c1.a), clamp(_c0.a + _c1.a, 0.0, 1.0));
    }`
 },
 {

--- a/scripts/glsl-functions.js
+++ b/scripts/glsl-functions.js
@@ -634,7 +634,7 @@ return _st;`
   type: 'combine',
   inputs: [],
   glsl:
-`return vec4(mix(_c0.rgb, _c1.rgb, _c1.a), _c0.a+_c1.a);
+`return vec4(mix(_c0.rgb, _c1.rgb, _c1.a), clamp(_c0.a + _c1.a, 0.0, 1.0));
 }`
 },
 {

--- a/src/glsl/glsl-functions.js
+++ b/src/glsl/glsl-functions.js
@@ -704,7 +704,7 @@ module.exports = () => [
 
   ],
   glsl:
-`   return vec4(mix(_c0.rgb, _c1.rgb, _c1.a), _c0.a+_c1.a);`
+`   return vec4(mix(_c0.rgb, _c1.rgb, _c1.a), clamp(_c0.a + _c1.a, 0.0, 1.0));`
 },
 {
   name: 'blend',


### PR DESCRIPTION
I looked at the layer glsl definition (`return vec4(mix(_c0.rgb, _c1.rgb, _c1.a), _c0.a+_c1.a);`) wondering about the bug I reported the other day on discord (#101). The addition at the end seemed weird since overloading alpha values doesn't make a visual difference like overloading r g or b. So I tried clamping the value on the alpha of the return. It fixed the issue.

My solution:
```glsl
return vec4(mix(_c0.rgb, _c1.rgb, _c1.a), clamp(_c0.a + _c1.a, 0.0, 1.0));
```
Not sure what was happening. I suppose it has to do with how the glsl mix function was being overloaded in the argument for the interpolation factor.

Example:
https://hydra.ojack.xyz/?sketch_id=KDZ0NelKLFsavRER