### PR TITLE
Fix 'update' function error log and reset 'update' function when hush()

### DIFF
--- a/hydra-synth.js
+++ b/hydra-synth.js
@@ -418,10 +418,10 @@ class HydraRenderer {
     this.timeSinceLastUpdate += dt
     if(!this.synth.fps || this.timeSinceLastUpdate >= 1000/this.synth.fps) {
     //  console.log(1000/this.timeSinceLastUpdate)
-      if(this.synth.update) {
-        try { this.synth.update(dt) } catch (e) { console.log(e) }
-      }
       this.synth.stats.fps = Math.ceil(1000/this.timeSinceLastUpdate)
+      if(this.synth.update) {
+        try { this.synth.update(this.timeSinceLastUpdate) } catch (e) { console.log(e) }
+      }
     //  console.log(this.synth.speed, this.synth.time)
       for (let i = 0; i < this.s.length; i++) {
         this.s[i].tick(this.synth.time)

--- a/hydra-synth.js
+++ b/hydra-synth.js
@@ -136,6 +136,7 @@ class HydraRenderer {
       this.synth.solid(0, 0, 0, 0).out(output)
     })
     this.synth.render(this.o[0])
+    this.synth.update = (dt) => {}
   }
 
   loadScript(url = "") {
@@ -414,7 +415,7 @@ class HydraRenderer {
     if(this.detectAudio === true) this.synth.a.tick()
   //  let updateInterval = 1000/this.synth.fps // ms
     if(this.synth.update) {
-      try { this.synth.update(dt) } catch (e) { console.log(error) }
+      try { this.synth.update(dt) } catch (e) { console.log(e) }
     }
 
     this.sandbox.set('time', this.synth.time += dt * 0.001 * this.synth.speed)

--- a/hydra-synth.js
+++ b/hydra-synth.js
@@ -414,14 +414,13 @@ class HydraRenderer {
     this.sandbox.tick()
     if(this.detectAudio === true) this.synth.a.tick()
   //  let updateInterval = 1000/this.synth.fps // ms
-    if(this.synth.update) {
-      try { this.synth.update(dt) } catch (e) { console.log(e) }
-    }
-
     this.sandbox.set('time', this.synth.time += dt * 0.001 * this.synth.speed)
     this.timeSinceLastUpdate += dt
     if(!this.synth.fps || this.timeSinceLastUpdate >= 1000/this.synth.fps) {
     //  console.log(1000/this.timeSinceLastUpdate)
+      if(this.synth.update) {
+        try { this.synth.update(dt) } catch (e) { console.log(e) }
+      }
       this.synth.stats.fps = Math.ceil(1000/this.timeSinceLastUpdate)
     //  console.log(this.synth.speed, this.synth.time)
       for (let i = 0; i < this.s.length; i++) {


### PR DESCRIPTION
Errors inside the update function weren't logging because of an error.
Also added a reset of given function to the hush() function.

Edit:
while discussing a problem i had trying to have variables change for only one frame, ojack discovered the problem was update was not being constrained by the fps setting, so it would never be in sync when an fps is set. we discussed it a bit and i decided to add the constrain to this pr