### PR TITLE
Fix for #154 (option 3)

### DIFF
--- a/src/lib/array-utils.js
+++ b/src/lib/array-utils.js
@@ -8,6 +8,14 @@ var map = (num, in_min, in_max, out_min, out_max) => {
   return (num - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 
+// The '%' operator is a remainder operator, and Javascript lacks a dedicated
+// modulo operator. This function is an implementation of the operation
+// copied-n-pasted from
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder#description
+var modulo = (n, d) => {
+    return ((n % d) + d) % d;
+}
+
 export default {
   init: () => {
 
@@ -62,9 +70,22 @@ export default {
     if (smooth!==0) {
       let ease = arr._ease ? arr._ease : easing['linear']
       let _index = index - (smooth / 2)
-      let currValue = arr[Math.floor(_index % (arr.length))]
-      let nextValue = arr[Math.floor((_index + 1) % (arr.length))]
-      let t = Math.min((_index%1)/smooth,1)
+      // Compute the first value used for the interpolation: wrap _index inside the range [0, arr.length), then round the resulting value towards 0.
+      // Note that, during the first seconds Hydra is running, _index may assume a negative value.
+      // If we wrapped _index inside the range [0, arr.length) using the regular remainder operator, the result would be negative.
+      // Passing a negative index to an array returns undefined, which ultimately causes a number of graphical glitches.
+      // We need to use the modulo operation to prevent this.
+      let currValue = arr[Math.floor(modulo(_index, arr.length))]
+      // Compute the second value used for the interpolation, in a similar fashion to 'currValue'.
+      // The above reasoning about the choice of the modulo operation applies for 'nextValue', too.
+      let nextValue = arr[Math.floor(modulo(_index + 1, arr.length))]
+      // Compute the time parameter for the interpolation.
+      // Note that, during the first seconds Hydra is running, _index may assume a negative value.
+      // Assuming 'smooth' is positive, if we wrapped _index in the range [0, 1) using the regular remainder operator, t would become negative as a result.
+      // This would cause the final interpolation to assume values inconsistent with the later ones.
+      // E.g. [0, 1].smooth() should always generate values between 0 and 1, but the initial values would be negative.
+      // We need to use the modulo operation to prevent this.
+      let t = Math.min(modulo(_index, 1)/smooth,1)
       return ease(t) * (nextValue - currValue) + currValue
     }
     else {


### PR DESCRIPTION
As a brief recap of #154, whenever a Hydra function uses an array as one of its parameters, and this array's `smooth` property is set to a non-zero value:

* the output buffer chosen for displaying this function will behave in an "unexpected way" (dependent on the specific function used);
* this will only happen during the very first seconds Hydra is started, after which the output buffer will always behave as expected.

As explained in https://github.com/hydra-synth/hydra-synth/issues/154#issuecomment-1825037567, the root cause of this problem is a negative index used when searching through the original array.

This PR provides a possible fix for this issue, specifically the fix n. 3 mentioned in https://github.com/hydra-synth/hydra-synth/issues/154#issuecomment-1826088076. During the first seconds Hydra is started, instead of computing `arr[-1]` as the second value for the interpolation, `Array.smooth()` now uses the array's last value instead.

It was also discovered that the "time" parameter used for the interpolation (the variable `t`) stored negative values during the first seconds. This would make the interpolation behaviour inconsistent because, most of the time, `t` only stores values between 0 and 1. This PR takes care of this issue as well.