### PR TITLE
Support using require

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "exports": {
     ".": {
       "import": "./src/hydra-synth.js",
-      "require": "./src/index.js"
+      "require": "./dist/hydra-synth.js"
     },
     "./src/glsl/glsl-functions.js": {
       "import": "./src/glsl/glsl-functions.js",


### PR DESCRIPTION
As the browserify build is a UMD, it natively supports both the browser context and the require syntax.

We only need to point to the right file when using the require syntax.