### PR TITLE
Ensure same `time` value per frame render for all Outputs

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -8,7 +8,7 @@ const { fugitiveGeometry, exampleVideo, exampleResize, nonGlobalCanvas } = requi
 // const HydraShaders = require('./../shader-generator.js')
 
 function init () {
- 
+
 //   const canvas = document.createElement('canvas')
 //   canvas.style.backgroundColor = "#000"
 //   canvas.width = 800
@@ -20,7 +20,7 @@ function init () {
 
 
 
-var hydra = new Hydra({detectAudio:false, makeGlobal: true})
+window.hydra = new Hydra({detectAudio:false, makeGlobal: true})
 
 osc().out()
 // console.log(hydra)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-synth",
-  "version": "1.3.28",
+  "version": "1.3.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-synth",
-      "version": "1.3.28",
+      "version": "1.3.29",
       "license": "AGPL",
       "dependencies": {
         "meyda": "^5.5.1",

--- a/src/hydra-synth.js
+++ b/src/hydra-synth.js
@@ -436,9 +436,10 @@ class HydraRenderer {
         this.s[i].tick(this.synth.time)
       }
     //  console.log(this.canvas.width, this.canvas.height)
+      const currentTime = this.synth.time;
       for (let i = 0; i < this.o.length; i++) {
         this.o[i].tick({
-          time: this.synth.time,
+          time: currentTime,
           mouse: this.synth.mouse,
           bpm: this.synth.bpm,
           resolution: [this.canvas.width, this.canvas.height]


### PR DESCRIPTION
Solves #158 

I did a basic benchmark on the dev website running an `osc()` and getting the average fps after a long time (a minute or so) a couple of times. Practically no difference, results even seemed random and not related to the change.