### PR TITLE
check if src is both null && undefined

### DIFF
--- a/dist/hydra-synth.js
+++ b/dist/hydra-synth.js
@@ -2804,7 +2804,7 @@ class HydraSource {
 
   tick(time) {
     //  console.log(this.src, this.tex.width, this.tex.height)
-    if (this.src !== null && this.dynamic === true) {
+    if (this.src && this.dynamic === true) {
       if (this.src.videoWidth && this.src.videoWidth !== this.tex.width) {
         console.log(this.src.videoWidth, this.src.videoHeight, this.tex.width, this.tex.height);
         this.tex.resize(this.src.videoWidth, this.src.videoHeight);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-synth",
-  "version": "1.3.28",
+  "version": "1.3.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-synth",
-      "version": "1.3.28",
+      "version": "1.3.29",
       "license": "AGPL",
       "dependencies": {
         "meyda": "^5.5.1",

--- a/src/hydra-source.js
+++ b/src/hydra-source.js
@@ -108,7 +108,7 @@ class HydraSource {
 
   tick (time) {
     //  console.log(this.src, this.tex.width, this.tex.height)
-    if (this.src !== null && this.dynamic === true) {
+    if (this.src && this.dynamic === true) {
       if (this.src.videoWidth && this.src.videoWidth !== this.tex.width) {
         console.log(
           this.src.videoWidth,


### PR DESCRIPTION
Small fix as discussed in #162 – `clear()` uses the same check.