### PR TITLE
Add initCanvas method to HydraSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,15 @@ shape(4).diff(osc(2, 0.1, 1.2)).out()
 ### Known issues / troubleshooting
 
 #### Vite
-When using hydra with Vite, you might see the error 
+When using hydra with Vite, you might see the error `Uncaught ReferenceError: global is not defined`. This is an issue in `hydra-synth` dependency, which further depends on node's `global`. 
+
+- To fully mitigate the issue: add a polyfill for `global`. (See [ref](https://github.com/vitejs/vite/discussions/5912#discussioncomment-1724947))
+- To workaround: add the following snippet to `vite.config.json`. (See [ref](https://github.com/vitejs/vite/discussions/5912#discussioncomment-2908994))
+``` js
+define: {
+  global: {},
+},
+```
 
 #### Autoplay on iOS
 

--- a/src/hydra-source.js
+++ b/src/hydra-source.js
@@ -91,6 +91,32 @@ class HydraSource {
       .catch(err => console.log('could not get screen', err))
   }
 
+  // cache for the canvases, so we don't create them every time
+  canvases = {}
+
+  // Creates a canvas and returns the 2d context
+  initCanvas (width = 1000, height = 1000) {
+    if (this.canvases[this.label] == undefined) {
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext('2d')
+      if(ctx != null)
+        this.canvases[this.label] = ctx
+    }
+
+    const ctx = this.canvases[this.label]
+    const canvas = ctx.canvas
+    if (canvas.width !== width && canvas.height !== height) {
+      canvas.width = width
+      canvas.height = height
+    } else {
+      ctx.clearRect(0, 0, width, height)
+    }
+    this.init({ src: canvas })
+
+    this.dynamic = true
+    return ctx
+  }
+
   resize (width, height) {
     this.width = width
     this.height = height


### PR DESCRIPTION
An easy way to create a canvas context, to draw onto, and bring that into hydra.

Example:

```js
const canvas = s0.initCanvas()

canvas.font = "helvetica 14pt"
canvas.fillColor = "red"
canvas.fillText(10, 10, "test")
canvas.fillRect(10, 10, 100, 100)
		
src(s0).out()
```

Arguments are width and height, defaulting to 1000.


I didn't exactly know where to put documentation for this, if you point me to the place I will do that as well :) 
