### PR TITLE
throw error and stop compilation when incorrect arguments passed as texture

### DIFF
--- a/src/format-arguments.js
+++ b/src/format-arguments.js
@@ -57,6 +57,12 @@ export default function formatArguments(transform, startIndex, synthContext) {
     // if user has input something for this argument
     if (userArgs.length > index) {
       typedArg.value = userArgs[index]
+
+      if (typedArg.type === 'vec4') {
+        if (!(typedArg.value.type === "GlslSource" || typedArg.value.getTexture)) {
+          throw new Error("Arguments must be a texture or GlslSource")
+        }
+      }
       // do something if a composite or transform
 
       if (typeof userArgs[index] === 'function') {
@@ -66,7 +72,7 @@ export default function formatArguments(transform, startIndex, synthContext) {
         typedArg.value = (context, props, batchId) => {
           try {
             const val = userArgs[index](props)
-            if(typeof val === 'number') {
+            if (typeof val === 'number') {
               return val
             } else {
               console.warn('function does not return a number', userArgs[index])
@@ -87,12 +93,12 @@ export default function formatArguments(transform, startIndex, synthContext) {
         //  } else {
         //  console.log("is Array")
         // filter out values that are not a number
-       // const filteredArray = userArgs[index].filter((val) => typeof val === 'number')
-       // typedArg.value = (context, props, batchId) => arrayUtils.getValue(filteredArray)(props)
-       typedArg.value = (context, props, batchId) => arrayUtils.getValue(userArgs[index])(props)
-       typedArg.isUniform = true
+        // const filteredArray = userArgs[index].filter((val) => typeof val === 'number')
+        // typedArg.value = (context, props, batchId) => arrayUtils.getValue(filteredArray)(props)
+        typedArg.value = (context, props, batchId) => arrayUtils.getValue(userArgs[index])(props)
+        typedArg.isUniform = true
         // }
-      } 
+      }
     }
 
     if (startIndex < 0) {

--- a/src/glsl-source.js
+++ b/src/glsl-source.js
@@ -20,13 +20,14 @@ GlslSource.prototype.addTransform = function (obj)  {
 
 GlslSource.prototype.out = function (_output) {
   var output = _output || this.defaultOutput
-  var glsl = this.glsl(output)
-  this.synth.currentFunctions = []
+ 
  // output.renderPasses(glsl)
   if(output) try{
+     var glsl = this.glsl(output)
+    this.synth.currentFunctions = []
     output.render(glsl)
   } catch (error) {
-    console.log('shader could not compile', error)
+    console.warn('shader could not compile', error)
   }
 }
 

--- a/src/hydra-synth.js
+++ b/src/hydra-synth.js
@@ -420,6 +420,7 @@ class HydraRenderer {
 
   // dt in ms
   tick (dt, uniforms) {
+    try {
     this.sandbox.tick()
     if(this.detectAudio === true) this.synth.a.tick()
   //  let updateInterval = 1000/this.synth.fps // ms
@@ -465,8 +466,11 @@ class HydraRenderer {
       this.canvasToImage()
       this.saveFrame = false
     }
+  } catch(e) {
+    console.warn('Error during tick():', e)
   //  this.regl.poll()
   }
+}
 
 
 }


### PR DESCRIPTION
This no longer causes a hard crash for the following functions:
```
osc().modulate(osc().r).out()
```

and 
```
osc().modulate().out()
```