### PR TITLE
Add pluggable renderer interface

### DIFF
--- a/dev/test-vertex-webgl.html
+++ b/dev/test-vertex-webgl.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hydra Vertex Extension Test (Core + Install)</title>
+    <style>
+      body { margin: 0; background: black; }
+      canvas { width: 100vw; height: 100vh; }
+      #status { position: fixed; top: 10px; left: 10px; color: white; font-family: monospace; z-index: 100; }
+      #controls { position: fixed; bottom: 10px; left: 10px; color: white; font-family: monospace; z-index: 100; }
+    </style>
+  </head>
+  <body>
+    <div id="status">Loading...</div>
+    <div id="controls">
+      Press 1-4 to switch patterns
+    </div>
+    <script type="module">
+      // Test: Core hydra-synth + vertex extension install()
+      // This validates the renderer interface works with vertex extension
+      import HydraRenderer from '../src/hydra-synth.js'
+      import { install } from '../extensions/vertex/index.js'
+
+      window.onload = async () => {
+        const status = document.getElementById('status')
+
+        try {
+          status.textContent = 'Creating core Hydra...'
+
+          // Create hydra instance using core (with new renderer interface)
+          const hydra = new HydraRenderer({
+            detectAudio: false,
+            makeGlobal: true,
+            useWGSL: false
+          })
+
+          await hydra.ready()
+
+          // Install vertex extension on top
+          status.textContent = 'Installing vertex extension...'
+          const success = install(hydra)
+
+          if (!success) {
+            throw new Error('Vertex extension install failed')
+          }
+
+          // Log info
+          console.log('Hydra:', hydra)
+          console.log('Renderer:', hydra.renderer)
+          console.log('Renderer capabilities:', hydra.renderer.capabilities)
+          status.textContent = `Core + Vertex Extension (${hydra.renderer.capabilities.name})`
+
+          // Test 2D pattern first
+          osc(10, 0.1, 1).out(o0)
+
+          // Keyboard controls
+          document.addEventListener('keydown', (e) => {
+            switch (e.key) {
+              case '1':
+                // 2D pattern
+                osc(10, 0.1, 1).out(o0)
+                status.textContent = 'Pattern 1: osc (2D)'
+                break
+              case '2':
+                // 2D with modulation
+                osc(20, 0.05, 1.5).rotate(0.1).modulate(noise(3), 0.2).out(o0)
+                status.textContent = 'Pattern 2: osc + noise (2D)'
+                break
+              case '3':
+                // 3D - simple sphere
+                osc(10).out(o0, sphere().perspective(60).rotateY(() => time))
+                status.textContent = 'Pattern 3: sphere (3D)'
+                break
+              case '4':
+                // 3D - cube with texture
+                noise(5).colorama(0.5).out(o0, cube().perspective(60).rotateX(() => time * 0.5).rotateY(() => time))
+                status.textContent = 'Pattern 4: textured cube (3D)'
+                break
+            }
+          })
+
+          console.log('Hydra + Vertex initialized successfully')
+          status.textContent += ' - Press 1-4 (1-2: 2D, 3-4: 3D)'
+
+        } catch (e) {
+          console.error('Error:', e)
+          status.textContent = 'Error: ' + e.message
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/dev/test-webgl.html
+++ b/dev/test-webgl.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hydra WebGL Renderer Test (Core)</title>
+    <style>
+      body { margin: 0; background: black; }
+      canvas { width: 100vw; height: 100vh; }
+      #status { position: fixed; top: 10px; left: 10px; color: white; font-family: monospace; z-index: 100; }
+      #controls { position: fixed; bottom: 10px; left: 10px; color: white; font-family: monospace; z-index: 100; }
+    </style>
+  </head>
+  <body>
+    <div id="status">Loading...</div>
+    <div id="controls">
+      Press 1-4 to switch patterns
+    </div>
+    <script type="module">
+      // Test core hydra-synth with WebGL1Renderer
+      import HydraRenderer from '../src/hydra-synth.js'
+
+      window.onload = async () => {
+        const status = document.getElementById('status')
+
+        try {
+          status.textContent = 'Creating Hydra with WebGL...'
+
+          // Create hydra instance with default WebGL mode
+          const hydra = new HydraRenderer({
+            detectAudio: false,
+            makeGlobal: true,
+            useWGSL: false  // Ensure WebGL mode
+          })
+
+          // Wait for initialization
+          await hydra.ready()
+
+          // Log renderer info
+          console.log('Hydra:', hydra)
+          console.log('Renderer:', hydra.renderer)
+          console.log('Renderer capabilities:', hydra.renderer.capabilities)
+          console.log('Shader language:', hydra.renderer.shaderLanguage)
+          status.textContent = `Renderer: ${hydra.renderer.capabilities.name} (${hydra.renderer.shaderLanguage})`
+
+          // Basic test - osc pattern
+          osc(10, 0.1, 1).out(o0)
+
+          // Keyboard controls for testing patterns
+          document.addEventListener('keydown', (e) => {
+            switch (e.key) {
+              case '1':
+                osc(10, 0.1, 1).out(o0)
+                status.textContent = 'Pattern 1: osc'
+                break
+              case '2':
+                osc(20, 0.05, 1.5).rotate(0.1).modulate(noise(3), 0.2).out(o0)
+                status.textContent = 'Pattern 2: osc + noise modulation'
+                break
+              case '3':
+                noise(10).colorama(0.5).out(o0)
+                status.textContent = 'Pattern 3: noise colorama'
+                break
+              case '4':
+                gradient(0.5).rotate(() => time * 0.1).out(o0)
+                status.textContent = 'Pattern 4: rotating gradient'
+                break
+            }
+          })
+
+          console.log('Hydra WebGL initialized successfully')
+          status.textContent += ' - Press 1-4 for patterns'
+
+        } catch (e) {
+          console.error('Error:', e)
+          status.textContent = 'Error: ' + e.message
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/dev/test-webgpu.html
+++ b/dev/test-webgpu.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hydra WebGPU Renderer Test</title>
+    <style>
+      body { margin: 0; background: black; }
+      canvas { width: 100vw; height: 100vh; }
+      #status { position: fixed; top: 10px; left: 10px; color: white; font-family: monospace; z-index: 100; }
+      #controls { position: fixed; bottom: 10px; left: 10px; color: white; font-family: monospace; z-index: 100; }
+    </style>
+  </head>
+  <body>
+    <div id="status">Loading...</div>
+    <div id="controls">
+      Press 1-4 to switch patterns
+    </div>
+    <script type="module">
+      // Use the vertex extension's createHydra which has full WGSL support
+      import { createHydra } from '../extensions/vertex/index-webgpu.js'
+
+      window.onload = async () => {
+        const status = document.getElementById('status')
+
+        try {
+          // Check WebGPU support
+          if (!navigator.gpu) {
+            status.textContent = 'WebGPU not supported in this browser'
+            return
+          }
+
+          status.textContent = 'Creating Hydra with WebGPU...'
+
+          // Create hydra instance with WebGPU mode via vertex extension
+          const hydra = await createHydra({
+            detectAudio: false,
+            makeGlobal: true,
+            useWGSL: true
+          })
+
+          // Log renderer info
+          console.log('Hydra:', hydra)
+          console.log('wgslHydra:', hydra.wgslHydra)
+          status.textContent = `Renderer: WebGPU (WGSL)`
+
+          // Basic test - osc pattern
+          osc(10, 0.1, 1).out(o0)
+
+          // Keyboard controls for testing patterns
+          document.addEventListener('keydown', (e) => {
+            switch (e.key) {
+              case '1':
+                osc(10, 0.1, 1).out(o0)
+                status.textContent = 'Pattern 1: osc'
+                break
+              case '2':
+                osc(20, 0.05, 1.5).rotate(0.1).modulate(noise(3), 0.2).out(o0)
+                status.textContent = 'Pattern 2: osc + noise modulation'
+                break
+              case '3':
+                noise(10).colorama(0.5).out(o0)
+                status.textContent = 'Pattern 3: noise colorama'
+                break
+              case '4':
+                gradient(0.5).rotate(() => time * 0.1).out(o0)
+                status.textContent = 'Pattern 4: rotating gradient'
+                break
+            }
+          })
+
+          console.log('Hydra WebGPU initialized successfully')
+          status.textContent += ' - Press 1-4 for patterns'
+
+        } catch (e) {
+          console.error('Error:', e)
+          status.textContent = 'Error: ' + e.message
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/dist/hydra-synth.js
+++ b/dist/hydra-synth.js
@@ -527,7 +527,7 @@ if (typeof Object.create === 'function') {
 }
 
 },{}],3:[function(require,module,exports){
-!function(r,t){"object"==typeof exports&&"undefined"!=typeof module?module.exports=t():"function"==typeof define&&define.amd?define(t):(r="undefined"!=typeof globalThis?globalThis:r||self).Meyda=t()}(this,(function(){"use strict";function r(r,t,e){if(e||2===arguments.length)for(var a,n=0,o=t.length;n<o;n++)!a&&n in t||(a||(a=Array.prototype.slice.call(t,0,n)),a[n]=t[n]);return r.concat(a||Array.prototype.slice.call(t))}var t=Object.freeze({__proto__:null,blackman:function(r){for(var t=new Float32Array(r),e=2*Math.PI/(r-1),a=2*e,n=0;n<r/2;n++)t[n]=.42-.5*Math.cos(n*e)+.08*Math.cos(n*a);for(n=Math.ceil(r/2);n>0;n--)t[r-n]=t[n-1];return t},sine:function(r){for(var t=Math.PI/(r-1),e=new Float32Array(r),a=0;a<r;a++)e[a]=Math.sin(t*a);return e},hanning:function(r){for(var t=new Float32Array(r),e=0;e<r;e++)t[e]=.5-.5*Math.cos(2*Math.PI*e/(r-1));return t},hamming:function(r){for(var t=new Float32Array(r),e=0;e<r;e++)t[e]=.54-.46*Math.cos(2*Math.PI*(e/r-1));return t}}),e={};function a(r){for(;r%2==0&&r>1;)r/=2;return 1===r}function n(r,a){if("rect"!==a){if(""!==a&&a||(a="hanning"),e[a]||(e[a]={}),!e[a][r.length])try{e[a][r.length]=t[a](r.length)}catch(r){throw new Error("Invalid windowing function")}r=function(r,t){for(var e=[],a=0;a<Math.min(r.length,t.length);a++)e[a]=r[a]*t[a];return e}(r,e[a][r.length])}return r}function o(r,t,e){for(var a=new Float32Array(r),n=0;n<a.length;n++)a[n]=n*t/e,a[n]=13*Math.atan(a[n]/1315.8)+3.5*Math.atan(Math.pow(a[n]/7518,2));return a}function i(r){return Float32Array.from(r)}function u(r){return 1125*Math.log(1+r/700)}function f(r,t,e){for(var a,n=new Float32Array(r+2),o=new Float32Array(r+2),i=t/2,f=u(0),c=(u(i)-f)/(r+1),l=new Array(r+2),s=0;s<n.length;s++)n[s]=s*c,o[s]=(a=n[s],700*(Math.exp(a/1125)-1)),l[s]=Math.floor((e+1)*o[s]/t);for(var m=new Array(r),p=0;p<m.length;p++){m[p]=new Array(e/2+1).fill(0);for(s=l[p];s<l[p+1];s++)m[p][s]=(s-l[p])/(l[p+1]-l[p]);for(s=l[p+1];s<l[p+2];s++)m[p][s]=(l[p+2]-s)/(l[p+2]-l[p+1])}return m}function c(t,e,a,n,o,i,u){void 0===n&&(n=5),void 0===o&&(o=2),void 0===i&&(i=!0),void 0===u&&(u=440);var f=Math.floor(a/2)+1,c=new Array(a).fill(0).map((function(r,n){return t*function(r,t){return Math.log2(16*r/t)}(e*n/a,u)}));c[0]=c[1]-1.5*t;var l,s,m,p=c.slice(1).map((function(r,t){return Math.max(r-c[t])}),1).concat([1]),h=Math.round(t/2),g=new Array(t).fill(0).map((function(r,e){return c.map((function(r){return(10*t+h+r-e)%t-h}))})),w=g.map((function(r,t){return r.map((function(r,e){return Math.exp(-.5*Math.pow(2*g[t][e]/p[e],2))}))}));if(s=(l=w)[0].map((function(){return 0})),m=l.reduce((function(r,t){return t.forEach((function(t,e){r[e]+=Math.pow(t,2)})),r}),s).map(Math.sqrt),w=l.map((function(r,t){return r.map((function(r,t){return r/(m[t]||1)}))})),o){var v=c.map((function(r){return Math.exp(-.5*Math.pow((r/t-n)/o,2))}));w=w.map((function(r){return r.map((function(r,t){return r*v[t]}))}))}return i&&(w=r(r([],w.slice(3),!0),w.slice(0,3),!0)),w.map((function(r){return r.slice(0,f)}))}function l(r,t){for(var e=0,a=0,n=0;n<t.length;n++)e+=Math.pow(n,r)*Math.abs(t[n]),a+=t[n];return e/a}function s(r){var t=r.ampSpectrum,e=r.barkScale,a=r.numberOfBarkBands,n=void 0===a?24:a;if("object"!=typeof t||"object"!=typeof e)throw new TypeError;var o=n,i=new Float32Array(o),u=0,f=t,c=new Int32Array(o+1);c[0]=0;for(var l=e[f.length-1]/o,s=1,m=0;m<f.length;m++)for(;e[m]>l;)c[s++]=m,l=s*e[f.length-1]/o;c[o]=f.length-1;for(m=0;m<o;m++){for(var p=0,h=c[m];h<c[m+1];h++)p+=f[h];i[m]=Math.pow(p,.23)}for(m=0;m<i.length;m++)u+=i[m];return{specific:i,total:u}}function m(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;for(var e=new Float32Array(t.length),a=0;a<e.length;a++)e[a]=Math.pow(t[a],2);return e}function p(r){var t=r.ampSpectrum,e=r.melFilterBank,a=r.bufferSize;if("object"!=typeof t)throw new TypeError("Valid ampSpectrum is required to generate melBands");if("object"!=typeof e)throw new TypeError("Valid melFilterBank is required to generate melBands");for(var n=m({ampSpectrum:t}),o=e.length,i=Array(o),u=new Float32Array(o),f=0;f<u.length;f++){i[f]=new Float32Array(a/2),u[f]=0;for(var c=0;c<a/2;c++)i[f][c]=e[f][c]*n[c],u[f]+=i[f][c];u[f]=Math.log(u[f]+1)}return Array.prototype.slice.call(u)}function h(r){return r&&r.__esModule&&Object.prototype.hasOwnProperty.call(r,"default")?r.default:r}var g={exports:{}},w=null;var v=function(r,t){var e=r.length;return t=t||2,w&&w[e]||function(r){(w=w||{})[r]=new Array(r*r);for(var t=Math.PI/r,e=0;e<r;e++)for(var a=0;a<r;a++)w[r][a+e*r]=Math.cos(t*(a+.5)*e)}(e),r.map((function(){return 0})).map((function(a,n){return t*r.reduce((function(r,t,a,o){return r+t*w[e][a+n*e]}),0)}))};!function(r){r.exports=v}(g);var d=h(g.exports);var y=Object.freeze({__proto__:null,buffer:function(r){return r.signal},rms:function(r){var t=r.signal;if("object"!=typeof t)throw new TypeError;for(var e=0,a=0;a<t.length;a++)e+=Math.pow(t[a],2);return e/=t.length,e=Math.sqrt(e)},energy:function(r){var t=r.signal;if("object"!=typeof t)throw new TypeError;for(var e=0,a=0;a<t.length;a++)e+=Math.pow(Math.abs(t[a]),2);return e},complexSpectrum:function(r){return r.complexSpectrum},spectralSlope:function(r){var t=r.ampSpectrum,e=r.sampleRate,a=r.bufferSize;if("object"!=typeof t)throw new TypeError;for(var n=0,o=0,i=new Float32Array(t.length),u=0,f=0,c=0;c<t.length;c++){n+=t[c];var l=c*e/a;i[c]=l,u+=l*l,o+=l,f+=l*t[c]}return(t.length*f-o*n)/(n*(u-Math.pow(o,2)))},spectralCentroid:function(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;return l(1,t)},spectralRolloff:function(r){var t=r.ampSpectrum,e=r.sampleRate;if("object"!=typeof t)throw new TypeError;for(var a=t,n=e/(2*(a.length-1)),o=0,i=0;i<a.length;i++)o+=a[i];for(var u=.99*o,f=a.length-1;o>u&&f>=0;)o-=a[f],--f;return(f+1)*n},spectralFlatness:function(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;for(var e=0,a=0,n=0;n<t.length;n++)e+=Math.log(t[n]),a+=t[n];return Math.exp(e/t.length)*t.length/a},spectralSpread:function(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;return Math.sqrt(l(2,t)-Math.pow(l(1,t),2))},spectralSkewness:function(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;var e=l(1,t),a=l(2,t),n=l(3,t);return(2*Math.pow(e,3)-3*e*a+n)/Math.pow(Math.sqrt(a-Math.pow(e,2)),3)},spectralKurtosis:function(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;var e=t,a=l(1,e),n=l(2,e),o=l(3,e),i=l(4,e);return(-3*Math.pow(a,4)+6*a*n-4*a*o+i)/Math.pow(Math.sqrt(n-Math.pow(a,2)),4)},amplitudeSpectrum:function(r){return r.ampSpectrum},zcr:function(r){var t=r.signal;if("object"!=typeof t)throw new TypeError;for(var e=0,a=1;a<t.length;a++)(t[a-1]>=0&&t[a]<0||t[a-1]<0&&t[a]>=0)&&e++;return e},loudness:s,perceptualSpread:function(r){for(var t=s({ampSpectrum:r.ampSpectrum,barkScale:r.barkScale}),e=0,a=0;a<t.specific.length;a++)t.specific[a]>e&&(e=t.specific[a]);return Math.pow((t.total-e)/t.total,2)},perceptualSharpness:function(r){for(var t=s({ampSpectrum:r.ampSpectrum,barkScale:r.barkScale}),e=t.specific,a=0,n=0;n<e.length;n++)a+=n<15?(n+1)*e[n+1]:.066*Math.exp(.171*(n+1));return a*=.11/t.total},powerSpectrum:m,mfcc:function(r){var t=r.ampSpectrum,e=r.melFilterBank,a=r.numberOfMFCCCoefficients,n=r.bufferSize,o=Math.min(40,Math.max(1,a||13));if(e.length<o)throw new Error("Insufficient filter bank for requested number of coefficients");var i=p({ampSpectrum:t,melFilterBank:e,bufferSize:n});return d(i).slice(0,o)},chroma:function(r){var t=r.ampSpectrum,e=r.chromaFilterBank;if("object"!=typeof t)throw new TypeError("Valid ampSpectrum is required to generate chroma");if("object"!=typeof e)throw new TypeError("Valid chromaFilterBank is required to generate chroma");var a=e.map((function(r,e){return t.reduce((function(t,e,a){return t+e*r[a]}),0)})),n=Math.max.apply(Math,a);return n?a.map((function(r){return r/n})):a},spectralFlux:function(r){var t=r.signal,e=r.previousSignal,a=r.bufferSize;if("object"!=typeof t||"object"!=typeof e)throw new TypeError;for(var n=0,o=-a/2;o<t.length/2-1;o++)x=Math.abs(t[o])-Math.abs(e[o]),n+=(x+Math.abs(x))/2;return n},spectralCrest:function(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;var e=0,a=-1/0;return t.forEach((function(r){e+=Math.pow(r,2),a=r>a?r:a})),e/=t.length,e=Math.sqrt(e),a/e},melBands:p});function S(r){if(Array.isArray(r)){for(var t=0,e=Array(r.length);t<r.length;t++)e[t]=r[t];return e}return Array.from(r)}var _={},b={},M={bitReverseArray:function(r){if(void 0===_[r]){for(var t=(r-1).toString(2).length,e="0".repeat(t),a={},n=0;n<r;n++){var o=n.toString(2);o=e.substr(o.length)+o,o=[].concat(S(o)).reverse().join(""),a[n]=parseInt(o,2)}_[r]=a}return _[r]},multiply:function(r,t){return{real:r.real*t.real-r.imag*t.imag,imag:r.real*t.imag+r.imag*t.real}},add:function(r,t){return{real:r.real+t.real,imag:r.imag+t.imag}},subtract:function(r,t){return{real:r.real-t.real,imag:r.imag-t.imag}},euler:function(r,t){var e=-2*Math.PI*r/t;return{real:Math.cos(e),imag:Math.sin(e)}},conj:function(r){return r.imag*=-1,r},constructComplexArray:function(r){var t={};t.real=void 0===r.real?r.slice():r.real.slice();var e=t.real.length;return void 0===b[e]&&(b[e]=Array.apply(null,Array(e)).map(Number.prototype.valueOf,0)),t.imag=b[e].slice(),t}},F=function(r){var t={};void 0===r.real||void 0===r.imag?t=M.constructComplexArray(r):(t.real=r.real.slice(),t.imag=r.imag.slice());var e=t.real.length,a=Math.log2(e);if(Math.round(a)!=a)throw new Error("Input size must be a power of 2.");if(t.real.length!=t.imag.length)throw new Error("Real and imaginary components must have the same length.");for(var n=M.bitReverseArray(e),o={real:[],imag:[]},i=0;i<e;i++)o.real[n[i]]=t.real[i],o.imag[n[i]]=t.imag[i];for(var u=0;u<e;u++)t.real[u]=o.real[u],t.imag[u]=o.imag[u];for(var f=1;f<=a;f++)for(var c=Math.pow(2,f),l=0;l<c/2;l++)for(var s=M.euler(l,c),m=0;m<e/c;m++){var p=c*m+l,h=c*m+l+c/2,g={real:t.real[p],imag:t.imag[p]},w={real:t.real[h],imag:t.imag[h]},v=M.multiply(s,w),d=M.subtract(g,v);t.real[h]=d.real,t.imag[h]=d.imag;var y=M.add(v,g);t.real[p]=y.real,t.imag[p]=y.imag}return t},A=F,E=function(){function r(r,t){var e=this;if(this._m=t,!r.audioContext)throw this._m.errors.noAC;if(r.bufferSize&&!a(r.bufferSize))throw this._m._errors.notPow2;if(!r.source)throw this._m._errors.noSource;this._m.audioContext=r.audioContext,this._m.bufferSize=r.bufferSize||this._m.bufferSize||256,this._m.hopSize=r.hopSize||this._m.hopSize||this._m.bufferSize,this._m.sampleRate=r.sampleRate||this._m.audioContext.sampleRate||44100,this._m.callback=r.callback,this._m.windowingFunction=r.windowingFunction||"hanning",this._m.featureExtractors=y,this._m.EXTRACTION_STARTED=r.startImmediately||!1,this._m.channel="number"==typeof r.channel?r.channel:0,this._m.inputs=r.inputs||1,this._m.outputs=r.outputs||1,this._m.numberOfMFCCCoefficients=r.numberOfMFCCCoefficients||this._m.numberOfMFCCCoefficients||13,this._m.numberOfBarkBands=r.numberOfBarkBands||this._m.numberOfBarkBands||24,this._m.spn=this._m.audioContext.createScriptProcessor(this._m.bufferSize,this._m.inputs,this._m.outputs),this._m.spn.connect(this._m.audioContext.destination),this._m._featuresToExtract=r.featureExtractors||[],this._m.barkScale=o(this._m.bufferSize,this._m.sampleRate,this._m.bufferSize),this._m.melFilterBank=f(Math.max(this._m.melBands,this._m.numberOfMFCCCoefficients),this._m.sampleRate,this._m.bufferSize),this._m.inputData=null,this._m.previousInputData=null,this._m.frame=null,this._m.previousFrame=null,this.setSource(r.source),this._m.spn.onaudioprocess=function(r){var t;null!==e._m.inputData&&(e._m.previousInputData=e._m.inputData),e._m.inputData=r.inputBuffer.getChannelData(e._m.channel),e._m.previousInputData?((t=new Float32Array(e._m.previousInputData.length+e._m.inputData.length-e._m.hopSize)).set(e._m.previousInputData.slice(e._m.hopSize)),t.set(e._m.inputData,e._m.previousInputData.length-e._m.hopSize)):t=e._m.inputData,function(r,t,e){if(r.length<t)throw new Error("Buffer is too short for frame length");if(e<1)throw new Error("Hop length cannot be less that 1");if(t<1)throw new Error("Frame length cannot be less that 1");var a=1+Math.floor((r.length-t)/e);return new Array(a).fill(0).map((function(a,n){return r.slice(n*e,n*e+t)}))}(t,e._m.bufferSize,e._m.hopSize).forEach((function(r){e._m.frame=r;var t=e._m.extract(e._m._featuresToExtract,e._m.frame,e._m.previousFrame);"function"==typeof e._m.callback&&e._m.EXTRACTION_STARTED&&e._m.callback(t),e._m.previousFrame=e._m.frame}))}}return r.prototype.start=function(r){this._m._featuresToExtract=r||this._m._featuresToExtract,this._m.EXTRACTION_STARTED=!0},r.prototype.stop=function(){this._m.EXTRACTION_STARTED=!1},r.prototype.setSource=function(r){this._m.source&&this._m.source.disconnect(this._m.spn),this._m.source=r,this._m.source.connect(this._m.spn)},r.prototype.setChannel=function(r){r<=this._m.inputs?this._m.channel=r:console.error("Channel ".concat(r," does not exist. Make sure you've provided a value for 'inputs' that is greater than ").concat(r," when instantiating the MeydaAnalyzer"))},r.prototype.get=function(r){return this._m.inputData?this._m.extract(r||this._m._featuresToExtract,this._m.inputData,this._m.previousInputData):null},r}(),C={audioContext:null,spn:null,bufferSize:512,sampleRate:44100,melBands:26,chromaBands:12,callback:null,windowingFunction:"hanning",featureExtractors:y,EXTRACTION_STARTED:!1,numberOfMFCCCoefficients:13,numberOfBarkBands:24,_featuresToExtract:[],windowing:n,_errors:{notPow2:new Error("Meyda: Buffer size must be a power of 2, e.g. 64 or 512"),featureUndef:new Error("Meyda: No features defined."),invalidFeatureFmt:new Error("Meyda: Invalid feature format"),invalidInput:new Error("Meyda: Invalid input."),noAC:new Error("Meyda: No AudioContext specified."),noSource:new Error("Meyda: No source node specified.")},createMeydaAnalyzer:function(r){return new E(r,Object.assign({},C))},listAvailableFeatureExtractors:function(){return Object.keys(this.featureExtractors)},extract:function(r,t,e){var n=this;if(!t)throw this._errors.invalidInput;if("object"!=typeof t)throw this._errors.invalidInput;if(!r)throw this._errors.featureUndef;if(!a(t.length))throw this._errors.notPow2;void 0!==this.barkScale&&this.barkScale.length==this.bufferSize||(this.barkScale=o(this.bufferSize,this.sampleRate,this.bufferSize)),void 0!==this.melFilterBank&&this.barkScale.length==this.bufferSize&&this.melFilterBank.length==this.melBands||(this.melFilterBank=f(Math.max(this.melBands,this.numberOfMFCCCoefficients),this.sampleRate,this.bufferSize)),void 0!==this.chromaFilterBank&&this.chromaFilterBank.length==this.chromaBands||(this.chromaFilterBank=c(this.chromaBands,this.sampleRate,this.bufferSize)),"buffer"in t&&void 0===t.buffer?this.signal=i(t):this.signal=t;var u=k(t,this.windowingFunction,this.bufferSize);if(this.signal=u.windowedSignal,this.complexSpectrum=u.complexSpectrum,this.ampSpectrum=u.ampSpectrum,e){var l=k(e,this.windowingFunction,this.bufferSize);this.previousSignal=l.windowedSignal,this.previousComplexSpectrum=l.complexSpectrum,this.previousAmpSpectrum=l.ampSpectrum}var s=function(r){return n.featureExtractors[r]({ampSpectrum:n.ampSpectrum,chromaFilterBank:n.chromaFilterBank,complexSpectrum:n.complexSpectrum,signal:n.signal,bufferSize:n.bufferSize,sampleRate:n.sampleRate,barkScale:n.barkScale,melFilterBank:n.melFilterBank,previousSignal:n.previousSignal,previousAmpSpectrum:n.previousAmpSpectrum,previousComplexSpectrum:n.previousComplexSpectrum,numberOfMFCCCoefficients:n.numberOfMFCCCoefficients,numberOfBarkBands:n.numberOfBarkBands})};if("object"==typeof r)return r.reduce((function(r,t){var e;return Object.assign({},r,((e={})[t]=s(t),e))}),{});if("string"==typeof r)return s(r);throw this._errors.invalidFeatureFmt}},k=function(r,t,e){var a={};void 0===r.buffer?a.signal=i(r):a.signal=r,a.windowedSignal=n(a.signal,t),a.complexSpectrum=A(a.windowedSignal),a.ampSpectrum=new Float32Array(e/2);for(var o=0;o<e/2;o++)a.ampSpectrum[o]=Math.sqrt(Math.pow(a.complexSpectrum.real[o],2)+Math.pow(a.complexSpectrum.imag[o],2));return a};return"undefined"!=typeof window&&(window.Meyda=C),C}));
+!function(r,t){"object"==typeof exports&&"undefined"!=typeof module?module.exports=t():"function"==typeof define&&define.amd?define(t):(r="undefined"!=typeof globalThis?globalThis:r||self).Meyda=t()}(this,(function(){"use strict";function r(r,t,e){if(e||2===arguments.length)for(var a,n=0,o=t.length;n<o;n++)!a&&n in t||(a||(a=Array.prototype.slice.call(t,0,n)),a[n]=t[n]);return r.concat(a||Array.prototype.slice.call(t))}var t=Object.freeze({__proto__:null,blackman:function(r){for(var t=new Float32Array(r),e=2*Math.PI/(r-1),a=2*e,n=0;n<r/2;n++)t[n]=.42-.5*Math.cos(n*e)+.08*Math.cos(n*a);for(n=Math.ceil(r/2);n>0;n--)t[r-n]=t[n-1];return t},hamming:function(r){for(var t=new Float32Array(r),e=0;e<r;e++)t[e]=.54-.46*Math.cos(2*Math.PI*(e/r-1));return t},hanning:function(r){for(var t=new Float32Array(r),e=0;e<r;e++)t[e]=.5-.5*Math.cos(2*Math.PI*e/(r-1));return t},sine:function(r){for(var t=Math.PI/(r-1),e=new Float32Array(r),a=0;a<r;a++)e[a]=Math.sin(t*a);return e}}),e={};function a(r){for(;r%2==0&&r>1;)r/=2;return 1===r}function n(r,a){if("rect"!==a){if(""!==a&&a||(a="hanning"),e[a]||(e[a]={}),!e[a][r.length])try{e[a][r.length]=t[a](r.length)}catch(r){throw new Error("Invalid windowing function")}r=function(r,t){for(var e=[],a=0;a<Math.min(r.length,t.length);a++)e[a]=r[a]*t[a];return e}(r,e[a][r.length])}return r}function o(r,t,e){for(var a=new Float32Array(r),n=0;n<a.length;n++)a[n]=n*t/e,a[n]=13*Math.atan(a[n]/1315.8)+3.5*Math.atan(Math.pow(a[n]/7518,2));return a}function i(r){return Float32Array.from(r)}function u(r){return 1125*Math.log(1+r/700)}function f(r,t,e){for(var a,n=new Float32Array(r+2),o=new Float32Array(r+2),i=t/2,f=u(0),c=(u(i)-f)/(r+1),l=new Array(r+2),s=0;s<n.length;s++)n[s]=s*c,o[s]=(a=n[s],700*(Math.exp(a/1125)-1)),l[s]=Math.floor((e+1)*o[s]/t);for(var m=new Array(r),p=0;p<m.length;p++){m[p]=new Array(e/2+1).fill(0);for(s=l[p];s<l[p+1];s++)m[p][s]=(s-l[p])/(l[p+1]-l[p]);for(s=l[p+1];s<l[p+2];s++)m[p][s]=(l[p+2]-s)/(l[p+2]-l[p+1])}return m}function c(t,e,a,n,o,i,u){void 0===n&&(n=5),void 0===o&&(o=2),void 0===i&&(i=!0),void 0===u&&(u=440);var f=Math.floor(a/2)+1,c=new Array(a).fill(0).map((function(r,n){return t*function(r,t){return Math.log2(16*r/t)}(e*n/a,u)}));c[0]=c[1]-1.5*t;var l,s,m,p=c.slice(1).map((function(r,t){return Math.max(r-c[t])}),1).concat([1]),h=Math.round(t/2),g=new Array(t).fill(0).map((function(r,e){return c.map((function(r){return(10*t+h+r-e)%t-h}))})),w=g.map((function(r,t){return r.map((function(r,e){return Math.exp(-.5*Math.pow(2*g[t][e]/p[e],2))}))}));if(s=(l=w)[0].map((function(){return 0})),m=l.reduce((function(r,t){return t.forEach((function(t,e){r[e]+=Math.pow(t,2)})),r}),s).map(Math.sqrt),w=l.map((function(r,t){return r.map((function(r,t){return r/(m[t]||1)}))})),o){var v=c.map((function(r){return Math.exp(-.5*Math.pow((r/t-n)/o,2))}));w=w.map((function(r){return r.map((function(r,t){return r*v[t]}))}))}return i&&(w=r(r([],w.slice(3),!0),w.slice(0,3),!0)),w.map((function(r){return r.slice(0,f)}))}function l(r,t){for(var e=0,a=0,n=0;n<t.length;n++)e+=Math.pow(n,r)*Math.abs(t[n]),a+=t[n];return e/a}function s(r){var t=r.ampSpectrum,e=r.barkScale,a=r.numberOfBarkBands,n=void 0===a?24:a;if("object"!=typeof t||"object"!=typeof e)throw new TypeError;var o=n,i=new Float32Array(o),u=0,f=t,c=new Int32Array(o+1);c[0]=0;for(var l=e[f.length-1]/o,s=1,m=0;m<f.length;m++)for(;e[m]>l;)c[s++]=m,l=s*e[f.length-1]/o;c[o]=f.length-1;for(m=0;m<o;m++){for(var p=0,h=c[m];h<c[m+1];h++)p+=f[h];i[m]=Math.pow(p,.23)}for(m=0;m<i.length;m++)u+=i[m];return{specific:i,total:u}}function m(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;for(var e=new Float32Array(t.length),a=0;a<e.length;a++)e[a]=Math.pow(t[a],2);return e}function p(r){var t=r.ampSpectrum,e=r.melFilterBank,a=r.bufferSize;if("object"!=typeof t)throw new TypeError("Valid ampSpectrum is required to generate melBands");if("object"!=typeof e)throw new TypeError("Valid melFilterBank is required to generate melBands");for(var n=m({ampSpectrum:t}),o=e.length,i=Array(o),u=new Float32Array(o),f=0;f<u.length;f++){i[f]=new Float32Array(a/2),u[f]=0;for(var c=0;c<a/2;c++)i[f][c]=e[f][c]*n[c],u[f]+=i[f][c];u[f]=Math.log(u[f]+1)}return Array.prototype.slice.call(u)}function h(r){return r&&r.__esModule&&Object.prototype.hasOwnProperty.call(r,"default")?r.default:r}var g=null;var w=h((function(r,t){var e=r.length;return t=t||2,g&&g[e]||function(r){(g=g||{})[r]=new Array(r*r);for(var t=Math.PI/r,e=0;e<r;e++)for(var a=0;a<r;a++)g[r][a+e*r]=Math.cos(t*(a+.5)*e)}(e),r.map((function(){return 0})).map((function(a,n){return t*r.reduce((function(r,t,a,o){return r+t*g[e][a+n*e]}),0)}))}));var v=Object.freeze({__proto__:null,amplitudeSpectrum:function(r){return r.ampSpectrum},buffer:function(r){return r.signal},chroma:function(r){var t=r.ampSpectrum,e=r.chromaFilterBank;if("object"!=typeof t)throw new TypeError("Valid ampSpectrum is required to generate chroma");if("object"!=typeof e)throw new TypeError("Valid chromaFilterBank is required to generate chroma");var a=e.map((function(r,e){return t.reduce((function(t,e,a){return t+e*r[a]}),0)})),n=Math.max.apply(Math,a);return n?a.map((function(r){return r/n})):a},complexSpectrum:function(r){return r.complexSpectrum},energy:function(r){var t=r.signal;if("object"!=typeof t)throw new TypeError;for(var e=0,a=0;a<t.length;a++)e+=Math.pow(Math.abs(t[a]),2);return e},loudness:s,melBands:p,mfcc:function(r){var t=r.ampSpectrum,e=r.melFilterBank,a=r.numberOfMFCCCoefficients,n=r.bufferSize,o=Math.min(40,Math.max(1,a||13));if(e.length<o)throw new Error("Insufficient filter bank for requested number of coefficients");var i=p({ampSpectrum:t,melFilterBank:e,bufferSize:n});return w(i).slice(0,o)},perceptualSharpness:function(r){for(var t=s({ampSpectrum:r.ampSpectrum,barkScale:r.barkScale}),e=t.specific,a=0,n=0;n<e.length;n++)a+=n<15?(n+1)*e[n+1]:.066*Math.exp(.171*(n+1));return a*=.11/t.total},perceptualSpread:function(r){for(var t=s({ampSpectrum:r.ampSpectrum,barkScale:r.barkScale}),e=0,a=0;a<t.specific.length;a++)t.specific[a]>e&&(e=t.specific[a]);return Math.pow((t.total-e)/t.total,2)},powerSpectrum:m,rms:function(r){var t=r.signal;if("object"!=typeof t)throw new TypeError;for(var e=0,a=0;a<t.length;a++)e+=Math.pow(t[a],2);return e/=t.length,e=Math.sqrt(e)},spectralCentroid:function(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;return l(1,t)},spectralCrest:function(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;var e=0,a=-1/0;return t.forEach((function(r){e+=Math.pow(r,2),a=r>a?r:a})),e/=t.length,e=Math.sqrt(e),a/e},spectralFlatness:function(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;for(var e=0,a=0,n=0;n<t.length;n++)e+=Math.log(t[n]),a+=t[n];return Math.exp(e/t.length)*t.length/a},spectralFlux:function(r){var t=r.signal,e=r.previousSignal,a=r.bufferSize;if("object"!=typeof t||"object"!=typeof e)throw new TypeError;for(var n=0,o=-a/2;o<t.length/2-1;o++)x=Math.abs(t[o])-Math.abs(e[o]),n+=(x+Math.abs(x))/2;return n},spectralKurtosis:function(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;var e=t,a=l(1,e),n=l(2,e),o=l(3,e),i=l(4,e);return(-3*Math.pow(a,4)+6*a*n-4*a*o+i)/Math.pow(Math.sqrt(n-Math.pow(a,2)),4)},spectralRolloff:function(r){var t=r.ampSpectrum,e=r.sampleRate;if("object"!=typeof t)throw new TypeError;for(var a=t,n=e/(2*(a.length-1)),o=0,i=0;i<a.length;i++)o+=a[i];for(var u=.99*o,f=a.length-1;o>u&&f>=0;)o-=a[f],--f;return(f+1)*n},spectralSkewness:function(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;var e=l(1,t),a=l(2,t),n=l(3,t);return(2*Math.pow(e,3)-3*e*a+n)/Math.pow(Math.sqrt(a-Math.pow(e,2)),3)},spectralSlope:function(r){var t=r.ampSpectrum,e=r.sampleRate,a=r.bufferSize;if("object"!=typeof t)throw new TypeError;for(var n=0,o=0,i=new Float32Array(t.length),u=0,f=0,c=0;c<t.length;c++){n+=t[c];var l=c*e/a;i[c]=l,u+=l*l,o+=l,f+=l*t[c]}return(t.length*f-o*n)/(n*(u-Math.pow(o,2)))},spectralSpread:function(r){var t=r.ampSpectrum;if("object"!=typeof t)throw new TypeError;return Math.sqrt(l(2,t)-Math.pow(l(1,t),2))},zcr:function(r){var t=r.signal;if("object"!=typeof t)throw new TypeError;for(var e=0,a=1;a<t.length;a++)(t[a-1]>=0&&t[a]<0||t[a-1]<0&&t[a]>=0)&&e++;return e}});function d(r){if(Array.isArray(r)){for(var t=0,e=Array(r.length);t<r.length;t++)e[t]=r[t];return e}return Array.from(r)}var y={},S={},_={bitReverseArray:function(r){if(void 0===y[r]){for(var t=(r-1).toString(2).length,e="0".repeat(t),a={},n=0;n<r;n++){var o=n.toString(2);o=e.substr(o.length)+o,o=[].concat(d(o)).reverse().join(""),a[n]=parseInt(o,2)}y[r]=a}return y[r]},multiply:function(r,t){return{real:r.real*t.real-r.imag*t.imag,imag:r.real*t.imag+r.imag*t.real}},add:function(r,t){return{real:r.real+t.real,imag:r.imag+t.imag}},subtract:function(r,t){return{real:r.real-t.real,imag:r.imag-t.imag}},euler:function(r,t){var e=-2*Math.PI*r/t;return{real:Math.cos(e),imag:Math.sin(e)}},conj:function(r){return r.imag*=-1,r},constructComplexArray:function(r){var t={};t.real=void 0===r.real?r.slice():r.real.slice();var e=t.real.length;return void 0===S[e]&&(S[e]=Array.apply(null,Array(e)).map(Number.prototype.valueOf,0)),t.imag=S[e].slice(),t}},b=function(r){var t={};void 0===r.real||void 0===r.imag?t=_.constructComplexArray(r):(t.real=r.real.slice(),t.imag=r.imag.slice());var e=t.real.length,a=Math.log2(e);if(Math.round(a)!=a)throw new Error("Input size must be a power of 2.");if(t.real.length!=t.imag.length)throw new Error("Real and imaginary components must have the same length.");for(var n=_.bitReverseArray(e),o={real:[],imag:[]},i=0;i<e;i++)o.real[n[i]]=t.real[i],o.imag[n[i]]=t.imag[i];for(var u=0;u<e;u++)t.real[u]=o.real[u],t.imag[u]=o.imag[u];for(var f=1;f<=a;f++)for(var c=Math.pow(2,f),l=0;l<c/2;l++)for(var s=_.euler(l,c),m=0;m<e/c;m++){var p=c*m+l,h=c*m+l+c/2,g={real:t.real[p],imag:t.imag[p]},w={real:t.real[h],imag:t.imag[h]},v=_.multiply(s,w),d=_.subtract(g,v);t.real[h]=d.real,t.imag[h]=d.imag;var y=_.add(v,g);t.real[p]=y.real,t.imag[p]=y.imag}return t},M=b,F=function(){function r(r,t){var e=this;if(this._m=t,!r.audioContext)throw this._m.errors.noAC;if(r.bufferSize&&!a(r.bufferSize))throw this._m._errors.notPow2;if(!r.source)throw this._m._errors.noSource;this._m.audioContext=r.audioContext,this._m.bufferSize=r.bufferSize||this._m.bufferSize||256,this._m.hopSize=r.hopSize||this._m.hopSize||this._m.bufferSize,this._m.sampleRate=r.sampleRate||this._m.audioContext.sampleRate||44100,this._m.callback=r.callback,this._m.windowingFunction=r.windowingFunction||"hanning",this._m.featureExtractors=v,this._m.EXTRACTION_STARTED=r.startImmediately||!1,this._m.channel="number"==typeof r.channel?r.channel:0,this._m.inputs=r.inputs||1,this._m.outputs=r.outputs||1,this._m.numberOfMFCCCoefficients=r.numberOfMFCCCoefficients||this._m.numberOfMFCCCoefficients||13,this._m.numberOfBarkBands=r.numberOfBarkBands||this._m.numberOfBarkBands||24,this._m.spn=this._m.audioContext.createScriptProcessor(this._m.bufferSize,this._m.inputs,this._m.outputs),this._m.spn.connect(this._m.audioContext.destination),this._m._featuresToExtract=r.featureExtractors||[],this._m.barkScale=o(this._m.bufferSize,this._m.sampleRate,this._m.bufferSize),this._m.melFilterBank=f(Math.max(this._m.melBands,this._m.numberOfMFCCCoefficients),this._m.sampleRate,this._m.bufferSize),this._m.inputData=null,this._m.previousInputData=null,this._m.frame=null,this._m.previousFrame=null,this.setSource(r.source),this._m.spn.onaudioprocess=function(r){var t;null!==e._m.inputData&&(e._m.previousInputData=e._m.inputData),e._m.inputData=r.inputBuffer.getChannelData(e._m.channel),e._m.previousInputData?((t=new Float32Array(e._m.previousInputData.length+e._m.inputData.length-e._m.hopSize)).set(e._m.previousInputData.slice(e._m.hopSize)),t.set(e._m.inputData,e._m.previousInputData.length-e._m.hopSize)):t=e._m.inputData;var a=function(r,t,e){if(r.length<t)throw new Error("Buffer is too short for frame length");if(e<1)throw new Error("Hop length cannot be less that 1");if(t<1)throw new Error("Frame length cannot be less that 1");var a=1+Math.floor((r.length-t)/e);return new Array(a).fill(0).map((function(a,n){return r.slice(n*e,n*e+t)}))}(t,e._m.bufferSize,e._m.hopSize);a.forEach((function(r){e._m.frame=r;var t=e._m.extract(e._m._featuresToExtract,e._m.frame,e._m.previousFrame);"function"==typeof e._m.callback&&e._m.EXTRACTION_STARTED&&e._m.callback(t),e._m.previousFrame=e._m.frame}))}}return r.prototype.start=function(r){this._m._featuresToExtract=r||this._m._featuresToExtract,this._m.EXTRACTION_STARTED=!0},r.prototype.stop=function(){this._m.EXTRACTION_STARTED=!1},r.prototype.setSource=function(r){this._m.source&&this._m.source.disconnect(this._m.spn),this._m.source=r,this._m.source.connect(this._m.spn)},r.prototype.setChannel=function(r){r<=this._m.inputs?this._m.channel=r:console.error("Channel ".concat(r," does not exist. Make sure you've provided a value for 'inputs' that is greater than ").concat(r," when instantiating the MeydaAnalyzer"))},r.prototype.get=function(r){return this._m.inputData?this._m.extract(r||this._m._featuresToExtract,this._m.inputData,this._m.previousInputData):null},r}(),A={audioContext:null,spn:null,bufferSize:512,sampleRate:44100,melBands:26,chromaBands:12,callback:null,windowingFunction:"hanning",featureExtractors:v,EXTRACTION_STARTED:!1,numberOfMFCCCoefficients:13,numberOfBarkBands:24,_featuresToExtract:[],windowing:n,_errors:{notPow2:new Error("Meyda: Buffer size must be a power of 2, e.g. 64 or 512"),featureUndef:new Error("Meyda: No features defined."),invalidFeatureFmt:new Error("Meyda: Invalid feature format"),invalidInput:new Error("Meyda: Invalid input."),noAC:new Error("Meyda: No AudioContext specified."),noSource:new Error("Meyda: No source node specified.")},createMeydaAnalyzer:function(r){return new F(r,Object.assign({},A))},listAvailableFeatureExtractors:function(){return Object.keys(this.featureExtractors)},extract:function(r,t,e){var n=this;if(!t)throw this._errors.invalidInput;if("object"!=typeof t)throw this._errors.invalidInput;if(!r)throw this._errors.featureUndef;if(!a(t.length))throw this._errors.notPow2;void 0!==this.barkScale&&this.barkScale.length==this.bufferSize||(this.barkScale=o(this.bufferSize,this.sampleRate,this.bufferSize)),void 0!==this.melFilterBank&&this.barkScale.length==this.bufferSize&&this.melFilterBank.length==this.melBands||(this.melFilterBank=f(Math.max(this.melBands,this.numberOfMFCCCoefficients),this.sampleRate,this.bufferSize)),void 0!==this.chromaFilterBank&&this.chromaFilterBank.length==this.chromaBands||(this.chromaFilterBank=c(this.chromaBands,this.sampleRate,this.bufferSize)),"buffer"in t&&void 0===t.buffer?this.signal=i(t):this.signal=t;var u=E(t,this.windowingFunction,this.bufferSize);if(this.signal=u.windowedSignal,this.complexSpectrum=u.complexSpectrum,this.ampSpectrum=u.ampSpectrum,e){var l=E(e,this.windowingFunction,this.bufferSize);this.previousSignal=l.windowedSignal,this.previousComplexSpectrum=l.complexSpectrum,this.previousAmpSpectrum=l.ampSpectrum}var s=function(r){return n.featureExtractors[r]({ampSpectrum:n.ampSpectrum,chromaFilterBank:n.chromaFilterBank,complexSpectrum:n.complexSpectrum,signal:n.signal,bufferSize:n.bufferSize,sampleRate:n.sampleRate,barkScale:n.barkScale,melFilterBank:n.melFilterBank,previousSignal:n.previousSignal,previousAmpSpectrum:n.previousAmpSpectrum,previousComplexSpectrum:n.previousComplexSpectrum,numberOfMFCCCoefficients:n.numberOfMFCCCoefficients,numberOfBarkBands:n.numberOfBarkBands})};if("object"==typeof r)return r.reduce((function(r,t){var e;return Object.assign({},r,((e={})[t]=s(t),e))}),{});if("string"==typeof r)return s(r);throw this._errors.invalidFeatureFmt}},E=function(r,t,e){var a={};void 0===r.buffer?a.signal=i(r):a.signal=r,a.windowedSignal=n(a.signal,t),a.complexSpectrum=M(a.windowedSignal),a.ampSpectrum=new Float32Array(e/2);for(var o=0;o<e/2;o++)a.ampSpectrum[o]=Math.sqrt(Math.pow(a.complexSpectrum.real[o],2)+Math.pow(a.complexSpectrum.imag[o],2));return a};return"undefined"!=typeof window&&(window.Meyda=A),A}));
 
 
 },{}],4:[function(require,module,exports){
@@ -881,156 +881,170 @@ module.exports.polyfill = function(object) {
 
 }).call(this)}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"performance-now":4}],8:[function(require,module,exports){
-(function(aa,ia){"object"===typeof exports&&"undefined"!==typeof module?module.exports=ia():"function"===typeof define&&define.amd?define(ia):aa.createREGL=ia()})(this,function(){function aa(a,b){this.id=Ab++;this.type=a;this.data=b}function ia(a){if(0===a.length)return[];var b=a.charAt(0),c=a.charAt(a.length-1);if(1<a.length&&b===c&&('"'===b||"'"===b))return['"'+a.substr(1,a.length-2).replace(/\\/g,"\\\\").replace(/"/g,'\\"')+'"'];if(b=/\[(false|true|null|\d+|'[^']*'|"[^"]*")\]/.exec(a))return ia(a.substr(0,
-b.index)).concat(ia(b[1])).concat(ia(a.substr(b.index+b[0].length)));b=a.split(".");if(1===b.length)return['"'+a.replace(/\\/g,"\\\\").replace(/"/g,'\\"')+'"'];a=[];for(c=0;c<b.length;++c)a=a.concat(ia(b[c]));return a}function Za(a){return"["+ia(a).join("][")+"]"}function Bb(){var a={"":0},b=[""];return{id:function(c){var e=a[c];if(e)return e;e=a[c]=b.length;b.push(c);return e},str:function(a){return b[a]}}}function Cb(a,b,c){function e(){var b=window.innerWidth,e=window.innerHeight;a!==document.body&&
-(e=a.getBoundingClientRect(),b=e.right-e.left,e=e.bottom-e.top);g.width=c*b;g.height=c*e;E(g.style,{width:b+"px",height:e+"px"})}var g=document.createElement("canvas");E(g.style,{border:0,margin:0,padding:0,top:0,left:0});a.appendChild(g);a===document.body&&(g.style.position="absolute",E(a.style,{margin:0,padding:0}));window.addEventListener("resize",e,!1);e();return{canvas:g,onDestroy:function(){window.removeEventListener("resize",e);a.removeChild(g)}}}function Db(a,b){function c(c){try{return a.getContext(c,
-b)}catch(g){return null}}return c("webgl")||c("experimental-webgl")||c("webgl-experimental")}function $a(a){return"string"===typeof a?a.split():a}function ab(a){return"string"===typeof a?document.querySelector(a):a}function Eb(a){var b=a||{},c,e,g,d;a={};var n=[],f=[],r="undefined"===typeof window?1:window.devicePixelRatio,q=!1,t=function(a){},m=function(){};"string"===typeof b?c=document.querySelector(b):"object"===typeof b&&("string"===typeof b.nodeName&&"function"===typeof b.appendChild&&"function"===
-typeof b.getBoundingClientRect?c=b:"function"===typeof b.drawArrays||"function"===typeof b.drawElements?(d=b,g=d.canvas):("gl"in b?d=b.gl:"canvas"in b?g=ab(b.canvas):"container"in b&&(e=ab(b.container)),"attributes"in b&&(a=b.attributes),"extensions"in b&&(n=$a(b.extensions)),"optionalExtensions"in b&&(f=$a(b.optionalExtensions)),"onDone"in b&&(t=b.onDone),"profile"in b&&(q=!!b.profile),"pixelRatio"in b&&(r=+b.pixelRatio)));c&&("canvas"===c.nodeName.toLowerCase()?g=c:e=c);if(!d){if(!g){c=Cb(e||document.body,
-t,r);if(!c)return null;g=c.canvas;m=c.onDestroy}d=Db(g,a)}return d?{gl:d,canvas:g,container:e,extensions:n,optionalExtensions:f,pixelRatio:r,profile:q,onDone:t,onDestroy:m}:(m(),t("webgl not supported, try upgrading your browser or graphics drivers http://get.webgl.org"),null)}function Fb(a,b){function c(b){b=b.toLowerCase();var c;try{c=e[b]=a.getExtension(b)}catch(g){}return!!c}for(var e={},g=0;g<b.extensions.length;++g){var d=b.extensions[g];if(!c(d))return b.onDestroy(),b.onDone('"'+d+'" extension is not supported by the current WebGL context, try upgrading your system or a different browser'),
-null}b.optionalExtensions.forEach(c);return{extensions:e,restore:function(){Object.keys(e).forEach(function(a){if(e[a]&&!c(a))throw Error("(regl): error restoring extension "+a);})}}}function J(a,b){for(var c=Array(a),e=0;e<a;++e)c[e]=b(e);return c}function bb(a){var b,c;b=(65535<a)<<4;a>>>=b;c=(255<a)<<3;a>>>=c;b|=c;c=(15<a)<<2;a>>>=c;b|=c;c=(3<a)<<1;return b|c|a>>>c>>1}function cb(){function a(a){a:{for(var b=16;268435456>=b;b*=16)if(a<=b){a=b;break a}a=0}b=c[bb(a)>>2];return 0<b.length?b.pop():
-new ArrayBuffer(a)}function b(a){c[bb(a.byteLength)>>2].push(a)}var c=J(8,function(){return[]});return{alloc:a,free:b,allocType:function(b,c){var d=null;switch(b){case 5120:d=new Int8Array(a(c),0,c);break;case 5121:d=new Uint8Array(a(c),0,c);break;case 5122:d=new Int16Array(a(2*c),0,c);break;case 5123:d=new Uint16Array(a(2*c),0,c);break;case 5124:d=new Int32Array(a(4*c),0,c);break;case 5125:d=new Uint32Array(a(4*c),0,c);break;case 5126:d=new Float32Array(a(4*c),0,c);break;default:return null}return d.length!==
-c?d.subarray(0,c):d},freeType:function(a){b(a.buffer)}}}function ma(a){return!!a&&"object"===typeof a&&Array.isArray(a.shape)&&Array.isArray(a.stride)&&"number"===typeof a.offset&&a.shape.length===a.stride.length&&(Array.isArray(a.data)||M(a.data))}function db(a,b,c,e,g,d){for(var n=0;n<b;++n)for(var f=a[n],r=0;r<c;++r)for(var q=f[r],t=0;t<e;++t)g[d++]=q[t]}function eb(a,b,c,e,g){for(var d=1,n=c+1;n<b.length;++n)d*=b[n];var f=b[c];if(4===b.length-c){var r=b[c+1],q=b[c+2];b=b[c+3];for(n=0;n<f;++n)db(a[n],
-r,q,b,e,g),g+=d}else for(n=0;n<f;++n)eb(a[n],b,c+1,e,g),g+=d}function Ha(a){return Ia[Object.prototype.toString.call(a)]|0}function fb(a,b){for(var c=0;c<b.length;++c)a[c]=b[c]}function gb(a,b,c,e,g,d,n){for(var f=0,r=0;r<c;++r)for(var q=0;q<e;++q)a[f++]=b[g*r+d*q+n]}function Gb(a,b,c,e){function g(b){this.id=r++;this.buffer=a.createBuffer();this.type=b;this.usage=35044;this.byteLength=0;this.dimension=1;this.dtype=5121;this.persistentData=null;c.profile&&(this.stats={size:0})}function d(b,c,k){b.byteLength=
-c.byteLength;a.bufferData(b.type,c,k)}function n(a,b,c,h,l,e){a.usage=c;if(Array.isArray(b)){if(a.dtype=h||5126,0<b.length)if(Array.isArray(b[0])){l=hb(b);for(var v=h=1;v<l.length;++v)h*=l[v];a.dimension=h;b=Qa(b,l,a.dtype);d(a,b,c);e?a.persistentData=b:x.freeType(b)}else"number"===typeof b[0]?(a.dimension=l,l=x.allocType(a.dtype,b.length),fb(l,b),d(a,l,c),e?a.persistentData=l:x.freeType(l)):M(b[0])&&(a.dimension=b[0].length,a.dtype=h||Ha(b[0])||5126,b=Qa(b,[b.length,b[0].length],a.dtype),d(a,b,c),
-e?a.persistentData=b:x.freeType(b))}else if(M(b))a.dtype=h||Ha(b),a.dimension=l,d(a,b,c),e&&(a.persistentData=new Uint8Array(new Uint8Array(b.buffer)));else if(ma(b)){l=b.shape;var g=b.stride,v=b.offset,f=0,q=0,r=0,t=0;1===l.length?(f=l[0],q=1,r=g[0],t=0):2===l.length&&(f=l[0],q=l[1],r=g[0],t=g[1]);a.dtype=h||Ha(b.data)||5126;a.dimension=q;l=x.allocType(a.dtype,f*q);gb(l,b.data,f,q,r,t,v);d(a,l,c);e?a.persistentData=l:x.freeType(l)}}function f(c){b.bufferCount--;for(var d=0;d<e.state.length;++d){var k=
-e.state[d];k.buffer===c&&(a.disableVertexAttribArray(d),k.buffer=null)}a.deleteBuffer(c.buffer);c.buffer=null;delete q[c.id]}var r=0,q={};g.prototype.bind=function(){a.bindBuffer(this.type,this.buffer)};g.prototype.destroy=function(){f(this)};var t=[];c.profile&&(b.getTotalBufferSize=function(){var a=0;Object.keys(q).forEach(function(b){a+=q[b].stats.size});return a});return{create:function(m,e,d,h){function l(b){var m=35044,e=null,d=0,k=0,g=1;Array.isArray(b)||M(b)||ma(b)?e=b:"number"===typeof b?
-d=b|0:b&&("data"in b&&(e=b.data),"usage"in b&&(m=jb[b.usage]),"type"in b&&(k=Ra[b.type]),"dimension"in b&&(g=b.dimension|0),"length"in b&&(d=b.length|0));u.bind();e?n(u,e,m,k,g,h):(d&&a.bufferData(u.type,d,m),u.dtype=k||5121,u.usage=m,u.dimension=g,u.byteLength=d);c.profile&&(u.stats.size=u.byteLength*ja[u.dtype]);return l}b.bufferCount++;var u=new g(e);q[u.id]=u;d||l(m);l._reglType="buffer";l._buffer=u;l.subdata=function(b,c){var m=(c||0)|0,e;u.bind();if(M(b))a.bufferSubData(u.type,m,b);else if(Array.isArray(b)){if(0<
-b.length)if("number"===typeof b[0]){var d=x.allocType(u.dtype,b.length);fb(d,b);a.bufferSubData(u.type,m,d);x.freeType(d)}else if(Array.isArray(b[0])||M(b[0]))e=hb(b),d=Qa(b,e,u.dtype),a.bufferSubData(u.type,m,d),x.freeType(d)}else if(ma(b)){e=b.shape;var h=b.stride,k=d=0,g=0,F=0;1===e.length?(d=e[0],k=1,g=h[0],F=0):2===e.length&&(d=e[0],k=e[1],g=h[0],F=h[1]);e=Array.isArray(b.data)?u.dtype:Ha(b.data);e=x.allocType(e,d*k);gb(e,b.data,d,k,g,F,b.offset);a.bufferSubData(u.type,m,e);x.freeType(e)}return l};
-c.profile&&(l.stats=u.stats);l.destroy=function(){f(u)};return l},createStream:function(a,b){var c=t.pop();c||(c=new g(a));c.bind();n(c,b,35040,0,1,!1);return c},destroyStream:function(a){t.push(a)},clear:function(){S(q).forEach(f);t.forEach(f)},getBuffer:function(a){return a&&a._buffer instanceof g?a._buffer:null},restore:function(){S(q).forEach(function(b){b.buffer=a.createBuffer();a.bindBuffer(b.type,b.buffer);a.bufferData(b.type,b.persistentData||b.byteLength,b.usage)})},_initBuffer:n}}function Hb(a,
-b,c,e){function g(a){this.id=r++;f[this.id]=this;this.buffer=a;this.primType=4;this.type=this.vertCount=0}function d(e,d,g,h,l,u,v){e.buffer.bind();if(d){var f=v;v||M(d)&&(!ma(d)||M(d.data))||(f=b.oes_element_index_uint?5125:5123);c._initBuffer(e.buffer,d,g,f,3)}else a.bufferData(34963,u,g),e.buffer.dtype=f||5121,e.buffer.usage=g,e.buffer.dimension=3,e.buffer.byteLength=u;f=v;if(!v){switch(e.buffer.dtype){case 5121:case 5120:f=5121;break;case 5123:case 5122:f=5123;break;case 5125:case 5124:f=5125}e.buffer.dtype=
-f}e.type=f;d=l;0>d&&(d=e.buffer.byteLength,5123===f?d>>=1:5125===f&&(d>>=2));e.vertCount=d;d=h;0>h&&(d=4,h=e.buffer.dimension,1===h&&(d=0),2===h&&(d=1),3===h&&(d=4));e.primType=d}function n(a){e.elementsCount--;delete f[a.id];a.buffer.destroy();a.buffer=null}var f={},r=0,q={uint8:5121,uint16:5123};b.oes_element_index_uint&&(q.uint32=5125);g.prototype.bind=function(){this.buffer.bind()};var t=[];return{create:function(a,b){function k(a){if(a)if("number"===typeof a)h(a),l.primType=4,l.vertCount=a|0,
-l.type=5121;else{var b=null,c=35044,e=-1,g=-1,f=0,m=0;if(Array.isArray(a)||M(a)||ma(a))b=a;else if("data"in a&&(b=a.data),"usage"in a&&(c=jb[a.usage]),"primitive"in a&&(e=Sa[a.primitive]),"count"in a&&(g=a.count|0),"type"in a&&(m=q[a.type]),"length"in a)f=a.length|0;else if(f=g,5123===m||5122===m)f*=2;else if(5125===m||5124===m)f*=4;d(l,b,c,e,g,f,m)}else h(),l.primType=4,l.vertCount=0,l.type=5121;return k}var h=c.create(null,34963,!0),l=new g(h._buffer);e.elementsCount++;k(a);k._reglType="elements";
-k._elements=l;k.subdata=function(a,b){h.subdata(a,b);return k};k.destroy=function(){n(l)};return k},createStream:function(a){var b=t.pop();b||(b=new g(c.create(null,34963,!0,!1)._buffer));d(b,a,35040,-1,-1,0,0);return b},destroyStream:function(a){t.push(a)},getElements:function(a){return"function"===typeof a&&a._elements instanceof g?a._elements:null},clear:function(){S(f).forEach(n)}}}function kb(a){for(var b=x.allocType(5123,a.length),c=0;c<a.length;++c)if(isNaN(a[c]))b[c]=65535;else if(Infinity===
-a[c])b[c]=31744;else if(-Infinity===a[c])b[c]=64512;else{lb[0]=a[c];var e=Ib[0],g=e>>>31<<15,d=(e<<1>>>24)-127,e=e>>13&1023;b[c]=-24>d?g:-14>d?g+(e+1024>>-14-d):15<d?g+31744:g+(d+15<<10)+e}return b}function pa(a){return Array.isArray(a)||M(a)}function Ea(a){return"[object "+a+"]"}function mb(a){return Array.isArray(a)&&(0===a.length||"number"===typeof a[0])}function nb(a){return Array.isArray(a)&&0!==a.length&&pa(a[0])?!0:!1}function na(a){return Object.prototype.toString.call(a)}function Ta(a){if(!a)return!1;
-var b=na(a);return 0<=Jb.indexOf(b)?!0:mb(a)||nb(a)||ma(a)}function ob(a,b){36193===a.type?(a.data=kb(b),x.freeType(b)):a.data=b}function Ja(a,b,c,e,g,d){a="undefined"!==typeof y[a]?y[a]:L[a]*qa[b];d&&(a*=6);if(g){for(e=0;1<=c;)e+=a*c*c,c/=2;return e}return a*c*e}function Kb(a,b,c,e,g,d,n){function f(){this.format=this.internalformat=6408;this.type=5121;this.flipY=this.premultiplyAlpha=this.compressed=!1;this.unpackAlignment=1;this.colorSpace=37444;this.channels=this.height=this.width=0}function r(a,
-b){a.internalformat=b.internalformat;a.format=b.format;a.type=b.type;a.compressed=b.compressed;a.premultiplyAlpha=b.premultiplyAlpha;a.flipY=b.flipY;a.unpackAlignment=b.unpackAlignment;a.colorSpace=b.colorSpace;a.width=b.width;a.height=b.height;a.channels=b.channels}function q(a,b){if("object"===typeof b&&b){"premultiplyAlpha"in b&&(a.premultiplyAlpha=b.premultiplyAlpha);"flipY"in b&&(a.flipY=b.flipY);"alignment"in b&&(a.unpackAlignment=b.alignment);"colorSpace"in b&&(a.colorSpace=wa[b.colorSpace]);
-"type"in b&&(a.type=G[b.type]);var c=a.width,e=a.height,d=a.channels,h=!1;"shape"in b?(c=b.shape[0],e=b.shape[1],3===b.shape.length&&(d=b.shape[2],h=!0)):("radius"in b&&(c=e=b.radius),"width"in b&&(c=b.width),"height"in b&&(e=b.height),"channels"in b&&(d=b.channels,h=!0));a.width=c|0;a.height=e|0;a.channels=d|0;c=!1;"format"in b&&(c=b.format,e=a.internalformat=U[c],a.format=Lb[e],c in G&&!("type"in b)&&(a.type=G[c]),c in W&&(a.compressed=!0),c=!0);!h&&c?a.channels=L[a.format]:h&&!c&&a.channels!==
-La[a.format]&&(a.format=a.internalformat=La[a.channels])}}function t(b){a.pixelStorei(37440,b.flipY);a.pixelStorei(37441,b.premultiplyAlpha);a.pixelStorei(37443,b.colorSpace);a.pixelStorei(3317,b.unpackAlignment)}function m(){f.call(this);this.yOffset=this.xOffset=0;this.data=null;this.needsFree=!1;this.element=null;this.needsCopy=!1}function C(a,b){var c=null;Ta(b)?c=b:b&&(q(a,b),"x"in b&&(a.xOffset=b.x|0),"y"in b&&(a.yOffset=b.y|0),Ta(b.data)&&(c=b.data));if(b.copy){var e=g.viewportWidth,d=g.viewportHeight;
-a.width=a.width||e-a.xOffset;a.height=a.height||d-a.yOffset;a.needsCopy=!0}else if(!c)a.width=a.width||1,a.height=a.height||1,a.channels=a.channels||4;else if(M(c))a.channels=a.channels||4,a.data=c,"type"in b||5121!==a.type||(a.type=Ia[Object.prototype.toString.call(c)]|0);else if(mb(c)){a.channels=a.channels||4;e=c;d=e.length;switch(a.type){case 5121:case 5123:case 5125:case 5126:d=x.allocType(a.type,d);d.set(e);a.data=d;break;case 36193:a.data=kb(e)}a.alignment=1;a.needsFree=!0}else if(ma(c)){e=
-c.data;Array.isArray(e)||5121!==a.type||(a.type=Ia[Object.prototype.toString.call(e)]|0);var d=c.shape,h=c.stride,f,l,p,w;3===d.length?(p=d[2],w=h[2]):w=p=1;f=d[0];l=d[1];d=h[0];h=h[1];a.alignment=1;a.width=f;a.height=l;a.channels=p;a.format=a.internalformat=La[p];a.needsFree=!0;f=w;c=c.offset;p=a.width;w=a.height;l=a.channels;for(var z=x.allocType(36193===a.type?5126:a.type,p*w*l),I=0,fa=0;fa<w;++fa)for(var ga=0;ga<p;++ga)for(var xa=0;xa<l;++xa)z[I++]=e[d*ga+h*fa+f*xa+c];ob(a,z)}else if(na(c)===
-Ua||na(c)===pb)na(c)===Ua?a.element=c:a.element=c.canvas,a.width=a.element.width,a.height=a.element.height,a.channels=4;else if(na(c)===qb)a.element=c,a.width=c.width,a.height=c.height,a.channels=4;else if(na(c)===rb)a.element=c,a.width=c.naturalWidth,a.height=c.naturalHeight,a.channels=4;else if(na(c)===sb)a.element=c,a.width=c.videoWidth,a.height=c.videoHeight,a.channels=4;else if(nb(c)){e=a.width||c[0].length;d=a.height||c.length;h=a.channels;h=pa(c[0][0])?h||c[0][0].length:h||1;f=Ma.shape(c);
-p=1;for(w=0;w<f.length;++w)p*=f[w];p=x.allocType(36193===a.type?5126:a.type,p);Ma.flatten(c,f,"",p);ob(a,p);a.alignment=1;a.width=e;a.height=d;a.channels=h;a.format=a.internalformat=La[h];a.needsFree=!0}}function k(b,c,d,h,f){var g=b.element,l=b.data,k=b.internalformat,p=b.format,w=b.type,z=b.width,I=b.height;t(b);g?a.texSubImage2D(c,f,d,h,p,w,g):b.compressed?a.compressedTexSubImage2D(c,f,d,h,k,z,I,l):b.needsCopy?(e(),a.copyTexSubImage2D(c,f,d,h,b.xOffset,b.yOffset,z,I)):a.texSubImage2D(c,f,d,h,z,
-I,p,w,l)}function h(){return P.pop()||new m}function l(a){a.needsFree&&x.freeType(a.data);m.call(a);P.push(a)}function u(){f.call(this);this.genMipmaps=!1;this.mipmapHint=4352;this.mipmask=0;this.images=Array(16)}function v(a,b,c){var d=a.images[0]=h();a.mipmask=1;d.width=a.width=b;d.height=a.height=c;d.channels=a.channels=4}function N(a,b){var c=null;if(Ta(b))c=a.images[0]=h(),r(c,a),C(c,b),a.mipmask=1;else if(q(a,b),Array.isArray(b.mipmap))for(var d=b.mipmap,e=0;e<d.length;++e)c=a.images[e]=h(),
-r(c,a),c.width>>=e,c.height>>=e,C(c,d[e]),a.mipmask|=1<<e;else c=a.images[0]=h(),r(c,a),C(c,b),a.mipmask=1;r(a,a.images[0])}function B(b,c){for(var d=b.images,h=0;h<d.length&&d[h];++h){var f=d[h],g=c,l=h,k=f.element,p=f.data,w=f.internalformat,z=f.format,I=f.type,fa=f.width,ga=f.height,xa=f.channels;t(f);k?a.texImage2D(g,l,z,z,I,k):f.compressed?a.compressedTexImage2D(g,l,w,fa,ga,0,p):f.needsCopy?(e(),a.copyTexImage2D(g,l,z,f.xOffset,f.yOffset,fa,ga,0)):((f=!p)&&(p=x.zero.allocType(I,fa*ga*xa)),a.texImage2D(g,
-l,z,fa,ga,0,z,I,p),f&&p&&x.zero.freeType(p))}}function D(){var a=tb.pop()||new u;f.call(a);for(var b=a.mipmask=0;16>b;++b)a.images[b]=null;return a}function ib(a){for(var b=a.images,c=0;c<b.length;++c)b[c]&&l(b[c]),b[c]=null;tb.push(a)}function y(){this.magFilter=this.minFilter=9728;this.wrapT=this.wrapS=33071;this.anisotropic=1;this.genMipmaps=!1;this.mipmapHint=4352}function O(a,b){"min"in b&&(a.minFilter=Va[b.min],0<=Mb.indexOf(a.minFilter)&&!("faces"in b)&&(a.genMipmaps=!0));"mag"in b&&(a.magFilter=
-V[b.mag]);var c=a.wrapS,d=a.wrapT;if("wrap"in b){var e=b.wrap;"string"===typeof e?c=d=K[e]:Array.isArray(e)&&(c=K[e[0]],d=K[e[1]])}else"wrapS"in b&&(c=K[b.wrapS]),"wrapT"in b&&(d=K[b.wrapT]);a.wrapS=c;a.wrapT=d;"anisotropic"in b&&(a.anisotropic=b.anisotropic);if("mipmap"in b){c=!1;switch(typeof b.mipmap){case "string":a.mipmapHint=ua[b.mipmap];c=a.genMipmaps=!0;break;case "boolean":c=a.genMipmaps=b.mipmap;break;case "object":a.genMipmaps=!1,c=!0}!c||"min"in b||(a.minFilter=9984)}}function R(c,d){a.texParameteri(d,
-10241,c.minFilter);a.texParameteri(d,10240,c.magFilter);a.texParameteri(d,10242,c.wrapS);a.texParameteri(d,10243,c.wrapT);b.ext_texture_filter_anisotropic&&a.texParameteri(d,34046,c.anisotropic);c.genMipmaps&&(a.hint(33170,c.mipmapHint),a.generateMipmap(d))}function F(b){f.call(this);this.mipmask=0;this.internalformat=6408;this.id=ya++;this.refCount=1;this.target=b;this.texture=a.createTexture();this.unit=-1;this.bindCount=0;this.texInfo=new y;n.profile&&(this.stats={size:0})}function T(b){a.activeTexture(33984);
-a.bindTexture(b.target,b.texture)}function Aa(){var b=ha[0];b?a.bindTexture(b.target,b.texture):a.bindTexture(3553,null)}function A(b){var c=b.texture,e=b.unit,h=b.target;0<=e&&(a.activeTexture(33984+e),a.bindTexture(h,null),ha[e]=null);a.deleteTexture(c);b.texture=null;b.params=null;b.pixels=null;b.refCount=0;delete X[b.id];d.textureCount--}var ua={"don't care":4352,"dont care":4352,nice:4354,fast:4353},K={repeat:10497,clamp:33071,mirror:33648},V={nearest:9728,linear:9729},Va=E({mipmap:9987,"nearest mipmap nearest":9984,
-"linear mipmap nearest":9985,"nearest mipmap linear":9986,"linear mipmap linear":9987},V),wa={none:0,browser:37444},G={uint8:5121,rgba4:32819,rgb565:33635,"rgb5 a1":32820},U={alpha:6406,luminance:6409,"luminance alpha":6410,rgb:6407,rgba:6408,rgba4:32854,"rgb5 a1":32855,rgb565:36194},W={};b.ext_srgb&&(U.srgb=35904,U.srgba=35906);b.oes_texture_float&&(G.float32=G["float"]=5126);b.oes_texture_half_float&&(G.float16=G["half float"]=36193);b.webgl_depth_texture&&(E(U,{depth:6402,"depth stencil":34041}),
-E(G,{uint16:5123,uint32:5125,"depth stencil":34042}));b.webgl_compressed_texture_s3tc&&E(W,{"rgb s3tc dxt1":33776,"rgba s3tc dxt1":33777,"rgba s3tc dxt3":33778,"rgba s3tc dxt5":33779});b.webgl_compressed_texture_atc&&E(W,{"rgb atc":35986,"rgba atc explicit alpha":35987,"rgba atc interpolated alpha":34798});b.webgl_compressed_texture_pvrtc&&E(W,{"rgb pvrtc 4bppv1":35840,"rgb pvrtc 2bppv1":35841,"rgba pvrtc 4bppv1":35842,"rgba pvrtc 2bppv1":35843});b.webgl_compressed_texture_etc1&&(W["rgb etc1"]=36196);
-var Nb=Array.prototype.slice.call(a.getParameter(34467));Object.keys(W).forEach(function(a){var b=W[a];0<=Nb.indexOf(b)&&(U[a]=b)});var ca=Object.keys(U);c.textureFormats=ca;var J=[];Object.keys(U).forEach(function(a){J[U[a]]=a});var da=[];Object.keys(G).forEach(function(a){da[G[a]]=a});var oa=[];Object.keys(V).forEach(function(a){oa[V[a]]=a});var za=[];Object.keys(Va).forEach(function(a){za[Va[a]]=a});var ka=[];Object.keys(K).forEach(function(a){ka[K[a]]=a});var Lb=ca.reduce(function(a,b){var c=
-U[b];6409===c||6406===c||6409===c||6410===c||6402===c||34041===c?a[c]=c:32855===c||0<=b.indexOf("rgba")?a[c]=6408:a[c]=6407;return a},{}),P=[],tb=[],ya=0,X={},ea=c.maxTextureUnits,ha=Array(ea).map(function(){return null});E(F.prototype,{bind:function(){this.bindCount+=1;var b=this.unit;if(0>b){for(var c=0;c<ea;++c){var e=ha[c];if(e){if(0<e.bindCount)continue;e.unit=-1}ha[c]=this;b=c;break}n.profile&&d.maxTextureUnits<b+1&&(d.maxTextureUnits=b+1);this.unit=b;a.activeTexture(33984+b);a.bindTexture(this.target,
-this.texture)}return b},unbind:function(){--this.bindCount},decRef:function(){0>=--this.refCount&&A(this)}});n.profile&&(d.getTotalTextureSize=function(){var a=0;Object.keys(X).forEach(function(b){a+=X[b].stats.size});return a});return{create2D:function(b,c){function e(a,b){var c=f.texInfo;y.call(c);var d=D();"number"===typeof a?"number"===typeof b?v(d,a|0,b|0):v(d,a|0,a|0):a?(O(c,a),N(d,a)):v(d,1,1);c.genMipmaps&&(d.mipmask=(d.width<<1)-1);f.mipmask=d.mipmask;r(f,d);f.internalformat=d.internalformat;
-e.width=d.width;e.height=d.height;T(f);B(d,3553);R(c,3553);Aa();ib(d);n.profile&&(f.stats.size=Ja(f.internalformat,f.type,d.width,d.height,c.genMipmaps,!1));e.format=J[f.internalformat];e.type=da[f.type];e.mag=oa[c.magFilter];e.min=za[c.minFilter];e.wrapS=ka[c.wrapS];e.wrapT=ka[c.wrapT];return e}var f=new F(3553);X[f.id]=f;d.textureCount++;e(b,c);e.subimage=function(a,b,c,d){b|=0;c|=0;d|=0;var p=h();r(p,f);p.width=0;p.height=0;C(p,a);p.width=p.width||(f.width>>d)-b;p.height=p.height||(f.height>>d)-
-c;T(f);k(p,3553,b,c,d);Aa();l(p);return e};e.resize=function(b,c){var d=b|0,h=c|0||d;if(d===f.width&&h===f.height)return e;e.width=f.width=d;e.height=f.height=h;T(f);for(var p,w=f.channels,z=f.type,I=0;f.mipmask>>I;++I){var fa=d>>I,ga=h>>I;if(!fa||!ga)break;p=x.zero.allocType(z,fa*ga*w);a.texImage2D(3553,I,f.format,fa,ga,0,f.format,f.type,p);p&&x.zero.freeType(p)}Aa();n.profile&&(f.stats.size=Ja(f.internalformat,f.type,d,h,!1,!1));return e};e._reglType="texture2d";e._texture=f;n.profile&&(e.stats=
-f.stats);e.destroy=function(){f.decRef()};return e},createCube:function(b,c,e,f,g,ua){function A(a,b,c,d,e,f){var H,Y=m.texInfo;y.call(Y);for(H=0;6>H;++H)p[H]=D();if("number"===typeof a||!a)for(a=a|0||1,H=0;6>H;++H)v(p[H],a,a);else if("object"===typeof a)if(b)N(p[0],a),N(p[1],b),N(p[2],c),N(p[3],d),N(p[4],e),N(p[5],f);else if(O(Y,a),q(m,a),"faces"in a)for(a=a.faces,H=0;6>H;++H)r(p[H],m),N(p[H],a[H]);else for(H=0;6>H;++H)N(p[H],a);r(m,p[0]);m.mipmask=Y.genMipmaps?(p[0].width<<1)-1:p[0].mipmask;m.internalformat=
-p[0].internalformat;A.width=p[0].width;A.height=p[0].height;T(m);for(H=0;6>H;++H)B(p[H],34069+H);R(Y,34067);Aa();n.profile&&(m.stats.size=Ja(m.internalformat,m.type,A.width,A.height,Y.genMipmaps,!0));A.format=J[m.internalformat];A.type=da[m.type];A.mag=oa[Y.magFilter];A.min=za[Y.minFilter];A.wrapS=ka[Y.wrapS];A.wrapT=ka[Y.wrapT];for(H=0;6>H;++H)ib(p[H]);return A}var m=new F(34067);X[m.id]=m;d.cubeCount++;var p=Array(6);A(b,c,e,f,g,ua);A.subimage=function(a,b,c,p,d){c|=0;p|=0;d|=0;var e=h();r(e,m);
-e.width=0;e.height=0;C(e,b);e.width=e.width||(m.width>>d)-c;e.height=e.height||(m.height>>d)-p;T(m);k(e,34069+a,c,p,d);Aa();l(e);return A};A.resize=function(b){b|=0;if(b!==m.width){A.width=m.width=b;A.height=m.height=b;T(m);for(var c=0;6>c;++c)for(var p=0;m.mipmask>>p;++p)a.texImage2D(34069+c,p,m.format,b>>p,b>>p,0,m.format,m.type,null);Aa();n.profile&&(m.stats.size=Ja(m.internalformat,m.type,A.width,A.height,!1,!0));return A}};A._reglType="textureCube";A._texture=m;n.profile&&(A.stats=m.stats);A.destroy=
-function(){m.decRef()};return A},clear:function(){for(var b=0;b<ea;++b)a.activeTexture(33984+b),a.bindTexture(3553,null),ha[b]=null;S(X).forEach(A);d.cubeCount=0;d.textureCount=0},getTexture:function(a){return null},restore:function(){for(var b=0;b<ea;++b){var c=ha[b];c&&(c.bindCount=0,c.unit=-1,ha[b]=null)}S(X).forEach(function(b){b.texture=a.createTexture();a.bindTexture(b.target,b.texture);for(var c=0;32>c;++c)if(0!==(b.mipmask&1<<c))if(3553===b.target)a.texImage2D(3553,c,b.internalformat,b.width>>
-c,b.height>>c,0,b.internalformat,b.type,null);else for(var d=0;6>d;++d)a.texImage2D(34069+d,c,b.internalformat,b.width>>c,b.height>>c,0,b.internalformat,b.type,null);R(b.texInfo,b.target)})}}}function Ob(a,b,c,e,g,d){function n(a,b,c){this.target=a;this.texture=b;this.renderbuffer=c;var d=a=0;b?(a=b.width,d=b.height):c&&(a=c.width,d=c.height);this.width=a;this.height=d}function f(a){a&&(a.texture&&a.texture._texture.decRef(),a.renderbuffer&&a.renderbuffer._renderbuffer.decRef())}function r(a,b,c){a&&
-(a.texture?a.texture._texture.refCount+=1:a.renderbuffer._renderbuffer.refCount+=1)}function q(b,c){c&&(c.texture?a.framebufferTexture2D(36160,b,c.target,c.texture._texture.texture,0):a.framebufferRenderbuffer(36160,b,36161,c.renderbuffer._renderbuffer.renderbuffer))}function t(a){var b=3553,c=null,d=null,e=a;"object"===typeof a&&(e=a.data,"target"in a&&(b=a.target|0));a=e._reglType;"texture2d"===a?c=e:"textureCube"===a?c=e:"renderbuffer"===a&&(d=e,b=36161);return new n(b,c,d)}function m(a,b,c,d,
-f){if(c)return a=e.create2D({width:a,height:b,format:d,type:f}),a._texture.refCount=0,new n(3553,a,null);a=g.create({width:a,height:b,format:d});a._renderbuffer.refCount=0;return new n(36161,null,a)}function C(a){return a&&(a.texture||a.renderbuffer)}function k(a,b,c){a&&(a.texture?a.texture.resize(b,c):a.renderbuffer&&a.renderbuffer.resize(b,c),a.width=b,a.height=c)}function h(){this.id=O++;R[this.id]=this;this.framebuffer=a.createFramebuffer();this.height=this.width=0;this.colorAttachments=[];this.depthStencilAttachment=
-this.stencilAttachment=this.depthAttachment=null}function l(a){a.colorAttachments.forEach(f);f(a.depthAttachment);f(a.stencilAttachment);f(a.depthStencilAttachment)}function u(b){a.deleteFramebuffer(b.framebuffer);b.framebuffer=null;d.framebufferCount--;delete R[b.id]}function v(b){var d;a.bindFramebuffer(36160,b.framebuffer);var e=b.colorAttachments;for(d=0;d<e.length;++d)q(36064+d,e[d]);for(d=e.length;d<c.maxColorAttachments;++d)a.framebufferTexture2D(36160,36064+d,3553,null,0);a.framebufferTexture2D(36160,
-33306,3553,null,0);a.framebufferTexture2D(36160,36096,3553,null,0);a.framebufferTexture2D(36160,36128,3553,null,0);q(36096,b.depthAttachment);q(36128,b.stencilAttachment);q(33306,b.depthStencilAttachment);a.checkFramebufferStatus(36160);a.isContextLost();a.bindFramebuffer(36160,B.next?B.next.framebuffer:null);B.cur=B.next;a.getError()}function N(a,b){function c(a,b){var d,f=0,h=0,g=!0,k=!0;d=null;var q=!0,u="rgba",n="uint8",N=1,da=null,oa=null,B=null,ka=!1;if("number"===typeof a)f=a|0,h=b|0||f;else if(a){"shape"in
-a?(h=a.shape,f=h[0],h=h[1]):("radius"in a&&(f=h=a.radius),"width"in a&&(f=a.width),"height"in a&&(h=a.height));if("color"in a||"colors"in a)d=a.color||a.colors,Array.isArray(d);if(!d){"colorCount"in a&&(N=a.colorCount|0);"colorTexture"in a&&(q=!!a.colorTexture,u="rgba4");if("colorType"in a&&(n=a.colorType,!q))if("half float"===n||"float16"===n)u="rgba16f";else if("float"===n||"float32"===n)u="rgba32f";"colorFormat"in a&&(u=a.colorFormat,0<=x.indexOf(u)?q=!0:0<=D.indexOf(u)&&(q=!1))}if("depthTexture"in
-a||"depthStencilTexture"in a)ka=!(!a.depthTexture&&!a.depthStencilTexture);"depth"in a&&("boolean"===typeof a.depth?g=a.depth:(da=a.depth,k=!1));"stencil"in a&&("boolean"===typeof a.stencil?k=a.stencil:(oa=a.stencil,g=!1));"depthStencil"in a&&("boolean"===typeof a.depthStencil?g=k=a.depthStencil:(B=a.depthStencil,k=g=!1))}else f=h=1;var F=null,y=null,E=null,T=null;if(Array.isArray(d))F=d.map(t);else if(d)F=[t(d)];else for(F=Array(N),d=0;d<N;++d)F[d]=m(f,h,q,u,n);f=f||F[0].width;h=h||F[0].height;da?
-y=t(da):g&&!k&&(y=m(f,h,ka,"depth","uint32"));oa?E=t(oa):k&&!g&&(E=m(f,h,!1,"stencil","uint8"));B?T=t(B):!da&&!oa&&k&&g&&(T=m(f,h,ka,"depth stencil","depth stencil"));g=null;for(d=0;d<F.length;++d)r(F[d],f,h),F[d]&&F[d].texture&&(k=Wa[F[d].texture._texture.format]*Na[F[d].texture._texture.type],null===g&&(g=k));r(y,f,h);r(E,f,h);r(T,f,h);l(e);e.width=f;e.height=h;e.colorAttachments=F;e.depthAttachment=y;e.stencilAttachment=E;e.depthStencilAttachment=T;c.color=F.map(C);c.depth=C(y);c.stencil=C(E);
-c.depthStencil=C(T);c.width=e.width;c.height=e.height;v(e);return c}var e=new h;d.framebufferCount++;c(a,b);return E(c,{resize:function(a,b){var d=Math.max(a|0,1),f=Math.max(b|0||d,1);if(d===e.width&&f===e.height)return c;for(var h=e.colorAttachments,g=0;g<h.length;++g)k(h[g],d,f);k(e.depthAttachment,d,f);k(e.stencilAttachment,d,f);k(e.depthStencilAttachment,d,f);e.width=c.width=d;e.height=c.height=f;v(e);return c},_reglType:"framebuffer",_framebuffer:e,destroy:function(){u(e);l(e)},use:function(a){B.setFBO({framebuffer:c},
-a)}})}var B={cur:null,next:null,dirty:!1,setFBO:null},x=["rgba"],D=["rgba4","rgb565","rgb5 a1"];b.ext_srgb&&D.push("srgba");b.ext_color_buffer_half_float&&D.push("rgba16f","rgb16f");b.webgl_color_buffer_float&&D.push("rgba32f");var y=["uint8"];b.oes_texture_half_float&&y.push("half float","float16");b.oes_texture_float&&y.push("float","float32");var O=0,R={};return E(B,{getFramebuffer:function(a){return"function"===typeof a&&"framebuffer"===a._reglType&&(a=a._framebuffer,a instanceof h)?a:null},create:N,
-createCube:function(a){function b(a){var d,f={color:null},h=0,g=null;d="rgba";var l="uint8",m=1;if("number"===typeof a)h=a|0;else if(a){"shape"in a?h=a.shape[0]:("radius"in a&&(h=a.radius|0),"width"in a?h=a.width|0:"height"in a&&(h=a.height|0));if("color"in a||"colors"in a)g=a.color||a.colors,Array.isArray(g);g||("colorCount"in a&&(m=a.colorCount|0),"colorType"in a&&(l=a.colorType),"colorFormat"in a&&(d=a.colorFormat));"depth"in a&&(f.depth=a.depth);"stencil"in a&&(f.stencil=a.stencil);"depthStencil"in
-a&&(f.depthStencil=a.depthStencil)}else h=1;if(g)if(Array.isArray(g))for(a=[],d=0;d<g.length;++d)a[d]=g[d];else a=[g];else for(a=Array(m),g={radius:h,format:d,type:l},d=0;d<m;++d)a[d]=e.createCube(g);f.color=Array(a.length);for(d=0;d<a.length;++d)m=a[d],h=h||m.width,f.color[d]={target:34069,data:a[d]};for(d=0;6>d;++d){for(m=0;m<a.length;++m)f.color[m].target=34069+d;0<d&&(f.depth=c[0].depth,f.stencil=c[0].stencil,f.depthStencil=c[0].depthStencil);if(c[d])c[d](f);else c[d]=N(f)}return E(b,{width:h,
-height:h,color:a})}var c=Array(6);b(a);return E(b,{faces:c,resize:function(a){var d=a|0;if(d===b.width)return b;var e=b.color;for(a=0;a<e.length;++a)e[a].resize(d);for(a=0;6>a;++a)c[a].resize(d);b.width=b.height=d;return b},_reglType:"framebufferCube",destroy:function(){c.forEach(function(a){a.destroy()})}})},clear:function(){S(R).forEach(u)},restore:function(){B.cur=null;B.next=null;B.dirty=!0;S(R).forEach(function(b){b.framebuffer=a.createFramebuffer();v(b)})}})}function ub(){this.w=this.z=this.y=
-this.x=this.state=0;this.buffer=null;this.size=0;this.normalized=!1;this.type=5126;this.divisor=this.stride=this.offset=0}function Pb(a,b,c,e){a=c.maxAttributes;b=Array(a);for(c=0;c<a;++c)b[c]=new ub;return{Record:ub,scope:{},state:b}}function Qb(a,b,c,e){function g(a,b,c,d){this.name=a;this.id=b;this.location=c;this.info=d}function d(a,b){for(var c=0;c<a.length;++c)if(a[c].id===b.id){a[c].location=b.location;return}a.push(b)}function n(c,d,e){e=35632===c?q:t;var f=e[d];if(!f){var g=b.str(d),f=a.createShader(c);
-a.shaderSource(f,g);a.compileShader(f);e[d]=f}return f}function f(a,b){this.id=k++;this.fragId=a;this.vertId=b;this.program=null;this.uniforms=[];this.attributes=[];e.profile&&(this.stats={uniformsCount:0,attributesCount:0})}function r(c,f){var m,k;m=n(35632,c.fragId);k=n(35633,c.vertId);var q=c.program=a.createProgram();a.attachShader(q,m);a.attachShader(q,k);a.linkProgram(q);var r=a.getProgramParameter(q,35718);e.profile&&(c.stats.uniformsCount=r);var t=c.uniforms;for(m=0;m<r;++m)if(k=a.getActiveUniform(q,
-m))if(1<k.size)for(var C=0;C<k.size;++C){var y=k.name.replace("[0]","["+C+"]");d(t,new g(y,b.id(y),a.getUniformLocation(q,y),k))}else d(t,new g(k.name,b.id(k.name),a.getUniformLocation(q,k.name),k));r=a.getProgramParameter(q,35721);e.profile&&(c.stats.attributesCount=r);t=c.attributes;for(m=0;m<r;++m)(k=a.getActiveAttrib(q,m))&&d(t,new g(k.name,b.id(k.name),a.getAttribLocation(q,k.name),k))}var q={},t={},m={},C=[],k=0;e.profile&&(c.getMaxUniformsCount=function(){var a=0;C.forEach(function(b){b.stats.uniformsCount>
-a&&(a=b.stats.uniformsCount)});return a},c.getMaxAttributesCount=function(){var a=0;C.forEach(function(b){b.stats.attributesCount>a&&(a=b.stats.attributesCount)});return a});return{clear:function(){var b=a.deleteShader.bind(a);S(q).forEach(b);q={};S(t).forEach(b);t={};C.forEach(function(b){a.deleteProgram(b.program)});C.length=0;m={};c.shaderCount=0},program:function(a,b,d){var e=m[b];e||(e=m[b]={});var g=e[a];g||(g=new f(b,a),c.shaderCount++,r(g,d),e[a]=g,C.push(g));return g},restore:function(){q=
-{};t={};for(var a=0;a<C.length;++a)r(C[a])},shader:n,frag:-1,vert:-1}}function Rb(a,b,c,e,g,d,n){function f(d){var f;f=null===b.next?5121:b.next.colorAttachments[0].texture._texture.type;var g=0,r=0,k=e.framebufferWidth,h=e.framebufferHeight,l=null;M(d)?l=d:d&&(g=d.x|0,r=d.y|0,k=(d.width||e.framebufferWidth-g)|0,h=(d.height||e.framebufferHeight-r)|0,l=d.data||null);c();d=k*h*4;l||(5121===f?l=new Uint8Array(d):5126===f&&(l=l||new Float32Array(d)));a.pixelStorei(3333,4);a.readPixels(g,r,k,h,6408,f,
-l);return l}function r(a){var c;b.setFBO({framebuffer:a.framebuffer},function(){c=f(a)});return c}return function(a){return a&&"framebuffer"in a?r(a):f(a)}}function Ba(a){return Array.prototype.slice.call(a)}function Ca(a){return Ba(a).join("")}function Sb(){function a(){var a=[],b=[];return E(function(){a.push.apply(a,Ba(arguments))},{def:function(){var d="v"+c++;b.push(d);0<arguments.length&&(a.push(d,"="),a.push.apply(a,Ba(arguments)),a.push(";"));return d},toString:function(){return Ca([0<b.length?
-"var "+b+";":"",Ca(a)])}})}function b(){function b(a,e){d(a,e,"=",c.def(a,e),";")}var c=a(),d=a(),e=c.toString,g=d.toString;return E(function(){c.apply(c,Ba(arguments))},{def:c.def,entry:c,exit:d,save:b,set:function(a,d,e){b(a,d);c(a,d,"=",e,";")},toString:function(){return e()+g()}})}var c=0,e=[],g=[],d=a(),n={};return{global:d,link:function(a){for(var b=0;b<g.length;++b)if(g[b]===a)return e[b];b="g"+c++;e.push(b);g.push(a);return b},block:a,proc:function(a,c){function d(){var a="a"+e.length;e.push(a);
-return a}var e=[];c=c||0;for(var g=0;g<c;++g)d();var g=b(),C=g.toString;return n[a]=E(g,{arg:d,toString:function(){return Ca(["function(",e.join(),"){",C(),"}"])}})},scope:b,cond:function(){var a=Ca(arguments),c=b(),d=b(),e=c.toString,g=d.toString;return E(c,{then:function(){c.apply(c,Ba(arguments));return this},"else":function(){d.apply(d,Ba(arguments));return this},toString:function(){var b=g();b&&(b="else{"+b+"}");return Ca(["if(",a,"){",e(),"}",b])}})},compile:function(){var a=['"use strict";',
-d,"return {"];Object.keys(n).forEach(function(b){a.push('"',b,'":',n[b].toString(),",")});a.push("}");var b=Ca(a).replace(/;/g,";\n").replace(/}/g,"}\n").replace(/{/g,"{\n");return Function.apply(null,e.concat(b)).apply(null,g)}}}function Oa(a){return Array.isArray(a)||M(a)||ma(a)}function vb(a){return a.sort(function(a,c){return"viewport"===a?-1:"viewport"===c?1:a<c?-1:1})}function Z(a,b,c,e){this.thisDep=a;this.contextDep=b;this.propDep=c;this.append=e}function va(a){return a&&!(a.thisDep||a.contextDep||
-a.propDep)}function D(a){return new Z(!1,!1,!1,a)}function P(a,b){var c=a.type;return 0===c?(c=a.data.length,new Z(!0,1<=c,2<=c,b)):4===c?(c=a.data,new Z(c.thisDep,c.contextDep,c.propDep,b)):new Z(3===c,2===c,1===c,b)}function Tb(a,b,c,e,g,d,n,f,r,q,t,m,C,k,h){function l(a){return a.replace(".","_")}function u(a,b,c){var d=l(a);Ka.push(a);Fa[d]=ra[d]=!!c;sa[d]=b}function v(a,b,c){var d=l(a);Ka.push(a);Array.isArray(c)?(ra[d]=c.slice(),Fa[d]=c.slice()):ra[d]=Fa[d]=c;ta[d]=b}function N(){var a=Sb(),
-c=a.link,d=a.global;a.id=qa++;a.batchId="0";var e=c(na),f=a.shared={props:"a0"};Object.keys(na).forEach(function(a){f[a]=d.def(e,".",a)});var g=a.next={},xa=a.current={};Object.keys(ta).forEach(function(a){Array.isArray(ra[a])&&(g[a]=d.def(f.next,".",a),xa[a]=d.def(f.current,".",a))});var H=a.constants={};Object.keys(aa).forEach(function(a){H[a]=d.def(JSON.stringify(aa[a]))});a.invoke=function(b,d){switch(d.type){case 0:var e=["this",f.context,f.props,a.batchId];return b.def(c(d.data),".call(",e.slice(0,
-Math.max(d.data.length+1,4)),")");case 1:return b.def(f.props,d.data);case 2:return b.def(f.context,d.data);case 3:return b.def("this",d.data);case 4:return d.data.append(a,b),d.data.ref}};a.attribCache={};var Y={};a.scopeAttrib=function(a){a=b.id(a);if(a in Y)return Y[a];var d=q.scope[a];d||(d=q.scope[a]=new ya);return Y[a]=c(d)};return a}function B(a){var b=a["static"];a=a.dynamic;var c;if("profile"in b){var d=!!b.profile;c=D(function(a,b){return d});c.enable=d}else if("profile"in a){var e=a.profile;
-c=P(e,function(a,b){return a.invoke(b,e)})}return c}function y(a,b){var c=a["static"],d=a.dynamic;if("framebuffer"in c){var e=c.framebuffer;return e?(e=f.getFramebuffer(e),D(function(a,b){var c=a.link(e),d=a.shared;b.set(d.framebuffer,".next",c);d=d.context;b.set(d,".framebufferWidth",c+".width");b.set(d,".framebufferHeight",c+".height");return c})):D(function(a,b){var c=a.shared;b.set(c.framebuffer,".next","null");c=c.context;b.set(c,".framebufferWidth",c+".drawingBufferWidth");b.set(c,".framebufferHeight",
-c+".drawingBufferHeight");return"null"})}if("framebuffer"in d){var g=d.framebuffer;return P(g,function(a,b){var c=a.invoke(b,g),d=a.shared,e=d.framebuffer,c=b.def(e,".getFramebuffer(",c,")");b.set(e,".next",c);d=d.context;b.set(d,".framebufferWidth",c+"?"+c+".width:"+d+".drawingBufferWidth");b.set(d,".framebufferHeight",c+"?"+c+".height:"+d+".drawingBufferHeight");return c})}return null}function x(a,b,c){function d(a){if(a in e){var c=e[a];a=!0;var p=c.x|0,ba=c.y|0,g,h;"width"in c?g=c.width|0:a=!1;
-"height"in c?h=c.height|0:a=!1;return new Z(!a&&b&&b.thisDep,!a&&b&&b.contextDep,!a&&b&&b.propDep,function(a,b){var d=a.shared.context,e=g;"width"in c||(e=b.def(d,".","framebufferWidth","-",p));var f=h;"height"in c||(f=b.def(d,".","framebufferHeight","-",ba));return[p,ba,e,f]})}if(a in f){var z=f[a];a=P(z,function(a,b){var c=a.invoke(b,z),d=a.shared.context,e=b.def(c,".x|0"),p=b.def(c,".y|0"),Y=b.def('"width" in ',c,"?",c,".width|0:","(",d,".","framebufferWidth","-",e,")"),c=b.def('"height" in ',
-c,"?",c,".height|0:","(",d,".","framebufferHeight","-",p,")");return[e,p,Y,c]});b&&(a.thisDep=a.thisDep||b.thisDep,a.contextDep=a.contextDep||b.contextDep,a.propDep=a.propDep||b.propDep);return a}return b?new Z(b.thisDep,b.contextDep,b.propDep,function(a,b){var c=a.shared.context;return[0,0,b.def(c,".","framebufferWidth"),b.def(c,".","framebufferHeight")]}):null}var e=a["static"],f=a.dynamic;if(a=d("viewport")){var g=a;a=new Z(a.thisDep,a.contextDep,a.propDep,function(a,b){var c=g.append(a,b),d=a.shared.context;
-b.set(d,".viewportWidth",c[2]);b.set(d,".viewportHeight",c[3]);return c})}return{viewport:a,scissor_box:d("scissor.box")}}function E(a){function c(a){if(a in d){var p=b.id(d[a]);a=D(function(){return p});a.id=p;return a}if(a in e){var f=e[a];return P(f,function(a,b){var c=a.invoke(b,f);return b.def(a.shared.strings,".id(",c,")")})}return null}var d=a["static"],e=a.dynamic,f=c("frag"),g=c("vert"),h=null;va(f)&&va(g)?(h=t.program(g.id,f.id),a=D(function(a,b){return a.link(h)})):a=new Z(f&&f.thisDep||
-g&&g.thisDep,f&&f.contextDep||g&&g.contextDep,f&&f.propDep||g&&g.propDep,function(a,b){var c=a.shared.shader,d;d=f?f.append(a,b):b.def(c,".","frag");var e;e=g?g.append(a,b):b.def(c,".","vert");return b.def(c+".program("+e+","+d+")")});return{frag:f,vert:g,progVar:a,program:h}}function O(a,b){function c(a,b){if(a in e){var d=e[a]|0;return D(function(a,c){b&&(a.OFFSET=d);return d})}if(a in f){var p=f[a];return P(p,function(a,c){var d=a.invoke(c,p);b&&(a.OFFSET=d);return d})}return b&&g?D(function(a,
-b){a.OFFSET="0";return 0}):null}var e=a["static"],f=a.dynamic,g=function(){if("elements"in e){var a=e.elements;Oa(a)?a=d.getElements(d.create(a,!0)):a&&(a=d.getElements(a));var b=D(function(b,c){if(a){var d=b.link(a);return b.ELEMENTS=d}return b.ELEMENTS=null});b.value=a;return b}if("elements"in f){var c=f.elements;return P(c,function(a,b){var d=a.shared,e=d.isBufferArgs,d=d.elements,p=a.invoke(b,c),f=b.def("null"),e=b.def(e,"(",p,")"),p=a.cond(e).then(f,"=",d,".createStream(",p,");")["else"](f,"=",
-d,".getElements(",p,");");b.entry(p);b.exit(a.cond(e).then(d,".destroyStream(",f,");"));return a.ELEMENTS=f})}return null}(),h=c("offset",!0);return{elements:g,primitive:function(){if("primitive"in e){var a=e.primitive;return D(function(b,c){return Sa[a]})}if("primitive"in f){var b=f.primitive;return P(b,function(a,c){var d=a.constants.primTypes,e=a.invoke(c,b);return c.def(d,"[",e,"]")})}return g?va(g)?g.value?D(function(a,b){return b.def(a.ELEMENTS,".primType")}):D(function(){return 4}):new Z(g.thisDep,
-g.contextDep,g.propDep,function(a,b){var c=a.ELEMENTS;return b.def(c,"?",c,".primType:",4)}):null}(),count:function(){if("count"in e){var a=e.count|0;return D(function(){return a})}if("count"in f){var b=f.count;return P(b,function(a,c){return a.invoke(c,b)})}return g?va(g)?g?h?new Z(h.thisDep,h.contextDep,h.propDep,function(a,b){return b.def(a.ELEMENTS,".vertCount-",a.OFFSET)}):D(function(a,b){return b.def(a.ELEMENTS,".vertCount")}):D(function(){return-1}):new Z(g.thisDep||h.thisDep,g.contextDep||
-h.contextDep,g.propDep||h.propDep,function(a,b){var c=a.ELEMENTS;return a.OFFSET?b.def(c,"?",c,".vertCount-",a.OFFSET,":-1"):b.def(c,"?",c,".vertCount:-1")}):null}(),instances:c("instances",!1),offset:h}}function R(a,b){var c=a["static"],d=a.dynamic,e={};Ka.forEach(function(a){function b(f,g){if(a in c){var w=f(c[a]);e[p]=D(function(){return w})}else if(a in d){var h=d[a];e[p]=P(h,function(a,b){return g(a,b,a.invoke(b,h))})}}var p=l(a);switch(a){case "cull.enable":case "blend.enable":case "dither":case "stencil.enable":case "depth.enable":case "scissor.enable":case "polygonOffset.enable":case "sample.alpha":case "sample.enable":case "depth.mask":return b(function(a){return a},
-function(a,b,c){return c});case "depth.func":return b(function(a){return Xa[a]},function(a,b,c){return b.def(a.constants.compareFuncs,"[",c,"]")});case "depth.range":return b(function(a){return a},function(a,b,c){a=b.def("+",c,"[0]");b=b.def("+",c,"[1]");return[a,b]});case "blend.func":return b(function(a){return[Ga["srcRGB"in a?a.srcRGB:a.src],Ga["dstRGB"in a?a.dstRGB:a.dst],Ga["srcAlpha"in a?a.srcAlpha:a.src],Ga["dstAlpha"in a?a.dstAlpha:a.dst]]},function(a,b,c){function d(a,e){return b.def('"',
-a,e,'" in ',c,"?",c,".",a,e,":",c,".",a)}a=a.constants.blendFuncs;var e=d("src","RGB"),p=d("dst","RGB"),e=b.def(a,"[",e,"]"),f=b.def(a,"[",d("src","Alpha"),"]"),p=b.def(a,"[",p,"]");a=b.def(a,"[",d("dst","Alpha"),"]");return[e,p,f,a]});case "blend.equation":return b(function(a){if("string"===typeof a)return[X[a],X[a]];if("object"===typeof a)return[X[a.rgb],X[a.alpha]]},function(a,b,c){var d=a.constants.blendEquations,e=b.def(),p=b.def();a=a.cond("typeof ",c,'==="string"');a.then(e,"=",p,"=",d,"[",
-c,"];");a["else"](e,"=",d,"[",c,".rgb];",p,"=",d,"[",c,".alpha];");b(a);return[e,p]});case "blend.color":return b(function(a){return J(4,function(b){return+a[b]})},function(a,b,c){return J(4,function(a){return b.def("+",c,"[",a,"]")})});case "stencil.mask":return b(function(a){return a|0},function(a,b,c){return b.def(c,"|0")});case "stencil.func":return b(function(a){return[Xa[a.cmp||"keep"],a.ref||0,"mask"in a?a.mask:-1]},function(a,b,c){a=b.def('"cmp" in ',c,"?",a.constants.compareFuncs,"[",c,".cmp]",
-":",7680);var d=b.def(c,".ref|0");b=b.def('"mask" in ',c,"?",c,".mask|0:-1");return[a,d,b]});case "stencil.opFront":case "stencil.opBack":return b(function(b){return["stencil.opBack"===a?1029:1028,Pa[b.fail||"keep"],Pa[b.zfail||"keep"],Pa[b.zpass||"keep"]]},function(b,c,d){function e(a){return c.def('"',a,'" in ',d,"?",p,"[",d,".",a,"]:",7680)}var p=b.constants.stencilOps;return["stencil.opBack"===a?1029:1028,e("fail"),e("zfail"),e("zpass")]});case "polygonOffset.offset":return b(function(a){return[a.factor|
-0,a.units|0]},function(a,b,c){a=b.def(c,".factor|0");b=b.def(c,".units|0");return[a,b]});case "cull.face":return b(function(a){var b=0;"front"===a?b=1028:"back"===a&&(b=1029);return b},function(a,b,c){return b.def(c,'==="front"?',1028,":",1029)});case "lineWidth":return b(function(a){return a},function(a,b,c){return c});case "frontFace":return b(function(a){return wb[a]},function(a,b,c){return b.def(c+'==="cw"?2304:2305')});case "colorMask":return b(function(a){return a.map(function(a){return!!a})},
-function(a,b,c){return J(4,function(a){return"!!"+c+"["+a+"]"})});case "sample.coverage":return b(function(a){return["value"in a?a.value:1,!!a.invert]},function(a,b,c){a=b.def('"value" in ',c,"?+",c,".value:1");b=b.def("!!",c,".invert");return[a,b]})}});return e}function F(a,b){var c=a["static"],d=a.dynamic,e={};Object.keys(c).forEach(function(a){var b=c[a],d;if("number"===typeof b||"boolean"===typeof b)d=D(function(){return b});else if("function"===typeof b){var p=b._reglType;if("texture2d"===p||
-"textureCube"===p)d=D(function(a){return a.link(b)});else if("framebuffer"===p||"framebufferCube"===p)d=D(function(a){return a.link(b.color[0])})}else pa(b)&&(d=D(function(a){return a.global.def("[",J(b.length,function(a){return b[a]}),"]")}));d.value=b;e[a]=d});Object.keys(d).forEach(function(a){var b=d[a];e[a]=P(b,function(a,c){return a.invoke(c,b)})});return e}function T(a,c){var d=a["static"],e=a.dynamic,f={};Object.keys(d).forEach(function(a){var c=d[a],e=b.id(a),p=new ya;if(Oa(c))p.state=1,
-p.buffer=g.getBuffer(g.create(c,34962,!1,!0)),p.type=0;else{var w=g.getBuffer(c);if(w)p.state=1,p.buffer=w,p.type=0;else if("constant"in c){var h=c.constant;p.buffer="null";p.state=2;"number"===typeof h?p.x=h:Da.forEach(function(a,b){b<h.length&&(p[a]=h[b])})}else{var w=Oa(c.buffer)?g.getBuffer(g.create(c.buffer,34962,!1,!0)):g.getBuffer(c.buffer),k=c.offset|0,m=c.stride|0,I=c.size|0,l=!!c.normalized,n=0;"type"in c&&(n=Ra[c.type]);c=c.divisor|0;p.buffer=w;p.state=1;p.size=I;p.normalized=l;p.type=
-n||w.dtype;p.offset=k;p.stride=m;p.divisor=c}}f[a]=D(function(a,b){var c=a.attribCache;if(e in c)return c[e];var d={isStream:!1};Object.keys(p).forEach(function(a){d[a]=p[a]});p.buffer&&(d.buffer=a.link(p.buffer),d.type=d.type||d.buffer+".dtype");return c[e]=d})});Object.keys(e).forEach(function(a){var b=e[a];f[a]=P(b,function(a,c){function d(a){c(w[a],"=",e,".",a,"|0;")}var e=a.invoke(c,b),p=a.shared,f=p.isBufferArgs,g=p.buffer,w={isStream:c.def(!1)},h=new ya;h.state=1;Object.keys(h).forEach(function(a){w[a]=
-c.def(""+h[a])});var z=w.buffer,k=w.type;c("if(",f,"(",e,")){",w.isStream,"=true;",z,"=",g,".createStream(",34962,",",e,");",k,"=",z,".dtype;","}else{",z,"=",g,".getBuffer(",e,");","if(",z,"){",k,"=",z,".dtype;",'}else if("constant" in ',e,"){",w.state,"=",2,";","if(typeof "+e+'.constant === "number"){',w[Da[0]],"=",e,".constant;",Da.slice(1).map(function(a){return w[a]}).join("="),"=0;","}else{",Da.map(function(a,b){return w[a]+"="+e+".constant.length>"+b+"?"+e+".constant["+b+"]:0;"}).join(""),"}}else{",
-"if(",f,"(",e,".buffer)){",z,"=",g,".createStream(",34962,",",e,".buffer);","}else{",z,"=",g,".getBuffer(",e,".buffer);","}",k,'="type" in ',e,"?",p.glTypes,"[",e,".type]:",z,".dtype;",w.normalized,"=!!",e,".normalized;");d("size");d("offset");d("stride");d("divisor");c("}}");c.exit("if(",w.isStream,"){",g,".destroyStream(",z,");","}");return w})});return f}function M(a){var b=a["static"],c=a.dynamic,d={};Object.keys(b).forEach(function(a){var c=b[a];d[a]=D(function(a,b){return"number"===typeof c||
-"boolean"===typeof c?""+c:a.link(c)})});Object.keys(c).forEach(function(a){var b=c[a];d[a]=P(b,function(a,c){return a.invoke(c,b)})});return d}function A(a,b,c,d,e){var f=y(a,e),g=x(a,f,e),h=O(a,e),k=R(a,e),m=E(a,e),ba=g.viewport;ba&&(k.viewport=ba);ba=l("scissor.box");(g=g[ba])&&(k[ba]=g);g=0<Object.keys(k).length;f={framebuffer:f,draw:h,shader:m,state:k,dirty:g};f.profile=B(a,e);f.uniforms=F(c,e);f.attributes=T(b,e);f.context=M(d,e);return f}function ua(a,b,c){var d=a.shared.context,e=a.scope();
-Object.keys(c).forEach(function(f){b.save(d,"."+f);e(d,".",f,"=",c[f].append(a,b),";")});b(e)}function K(a,b,c,d){var e=a.shared,f=e.gl,g=e.framebuffer,h;ha&&(h=b.def(e.extensions,".webgl_draw_buffers"));var k=a.constants,e=k.drawBuffer,k=k.backBuffer;a=c?c.append(a,b):b.def(g,".next");d||b("if(",a,"!==",g,".cur){");b("if(",a,"){",f,".bindFramebuffer(",36160,",",a,".framebuffer);");ha&&b(h,".drawBuffersWEBGL(",e,"[",a,".colorAttachments.length]);");b("}else{",f,".bindFramebuffer(",36160,",null);");
-ha&&b(h,".drawBuffersWEBGL(",k,");");b("}",g,".cur=",a,";");d||b("}")}function V(a,b,c){var d=a.shared,e=d.gl,f=a.current,g=a.next,h=d.current,k=d.next,m=a.cond(h,".dirty");Ka.forEach(function(b){b=l(b);if(!(b in c.state)){var d,w;if(b in g){d=g[b];w=f[b];var I=J(ra[b].length,function(a){return m.def(d,"[",a,"]")});m(a.cond(I.map(function(a,b){return a+"!=="+w+"["+b+"]"}).join("||")).then(e,".",ta[b],"(",I,");",I.map(function(a,b){return w+"["+b+"]="+a}).join(";"),";"))}else d=m.def(k,".",b),I=a.cond(d,
-"!==",h,".",b),m(I),b in sa?I(a.cond(d).then(e,".enable(",sa[b],");")["else"](e,".disable(",sa[b],");"),h,".",b,"=",d,";"):I(e,".",ta[b],"(",d,");",h,".",b,"=",d,";")}});0===Object.keys(c.state).length&&m(h,".dirty=false;");b(m)}function Q(a,b,c,d){var e=a.shared,f=a.current,g=e.current,h=e.gl;vb(Object.keys(c)).forEach(function(e){var k=c[e];if(!d||d(k)){var m=k.append(a,b);if(sa[e]){var l=sa[e];va(k)?m?b(h,".enable(",l,");"):b(h,".disable(",l,");"):b(a.cond(m).then(h,".enable(",l,");")["else"](h,
-".disable(",l,");"));b(g,".",e,"=",m,";")}else if(pa(m)){var n=f[e];b(h,".",ta[e],"(",m,");",m.map(function(a,b){return n+"["+b+"]="+a}).join(";"),";")}else b(h,".",ta[e],"(",m,");",g,".",e,"=",m,";")}})}function wa(a,b){ea&&(a.instancing=b.def(a.shared.extensions,".angle_instanced_arrays"))}function G(a,b,c,d,e){function f(){return"undefined"===typeof performance?"Date.now()":"performance.now()"}function g(a){t=b.def();a(t,"=",f(),";");"string"===typeof e?a(ba,".count+=",e,";"):a(ba,".count++;");
-k&&(d?(r=b.def(),a(r,"=",q,".getNumPendingQueries();")):a(q,".beginQuery(",ba,");"))}function h(a){a(ba,".cpuTime+=",f(),"-",t,";");k&&(d?a(q,".pushScopeStats(",r,",",q,".getNumPendingQueries(),",ba,");"):a(q,".endQuery();"))}function m(a){var c=b.def(n,".profile");b(n,".profile=",a,";");b.exit(n,".profile=",c,";")}var l=a.shared,ba=a.stats,n=l.current,q=l.timer;c=c.profile;var t,r;if(c){if(va(c)){c.enable?(g(b),h(b.exit),m("true")):m("false");return}c=c.append(a,b);m(c)}else c=b.def(n,".profile");
-l=a.block();g(l);b("if(",c,"){",l,"}");a=a.block();h(a);b.exit("if(",c,"){",a,"}")}function U(a,b,c,d,e){function f(a){switch(a){case 35664:case 35667:case 35671:return 2;case 35665:case 35668:case 35672:return 3;case 35666:case 35669:case 35673:return 4;default:return 1}}function g(c,d,e){function f(){b("if(!",z,".buffer){",k,".enableVertexAttribArray(",l,");}");var c=e.type,g;g=e.size?b.def(e.size,"||",d):d;b("if(",z,".type!==",c,"||",z,".size!==",g,"||",q.map(function(a){return z+"."+a+"!=="+e[a]}).join("||"),
-"){",k,".bindBuffer(",34962,",",I,".buffer);",k,".vertexAttribPointer(",[l,g,c,e.normalized,e.stride,e.offset],");",z,".type=",c,";",z,".size=",g,";",q.map(function(a){return z+"."+a+"="+e[a]+";"}).join(""),"}");ea&&(c=e.divisor,b("if(",z,".divisor!==",c,"){",a.instancing,".vertexAttribDivisorANGLE(",[l,c],");",z,".divisor=",c,";}"))}function m(){b("if(",z,".buffer){",k,".disableVertexAttribArray(",l,");","}if(",Da.map(function(a,b){return z+"."+a+"!=="+n[b]}).join("||"),"){",k,".vertexAttrib4f(",
-l,",",n,");",Da.map(function(a,b){return z+"."+a+"="+n[b]+";"}).join(""),"}")}var k=h.gl,l=b.def(c,".location"),z=b.def(h.attributes,"[",l,"]");c=e.state;var I=e.buffer,n=[e.x,e.y,e.z,e.w],q=["buffer","normalized","offset","stride"];1===c?f():2===c?m():(b("if(",c,"===",1,"){"),f(),b("}else{"),m(),b("}"))}var h=a.shared;d.forEach(function(d){var h=d.name,k=c.attributes[h],m;if(k){if(!e(k))return;m=k.append(a,b)}else{if(!e(xb))return;var l=a.scopeAttrib(h);m={};Object.keys(new ya).forEach(function(a){m[a]=
-b.def(l,".",a)})}g(a.link(d),f(d.info.type),m)})}function W(a,c,d,e,f){for(var g=a.shared,h=g.gl,k,m=0;m<e.length;++m){var l=e[m],n=l.name,q=l.info.type,t=d.uniforms[n],l=a.link(l)+".location",r;if(t){if(!f(t))continue;if(va(t)){n=t.value;if(35678===q||35680===q)q=a.link(n._texture||n.color[0]._texture),c(h,".uniform1i(",l,",",q+".bind());"),c.exit(q,".unbind();");else if(35674===q||35675===q||35676===q)n=a.global.def("new Float32Array(["+Array.prototype.slice.call(n)+"])"),t=2,35675===q?t=3:35676===
-q&&(t=4),c(h,".uniformMatrix",t,"fv(",l,",false,",n,");");else{switch(q){case 5126:k="1f";break;case 35664:k="2f";break;case 35665:k="3f";break;case 35666:k="4f";break;case 35670:k="1i";break;case 5124:k="1i";break;case 35671:k="2i";break;case 35667:k="2i";break;case 35672:k="3i";break;case 35668:k="3i";break;case 35673:k="4i";break;case 35669:k="4i"}c(h,".uniform",k,"(",l,",",pa(n)?Array.prototype.slice.call(n):n,");")}continue}else r=t.append(a,c)}else{if(!f(xb))continue;r=c.def(g.uniforms,"[",
-b.id(n),"]")}35678===q?c("if(",r,"&&",r,'._reglType==="framebuffer"){',r,"=",r,".color[0];","}"):35680===q&&c("if(",r,"&&",r,'._reglType==="framebufferCube"){',r,"=",r,".color[0];","}");n=1;switch(q){case 35678:case 35680:q=c.def(r,"._texture");c(h,".uniform1i(",l,",",q,".bind());");c.exit(q,".unbind();");continue;case 5124:case 35670:k="1i";break;case 35667:case 35671:k="2i";n=2;break;case 35668:case 35672:k="3i";n=3;break;case 35669:case 35673:k="4i";n=4;break;case 5126:k="1f";break;case 35664:k=
-"2f";n=2;break;case 35665:k="3f";n=3;break;case 35666:k="4f";n=4;break;case 35674:k="Matrix2fv";break;case 35675:k="Matrix3fv";break;case 35676:k="Matrix4fv"}c(h,".uniform",k,"(",l,",");if("M"===k.charAt(0)){var l=Math.pow(q-35674+2,2),v=a.global.def("new Float32Array(",l,")");c("false,(Array.isArray(",r,")||",r," instanceof Float32Array)?",r,":(",J(l,function(a){return v+"["+a+"]="+r+"["+a+"]"}),",",v,")")}else 1<n?c(J(n,function(a){return r+"["+a+"]"})):c(r);c(");")}}function S(a,b,c,d){function e(f){var g=
-l[f];return g?g.contextDep&&d.contextDynamic||g.propDep?g.append(a,c):g.append(a,b):b.def(m,".",f)}function f(){function a(){c(u,".drawElementsInstancedANGLE(",[q,t,C,r+"<<(("+C+"-5121)>>1)",v],");")}function b(){c(u,".drawArraysInstancedANGLE(",[q,r,t,v],");")}n?da?a():(c("if(",n,"){"),a(),c("}else{"),b(),c("}")):b()}function g(){function a(){c(k+".drawElements("+[q,t,C,r+"<<(("+C+"-5121)>>1)"]+");")}function b(){c(k+".drawArrays("+[q,r,t]+");")}n?da?a():(c("if(",n,"){"),a(),c("}else{"),b(),c("}")):
-b()}var h=a.shared,k=h.gl,m=h.draw,l=d.draw,n=function(){var e=l.elements,f=b;if(e){if(e.contextDep&&d.contextDynamic||e.propDep)f=c;e=e.append(a,f)}else e=f.def(m,".","elements");e&&f("if("+e+")"+k+".bindBuffer(34963,"+e+".buffer.buffer);");return e}(),q=e("primitive"),r=e("offset"),t=function(){var e=l.count,f=b;if(e){if(e.contextDep&&d.contextDynamic||e.propDep)f=c;e=e.append(a,f)}else e=f.def(m,".","count");return e}();if("number"===typeof t){if(0===t)return}else c("if(",t,"){"),c.exit("}");var v,
-u;ea&&(v=e("instances"),u=a.instancing);var C=n+".type",da=l.elements&&va(l.elements);ea&&("number"!==typeof v||0<=v)?"string"===typeof v?(c("if(",v,">0){"),f(),c("}else if(",v,"<0){"),g(),c("}")):f():g()}function ca(a,b,c,d,e){b=N();e=b.proc("body",e);ea&&(b.instancing=e.def(b.shared.extensions,".angle_instanced_arrays"));a(b,e,c,d);return b.compile().body}function L(a,b,c,d){wa(a,b);U(a,b,c,d.attributes,function(){return!0});W(a,b,c,d.uniforms,function(){return!0});S(a,b,b,c)}function da(a,b){var c=
-a.proc("draw",1);wa(a,c);ua(a,c,b.context);K(a,c,b.framebuffer);V(a,c,b);Q(a,c,b.state);G(a,c,b,!1,!0);var d=b.shader.progVar.append(a,c);c(a.shared.gl,".useProgram(",d,".program);");if(b.shader.program)L(a,c,b,b.shader.program);else{var e=a.global.def("{}"),f=c.def(d,".id"),g=c.def(e,"[",f,"]");c(a.cond(g).then(g,".call(this,a0);")["else"](g,"=",e,"[",f,"]=",a.link(function(c){return ca(L,a,b,c,1)}),"(",d,");",g,".call(this,a0);"))}0<Object.keys(b.state).length&&c(a.shared.current,".dirty=true;")}
-function oa(a,b,c,d){function e(){return!0}a.batchId="a1";wa(a,b);U(a,b,c,d.attributes,e);W(a,b,c,d.uniforms,e);S(a,b,b,c)}function za(a,b,c,d){function e(a){return a.contextDep&&g||a.propDep}function f(a){return!e(a)}wa(a,b);var g=c.contextDep,h=b.def(),k=b.def();a.shared.props=k;a.batchId=h;var m=a.scope(),l=a.scope();b(m.entry,"for(",h,"=0;",h,"<","a1",";++",h,"){",k,"=","a0","[",h,"];",l,"}",m.exit);c.needsContext&&ua(a,l,c.context);c.needsFramebuffer&&K(a,l,c.framebuffer);Q(a,l,c.state,e);c.profile&&
-e(c.profile)&&G(a,l,c,!1,!0);d?(U(a,m,c,d.attributes,f),U(a,l,c,d.attributes,e),W(a,m,c,d.uniforms,f),W(a,l,c,d.uniforms,e),S(a,m,l,c)):(b=a.global.def("{}"),d=c.shader.progVar.append(a,l),k=l.def(d,".id"),m=l.def(b,"[",k,"]"),l(a.shared.gl,".useProgram(",d,".program);","if(!",m,"){",m,"=",b,"[",k,"]=",a.link(function(b){return ca(oa,a,c,b,2)}),"(",d,");}",m,".call(this,a0[",h,"],",h,");"))}function ka(a,b){function c(a){return a.contextDep&&e||a.propDep}var d=a.proc("batch",2);a.batchId="0";wa(a,
-d);var e=!1,f=!0;Object.keys(b.context).forEach(function(a){e=e||b.context[a].propDep});e||(ua(a,d,b.context),f=!1);var g=b.framebuffer,h=!1;g?(g.propDep?e=h=!0:g.contextDep&&e&&(h=!0),h||K(a,d,g)):K(a,d,null);b.state.viewport&&b.state.viewport.propDep&&(e=!0);V(a,d,b);Q(a,d,b.state,function(a){return!c(a)});b.profile&&c(b.profile)||G(a,d,b,!1,"a1");b.contextDep=e;b.needsContext=f;b.needsFramebuffer=h;f=b.shader.progVar;if(f.contextDep&&e||f.propDep)za(a,d,b,null);else if(f=f.append(a,d),d(a.shared.gl,
-".useProgram(",f,".program);"),b.shader.program)za(a,d,b,b.shader.program);else{var g=a.global.def("{}"),h=d.def(f,".id"),k=d.def(g,"[",h,"]");d(a.cond(k).then(k,".call(this,a0,a1);")["else"](k,"=",g,"[",h,"]=",a.link(function(c){return ca(za,a,b,c,2)}),"(",f,");",k,".call(this,a0,a1);"))}0<Object.keys(b.state).length&&d(a.shared.current,".dirty=true;")}function ia(a,c){function d(b){var g=c.shader[b];g&&e.set(f.shader,"."+b,g.append(a,e))}var e=a.proc("scope",3);a.batchId="a2";var f=a.shared,g=f.current;
-ua(a,e,c.context);c.framebuffer&&c.framebuffer.append(a,e);vb(Object.keys(c.state)).forEach(function(b){var d=c.state[b].append(a,e);pa(d)?d.forEach(function(c,d){e.set(a.next[b],"["+d+"]",c)}):e.set(f.next,"."+b,d)});G(a,e,c,!0,!0);["elements","offset","count","instances","primitive"].forEach(function(b){var d=c.draw[b];d&&e.set(f.draw,"."+b,""+d.append(a,e))});Object.keys(c.uniforms).forEach(function(d){e.set(f.uniforms,"["+b.id(d)+"]",c.uniforms[d].append(a,e))});Object.keys(c.attributes).forEach(function(b){var d=
-c.attributes[b].append(a,e),f=a.scopeAttrib(b);Object.keys(new ya).forEach(function(a){e.set(f,"."+a,d[a])})});d("vert");d("frag");0<Object.keys(c.state).length&&(e(g,".dirty=true;"),e.exit(g,".dirty=true;"));e("a1(",a.shared.context,",a0,",a.batchId,");")}function ma(a){if("object"===typeof a&&!pa(a)){for(var b=Object.keys(a),c=0;c<b.length;++c)if(la.isDynamic(a[b[c]]))return!0;return!1}}function ja(a,b,c){function d(a,b){g.forEach(function(c){var d=e[c];la.isDynamic(d)&&(d=a.invoke(b,d),b(l,".",
-c,"=",d,";"))})}var e=b["static"][c];if(e&&ma(e)){var f=a.global,g=Object.keys(e),h=!1,k=!1,m=!1,l=a.global.def("{}");g.forEach(function(b){var c=e[b];if(la.isDynamic(c))"function"===typeof c&&(c=e[b]=la.unbox(c)),b=P(c,null),h=h||b.thisDep,m=m||b.propDep,k=k||b.contextDep;else{f(l,".",b,"=");switch(typeof c){case "number":f(c);break;case "string":f('"',c,'"');break;case "object":Array.isArray(c)&&f("[",c.join(),"]");break;default:f(a.link(c))}f(";")}});b.dynamic[c]=new la.DynamicVariable(4,{thisDep:h,
-contextDep:k,propDep:m,ref:l,append:d});delete b["static"][c]}}var ya=q.Record,X={add:32774,subtract:32778,"reverse subtract":32779};c.ext_blend_minmax&&(X.min=32775,X.max=32776);var ea=c.angle_instanced_arrays,ha=c.webgl_draw_buffers,ra={dirty:!0,profile:h.profile},Fa={},Ka=[],sa={},ta={};u("dither",3024);u("blend.enable",3042);v("blend.color","blendColor",[0,0,0,0]);v("blend.equation","blendEquationSeparate",[32774,32774]);v("blend.func","blendFuncSeparate",[1,0,1,0]);u("depth.enable",2929,!0);
-v("depth.func","depthFunc",513);v("depth.range","depthRange",[0,1]);v("depth.mask","depthMask",!0);v("colorMask","colorMask",[!0,!0,!0,!0]);u("cull.enable",2884);v("cull.face","cullFace",1029);v("frontFace","frontFace",2305);v("lineWidth","lineWidth",1);u("polygonOffset.enable",32823);v("polygonOffset.offset","polygonOffset",[0,0]);u("sample.alpha",32926);u("sample.enable",32928);v("sample.coverage","sampleCoverage",[1,!1]);u("stencil.enable",2960);v("stencil.mask","stencilMask",-1);v("stencil.func",
-"stencilFunc",[519,0,-1]);v("stencil.opFront","stencilOpSeparate",[1028,7680,7680,7680]);v("stencil.opBack","stencilOpSeparate",[1029,7680,7680,7680]);u("scissor.enable",3089);v("scissor.box","scissor",[0,0,a.drawingBufferWidth,a.drawingBufferHeight]);v("viewport","viewport",[0,0,a.drawingBufferWidth,a.drawingBufferHeight]);var na={gl:a,context:C,strings:b,next:Fa,current:ra,draw:m,elements:d,buffer:g,shader:t,attributes:q.state,uniforms:r,framebuffer:f,extensions:c,timer:k,isBufferArgs:Oa},aa={primTypes:Sa,
-compareFuncs:Xa,blendFuncs:Ga,blendEquations:X,stencilOps:Pa,glTypes:Ra,orientationType:wb};ha&&(aa.backBuffer=[1029],aa.drawBuffer=J(e.maxDrawbuffers,function(a){return 0===a?[0]:J(a,function(a){return 36064+a})}));var qa=0;return{next:Fa,current:ra,procs:function(){var a=N(),b=a.proc("poll"),c=a.proc("refresh"),d=a.block();b(d);c(d);var f=a.shared,g=f.gl,h=f.next,k=f.current;d(k,".dirty=false;");K(a,b);K(a,c,null,!0);var m;ea&&(m=a.link(ea));for(var l=0;l<e.maxAttributes;++l){var n=c.def(f.attributes,
-"[",l,"]"),q=a.cond(n,".buffer");q.then(g,".enableVertexAttribArray(",l,");",g,".bindBuffer(",34962,",",n,".buffer.buffer);",g,".vertexAttribPointer(",l,",",n,".size,",n,".type,",n,".normalized,",n,".stride,",n,".offset);")["else"](g,".disableVertexAttribArray(",l,");",g,".vertexAttrib4f(",l,",",n,".x,",n,".y,",n,".z,",n,".w);",n,".buffer=null;");c(q);ea&&c(m,".vertexAttribDivisorANGLE(",l,",",n,".divisor);")}Object.keys(sa).forEach(function(e){var f=sa[e],m=d.def(h,".",e),l=a.block();l("if(",m,"){",
-g,".enable(",f,")}else{",g,".disable(",f,")}",k,".",e,"=",m,";");c(l);b("if(",m,"!==",k,".",e,"){",l,"}")});Object.keys(ta).forEach(function(e){var f=ta[e],m=ra[e],l,n,q=a.block();q(g,".",f,"(");pa(m)?(f=m.length,l=a.global.def(h,".",e),n=a.global.def(k,".",e),q(J(f,function(a){return l+"["+a+"]"}),");",J(f,function(a){return n+"["+a+"]="+l+"["+a+"];"}).join("")),b("if(",J(f,function(a){return l+"["+a+"]!=="+n+"["+a+"]"}).join("||"),"){",q,"}")):(l=d.def(h,".",e),n=d.def(k,".",e),q(l,");",k,".",e,
-"=",l,";"),b("if(",l,"!==",n,"){",q,"}"));c(q)});return a.compile()}(),compile:function(a,b,c,d,e){var f=N();f.stats=f.link(e);Object.keys(b["static"]).forEach(function(a){ja(f,b,a)});Ub.forEach(function(b){ja(f,a,b)});c=A(a,b,c,d,f);da(f,c);ia(f,c);ka(f,c);return f.compile()}}}function yb(a,b){for(var c=0;c<a.length;++c)if(a[c]===b)return c;return-1}var E=function(a,b){for(var c=Object.keys(b),e=0;e<c.length;++e)a[c[e]]=b[c[e]];return a},Ab=0,la={DynamicVariable:aa,define:function(a,b){return new aa(a,
-Za(b+""))},isDynamic:function(a){return"function"===typeof a&&!a._reglType||a instanceof aa},unbox:function(a,b){return"function"===typeof a?new aa(0,a):a},accessor:Za},Ya={next:"function"===typeof requestAnimationFrame?function(a){return requestAnimationFrame(a)}:function(a){return setTimeout(a,16)},cancel:"function"===typeof cancelAnimationFrame?function(a){return cancelAnimationFrame(a)}:clearTimeout},zb="undefined"!==typeof performance&&performance.now?function(){return performance.now()}:function(){return+new Date},
-x=cb();x.zero=cb();var Vb=function(a,b){var c=1;b.ext_texture_filter_anisotropic&&(c=a.getParameter(34047));var e=1,g=1;b.webgl_draw_buffers&&(e=a.getParameter(34852),g=a.getParameter(36063));var d=!!b.oes_texture_float;if(d){d=a.createTexture();a.bindTexture(3553,d);a.texImage2D(3553,0,6408,1,1,0,6408,5126,null);var n=a.createFramebuffer();a.bindFramebuffer(36160,n);a.framebufferTexture2D(36160,36064,3553,d,0);a.bindTexture(3553,null);if(36053!==a.checkFramebufferStatus(36160))d=!1;else{a.viewport(0,
-0,1,1);a.clearColor(1,0,0,1);a.clear(16384);var f=x.allocType(5126,4);a.readPixels(0,0,1,1,6408,5126,f);a.getError()?d=!1:(a.deleteFramebuffer(n),a.deleteTexture(d),d=1===f[0]);x.freeType(f)}}f=!0;f=a.createTexture();n=x.allocType(5121,36);a.activeTexture(33984);a.bindTexture(34067,f);a.texImage2D(34069,0,6408,3,3,0,6408,5121,n);x.freeType(n);a.bindTexture(34067,null);a.deleteTexture(f);f=!a.getError();return{colorBits:[a.getParameter(3410),a.getParameter(3411),a.getParameter(3412),a.getParameter(3413)],
-depthBits:a.getParameter(3414),stencilBits:a.getParameter(3415),subpixelBits:a.getParameter(3408),extensions:Object.keys(b).filter(function(a){return!!b[a]}),maxAnisotropic:c,maxDrawbuffers:e,maxColorAttachments:g,pointSizeDims:a.getParameter(33901),lineWidthDims:a.getParameter(33902),maxViewportDims:a.getParameter(3386),maxCombinedTextureUnits:a.getParameter(35661),maxCubeMapSize:a.getParameter(34076),maxRenderbufferSize:a.getParameter(34024),maxTextureUnits:a.getParameter(34930),maxTextureSize:a.getParameter(3379),
-maxAttributes:a.getParameter(34921),maxVertexUniforms:a.getParameter(36347),maxVertexTextureUnits:a.getParameter(35660),maxVaryingVectors:a.getParameter(36348),maxFragmentUniforms:a.getParameter(36349),glsl:a.getParameter(35724),renderer:a.getParameter(7937),vendor:a.getParameter(7936),version:a.getParameter(7938),readFloat:d,npotTextureCube:f}},M=function(a){return a instanceof Uint8Array||a instanceof Uint16Array||a instanceof Uint32Array||a instanceof Int8Array||a instanceof Int16Array||a instanceof
-Int32Array||a instanceof Float32Array||a instanceof Float64Array||a instanceof Uint8ClampedArray},S=function(a){return Object.keys(a).map(function(b){return a[b]})},Ma={shape:function(a){for(var b=[];a.length;a=a[0])b.push(a.length);return b},flatten:function(a,b,c,e){var g=1;if(b.length)for(var d=0;d<b.length;++d)g*=b[d];else g=0;c=e||x.allocType(c,g);switch(b.length){case 0:break;case 1:e=b[0];for(b=0;b<e;++b)c[b]=a[b];break;case 2:e=b[0];b=b[1];for(d=g=0;d<e;++d)for(var n=a[d],f=0;f<b;++f)c[g++]=
-n[f];break;case 3:db(a,b[0],b[1],b[2],c,0);break;default:eb(a,b,0,c,0)}return c}},Ia={"[object Int8Array]":5120,"[object Int16Array]":5122,"[object Int32Array]":5124,"[object Uint8Array]":5121,"[object Uint8ClampedArray]":5121,"[object Uint16Array]":5123,"[object Uint32Array]":5125,"[object Float32Array]":5126,"[object Float64Array]":5121,"[object ArrayBuffer]":5121},Ra={int8:5120,int16:5122,int32:5124,uint8:5121,uint16:5123,uint32:5125,"float":5126,float32:5126},jb={dynamic:35048,stream:35040,"static":35044},
-Qa=Ma.flatten,hb=Ma.shape,ja=[];ja[5120]=1;ja[5122]=2;ja[5124]=4;ja[5121]=1;ja[5123]=2;ja[5125]=4;ja[5126]=4;var Sa={points:0,point:0,lines:1,line:1,triangles:4,triangle:4,"line loop":2,"line strip":3,"triangle strip":5,"triangle fan":6},lb=new Float32Array(1),Ib=new Uint32Array(lb.buffer),Mb=[9984,9986,9985,9987],La=[0,6409,6410,6407,6408],L={};L[6409]=L[6406]=L[6402]=1;L[34041]=L[6410]=2;L[6407]=L[35904]=3;L[6408]=L[35906]=4;var Ua=Ea("HTMLCanvasElement"),pb=Ea("CanvasRenderingContext2D"),qb=Ea("ImageBitmap"),
-rb=Ea("HTMLImageElement"),sb=Ea("HTMLVideoElement"),Jb=Object.keys(Ia).concat([Ua,pb,qb,rb,sb]),qa=[];qa[5121]=1;qa[5126]=4;qa[36193]=2;qa[5123]=2;qa[5125]=4;var y=[];y[32854]=2;y[32855]=2;y[36194]=2;y[34041]=4;y[33776]=.5;y[33777]=.5;y[33778]=1;y[33779]=1;y[35986]=.5;y[35987]=1;y[34798]=1;y[35840]=.5;y[35841]=.25;y[35842]=.5;y[35843]=.25;y[36196]=.5;var Q=[];Q[32854]=2;Q[32855]=2;Q[36194]=2;Q[33189]=2;Q[36168]=1;Q[34041]=4;Q[35907]=4;Q[34836]=16;Q[34842]=8;Q[34843]=6;var Wb=function(a,b,c,e,g){function d(a){this.id=
-q++;this.refCount=1;this.renderbuffer=a;this.format=32854;this.height=this.width=0;g.profile&&(this.stats={size:0})}function n(b){var c=b.renderbuffer;a.bindRenderbuffer(36161,null);a.deleteRenderbuffer(c);b.renderbuffer=null;b.refCount=0;delete t[b.id];e.renderbufferCount--}var f={rgba4:32854,rgb565:36194,"rgb5 a1":32855,depth:33189,stencil:36168,"depth stencil":34041};b.ext_srgb&&(f.srgba=35907);b.ext_color_buffer_half_float&&(f.rgba16f=34842,f.rgb16f=34843);b.webgl_color_buffer_float&&(f.rgba32f=
-34836);var r=[];Object.keys(f).forEach(function(a){r[f[a]]=a});var q=0,t={};d.prototype.decRef=function(){0>=--this.refCount&&n(this)};g.profile&&(e.getTotalRenderbufferSize=function(){var a=0;Object.keys(t).forEach(function(b){a+=t[b].stats.size});return a});return{create:function(b,c){function k(b,c){var d=0,e=0,m=32854;"object"===typeof b&&b?("shape"in b?(e=b.shape,d=e[0]|0,e=e[1]|0):("radius"in b&&(d=e=b.radius|0),"width"in b&&(d=b.width|0),"height"in b&&(e=b.height|0)),"format"in b&&(m=f[b.format])):
-"number"===typeof b?(d=b|0,e="number"===typeof c?c|0:d):b||(d=e=1);if(d!==h.width||e!==h.height||m!==h.format)return k.width=h.width=d,k.height=h.height=e,h.format=m,a.bindRenderbuffer(36161,h.renderbuffer),a.renderbufferStorage(36161,m,d,e),g.profile&&(h.stats.size=Q[h.format]*h.width*h.height),k.format=r[h.format],k}var h=new d(a.createRenderbuffer());t[h.id]=h;e.renderbufferCount++;k(b,c);k.resize=function(b,c){var d=b|0,e=c|0||d;if(d===h.width&&e===h.height)return k;k.width=h.width=d;k.height=
-h.height=e;a.bindRenderbuffer(36161,h.renderbuffer);a.renderbufferStorage(36161,h.format,d,e);g.profile&&(h.stats.size=Q[h.format]*h.width*h.height);return k};k._reglType="renderbuffer";k._renderbuffer=h;g.profile&&(k.stats=h.stats);k.destroy=function(){h.decRef()};return k},clear:function(){S(t).forEach(n)},restore:function(){S(t).forEach(function(b){b.renderbuffer=a.createRenderbuffer();a.bindRenderbuffer(36161,b.renderbuffer);a.renderbufferStorage(36161,b.format,b.width,b.height)});a.bindRenderbuffer(36161,
-null)}}},Wa=[];Wa[6408]=4;Wa[6407]=3;var Na=[];Na[5121]=1;Na[5126]=4;Na[36193]=2;var Da=["x","y","z","w"],Ub="blend.func blend.equation stencil.func stencil.opFront stencil.opBack sample.coverage viewport scissor.box polygonOffset.offset".split(" "),Ga={0:0,1:1,zero:0,one:1,"src color":768,"one minus src color":769,"src alpha":770,"one minus src alpha":771,"dst color":774,"one minus dst color":775,"dst alpha":772,"one minus dst alpha":773,"constant color":32769,"one minus constant color":32770,"constant alpha":32771,
-"one minus constant alpha":32772,"src alpha saturate":776},Xa={never:512,less:513,"<":513,equal:514,"=":514,"==":514,"===":514,lequal:515,"<=":515,greater:516,">":516,notequal:517,"!=":517,"!==":517,gequal:518,">=":518,always:519},Pa={0:0,zero:0,keep:7680,replace:7681,increment:7682,decrement:7683,"increment wrap":34055,"decrement wrap":34056,invert:5386},wb={cw:2304,ccw:2305},xb=new Z(!1,!1,!1,function(){}),Xb=function(a,b){function c(){this.endQueryIndex=this.startQueryIndex=-1;this.sum=0;this.stats=
-null}function e(a,b,d){var e=n.pop()||new c;e.startQueryIndex=a;e.endQueryIndex=b;e.sum=0;e.stats=d;f.push(e)}if(!b.ext_disjoint_timer_query)return null;var g=[],d=[],n=[],f=[],r=[],q=[];return{beginQuery:function(a){var c=g.pop()||b.ext_disjoint_timer_query.createQueryEXT();b.ext_disjoint_timer_query.beginQueryEXT(35007,c);d.push(c);e(d.length-1,d.length,a)},endQuery:function(){b.ext_disjoint_timer_query.endQueryEXT(35007)},pushScopeStats:e,update:function(){var a,c;a=d.length;if(0!==a){q.length=
-Math.max(q.length,a+1);r.length=Math.max(r.length,a+1);r[0]=0;var e=q[0]=0;for(c=a=0;c<d.length;++c){var k=d[c];b.ext_disjoint_timer_query.getQueryObjectEXT(k,34919)?(e+=b.ext_disjoint_timer_query.getQueryObjectEXT(k,34918),g.push(k)):d[a++]=k;r[c+1]=e;q[c+1]=a}d.length=a;for(c=a=0;c<f.length;++c){var e=f[c],h=e.startQueryIndex,k=e.endQueryIndex;e.sum+=r[k]-r[h];h=q[h];k=q[k];k===h?(e.stats.gpuTime+=e.sum/1E6,n.push(e)):(e.startQueryIndex=h,e.endQueryIndex=k,f[a++]=e)}f.length=a}},getNumPendingQueries:function(){return d.length},
-clear:function(){g.push.apply(g,d);for(var a=0;a<g.length;a++)b.ext_disjoint_timer_query.deleteQueryEXT(g[a]);d.length=0;g.length=0},restore:function(){d.length=0;g.length=0}}};return function(a){function b(){if(0===G.length)B&&B.update(),ca=null;else{ca=Ya.next(b);t();for(var a=G.length-1;0<=a;--a){var c=G[a];c&&c(O,null,0)}k.flush();B&&B.update()}}function c(){!ca&&0<G.length&&(ca=Ya.next(b))}function e(){ca&&(Ya.cancel(b),ca=null)}function g(a){a.preventDefault();e();U.forEach(function(a){a()})}
-function d(a){k.getError();l.restore();Q.restore();F.restore();A.restore();M.restore();K.restore();B&&B.restore();V.procs.refresh();c();W.forEach(function(a){a()})}function n(a){function b(a){var c={},d={};Object.keys(a).forEach(function(b){var e=a[b];la.isDynamic(e)?d[b]=la.unbox(e,b):c[b]=e});return{dynamic:d,"static":c}}function c(a){for(;m.length<a;)m.push(null);return m}var d=b(a.context||{}),e=b(a.uniforms||{}),f=b(a.attributes||{}),g=b(function(a){function b(a){if(a in c){var d=c[a];delete c[a];
-Object.keys(d).forEach(function(b){c[a+"."+b]=d[b]})}}var c=E({},a);delete c.uniforms;delete c.attributes;delete c.context;"stencil"in c&&c.stencil.op&&(c.stencil.opBack=c.stencil.opFront=c.stencil.op,delete c.stencil.op);b("blend");b("depth");b("cull");b("stencil");b("polygonOffset");b("scissor");b("sample");return c}(a));a={gpuTime:0,cpuTime:0,count:0};var d=V.compile(g,f,e,d,a),h=d.draw,k=d.batch,l=d.scope,m=[];return E(function(a,b){var d;if("function"===typeof a)return l.call(this,null,a,0);
-if("function"===typeof b)if("number"===typeof a)for(d=0;d<a;++d)l.call(this,null,b,d);else if(Array.isArray(a))for(d=0;d<a.length;++d)l.call(this,a[d],b,d);else return l.call(this,a,b,0);else if("number"===typeof a){if(0<a)return k.call(this,c(a|0),a|0)}else if(Array.isArray(a)){if(a.length)return k.call(this,a,a.length)}else return h.call(this,a)},{stats:a})}function f(a,b){var c=0;V.procs.poll();var d=b.color;d&&(k.clearColor(+d[0]||0,+d[1]||0,+d[2]||0,+d[3]||0),c|=16384);"depth"in b&&(k.clearDepth(+b.depth),
-c|=256);"stencil"in b&&(k.clearStencil(b.stencil|0),c|=1024);k.clear(c)}function r(a){G.push(a);c();return{cancel:function(){function b(){var a=yb(G,b);G[a]=G[G.length-1];--G.length;0>=G.length&&e()}var c=yb(G,a);G[c]=b}}}function q(){var a=S.viewport,b=S.scissor_box;a[0]=a[1]=b[0]=b[1]=0;O.viewportWidth=O.framebufferWidth=O.drawingBufferWidth=a[2]=b[2]=k.drawingBufferWidth;O.viewportHeight=O.framebufferHeight=O.drawingBufferHeight=a[3]=b[3]=k.drawingBufferHeight}function t(){O.tick+=1;O.time=y();
-q();V.procs.poll()}function m(){q();V.procs.refresh();B&&B.update()}function y(){return(zb()-D)/1E3}a=Eb(a);if(!a)return null;var k=a.gl,h=k.getContextAttributes();k.isContextLost();var l=Fb(k,a);if(!l)return null;var u=Bb(),v={bufferCount:0,elementsCount:0,framebufferCount:0,shaderCount:0,textureCount:0,cubeCount:0,renderbufferCount:0,maxTextureUnits:0},x=l.extensions,B=Xb(k,x),D=zb(),J=k.drawingBufferWidth,P=k.drawingBufferHeight,O={tick:0,time:0,viewportWidth:J,viewportHeight:P,framebufferWidth:J,
-framebufferHeight:P,drawingBufferWidth:J,drawingBufferHeight:P,pixelRatio:a.pixelRatio},R=Vb(k,x),J=Pb(k,x,R,u),F=Gb(k,v,a,J),T=Hb(k,x,F,v),Q=Qb(k,u,v,a),A=Kb(k,x,R,function(){V.procs.poll()},O,v,a),M=Wb(k,x,R,v,a),K=Ob(k,x,R,A,M,v),V=Tb(k,u,x,R,F,T,A,K,{},J,Q,{elements:null,primitive:4,count:-1,offset:0,instances:-1},O,B,a),u=Rb(k,K,V.procs.poll,O,h,x,R),S=V.next,L=k.canvas,G=[],U=[],W=[],Z=[a.onDestroy],ca=null;L&&(L.addEventListener("webglcontextlost",g,!1),L.addEventListener("webglcontextrestored",
-d,!1));var aa=K.setFBO=n({framebuffer:la.define.call(null,1,"framebuffer")});m();h=E(n,{clear:function(a){if("framebuffer"in a)if(a.framebuffer&&"framebufferCube"===a.framebuffer_reglType)for(var b=0;6>b;++b)aa(E({framebuffer:a.framebuffer.faces[b]},a),f);else aa(a,f);else f(null,a)},prop:la.define.bind(null,1),context:la.define.bind(null,2),"this":la.define.bind(null,3),draw:n({}),buffer:function(a){return F.create(a,34962,!1,!1)},elements:function(a){return T.create(a,!1)},texture:A.create2D,cube:A.createCube,
-renderbuffer:M.create,framebuffer:K.create,framebufferCube:K.createCube,attributes:h,frame:r,on:function(a,b){var c;switch(a){case "frame":return r(b);case "lost":c=U;break;case "restore":c=W;break;case "destroy":c=Z}c.push(b);return{cancel:function(){for(var a=0;a<c.length;++a)if(c[a]===b){c[a]=c[c.length-1];c.pop();break}}}},limits:R,hasExtension:function(a){return 0<=R.extensions.indexOf(a.toLowerCase())},read:u,destroy:function(){G.length=0;e();L&&(L.removeEventListener("webglcontextlost",g),
-L.removeEventListener("webglcontextrestored",d));Q.clear();K.clear();M.clear();A.clear();T.clear();F.clear();B&&B.clear();Z.forEach(function(a){a()})},_gl:k,_refresh:m,poll:function(){t();B&&B.update()},now:y,stats:v});a.onDone(null,h);return h}});
+(function(U,X){"object"===typeof exports&&"undefined"!==typeof module?module.exports=X():"function"===typeof define&&define.amd?define(X):U.createREGL=X()})(this,function(){function U(a,b){this.id=Eb++;this.type=a;this.data=b}function X(a){if(0===a.length)return[];var b=a.charAt(0),c=a.charAt(a.length-1);if(1<a.length&&b===c&&('"'===b||"'"===b))return['"'+a.substr(1,a.length-2).replace(/\\/g,"\\\\").replace(/"/g,'\\"')+'"'];if(b=/\[(false|true|null|\d+|'[^']*'|"[^"]*")\]/.exec(a))return X(a.substr(0,
+b.index)).concat(X(b[1])).concat(X(a.substr(b.index+b[0].length)));b=a.split(".");if(1===b.length)return['"'+a.replace(/\\/g,"\\\\").replace(/"/g,'\\"')+'"'];a=[];for(c=0;c<b.length;++c)a=a.concat(X(b[c]));return a}function cb(a){return"["+X(a).join("][")+"]"}function db(a,b){if("function"===typeof a)return new U(0,a);if("number"===typeof a||"boolean"===typeof a)return new U(5,a);if(Array.isArray(a))return new U(6,a.map(function(a,e){return db(a,b+"["+e+"]")}));if(a instanceof U)return a}function Fb(){var a=
+{"":0},b=[""];return{id:function(c){var e=a[c];if(e)return e;e=a[c]=b.length;b.push(c);return e},str:function(a){return b[a]}}}function Gb(a,b,c){function e(){var b=window.innerWidth,e=window.innerHeight;a!==document.body&&(e=a.getBoundingClientRect(),b=e.right-e.left,e=e.bottom-e.top);f.width=c*b;f.height=c*e;A(f.style,{width:b+"px",height:e+"px"})}var f=document.createElement("canvas");A(f.style,{border:0,margin:0,padding:0,top:0,left:0});a.appendChild(f);a===document.body&&(f.style.position="absolute",
+A(a.style,{margin:0,padding:0}));var d;a!==document.body&&"function"===typeof ResizeObserver?(d=new ResizeObserver(function(){setTimeout(e)}),d.observe(a)):window.addEventListener("resize",e,!1);e();return{canvas:f,onDestroy:function(){d?d.disconnect():window.removeEventListener("resize",e);a.removeChild(f)}}}function Hb(a,b){function c(c){try{return a.getContext(c,b)}catch(f){return null}}return c("webgl")||c("experimental-webgl")||c("webgl-experimental")}function eb(a){return"string"===typeof a?
+a.split():a}function fb(a){return"string"===typeof a?document.querySelector(a):a}function Ib(a){var b=a||{},c,e,f,d;a={};var p=[],n=[],u="undefined"===typeof window?1:window.devicePixelRatio,t=!1,w=function(a){},k=function(){};"string"===typeof b?c=document.querySelector(b):"object"===typeof b&&("string"===typeof b.nodeName&&"function"===typeof b.appendChild&&"function"===typeof b.getBoundingClientRect?c=b:"function"===typeof b.drawArrays||"function"===typeof b.drawElements?(d=b,f=d.canvas):("gl"in
+b?d=b.gl:"canvas"in b?f=fb(b.canvas):"container"in b&&(e=fb(b.container)),"attributes"in b&&(a=b.attributes),"extensions"in b&&(p=eb(b.extensions)),"optionalExtensions"in b&&(n=eb(b.optionalExtensions)),"onDone"in b&&(w=b.onDone),"profile"in b&&(t=!!b.profile),"pixelRatio"in b&&(u=+b.pixelRatio)));c&&("canvas"===c.nodeName.toLowerCase()?f=c:e=c);if(!d){if(!f){c=Gb(e||document.body,w,u);if(!c)return null;f=c.canvas;k=c.onDestroy}void 0===a.premultipliedAlpha&&(a.premultipliedAlpha=!0);d=Hb(f,a)}return d?
+{gl:d,canvas:f,container:e,extensions:p,optionalExtensions:n,pixelRatio:u,profile:t,onDone:w,onDestroy:k}:(k(),w("webgl not supported, try upgrading your browser or graphics drivers http://get.webgl.org"),null)}function Jb(a,b){function c(b){b=b.toLowerCase();var c;try{c=e[b]=a.getExtension(b)}catch(f){}return!!c}for(var e={},f=0;f<b.extensions.length;++f){var d=b.extensions[f];if(!c(d))return b.onDestroy(),b.onDone('"'+d+'" extension is not supported by the current WebGL context, try upgrading your system or a different browser'),
+null}b.optionalExtensions.forEach(c);return{extensions:e,restore:function(){Object.keys(e).forEach(function(a){if(e[a]&&!c(a))throw Error("(regl): error restoring extension "+a);})}}}function J(a,b){for(var c=Array(a),e=0;e<a;++e)c[e]=b(e);return c}function gb(a){var b,c;b=(65535<a)<<4;a>>>=b;c=(255<a)<<3;a>>>=c;b|=c;c=(15<a)<<2;a>>>=c;b|=c;c=(3<a)<<1;return b|c|a>>>c>>1}function hb(){function a(a){a:{for(var b=16;268435456>=b;b*=16)if(a<=b){a=b;break a}a=0}b=c[gb(a)>>2];return 0<b.length?b.pop():
+new ArrayBuffer(a)}function b(a){c[gb(a.byteLength)>>2].push(a)}var c=J(8,function(){return[]});return{alloc:a,free:b,allocType:function(b,c){var d=null;switch(b){case 5120:d=new Int8Array(a(c),0,c);break;case 5121:d=new Uint8Array(a(c),0,c);break;case 5122:d=new Int16Array(a(2*c),0,c);break;case 5123:d=new Uint16Array(a(2*c),0,c);break;case 5124:d=new Int32Array(a(4*c),0,c);break;case 5125:d=new Uint32Array(a(4*c),0,c);break;case 5126:d=new Float32Array(a(4*c),0,c);break;default:return null}return d.length!==
+c?d.subarray(0,c):d},freeType:function(a){b(a.buffer)}}}function da(a){return!!a&&"object"===typeof a&&Array.isArray(a.shape)&&Array.isArray(a.stride)&&"number"===typeof a.offset&&a.shape.length===a.stride.length&&(Array.isArray(a.data)||M(a.data))}function ib(a,b,c,e,f,d){for(var p=0;p<b;++p)for(var n=a[p],u=0;u<c;++u)for(var t=n[u],w=0;w<e;++w)f[d++]=t[w]}function jb(a,b,c,e,f){for(var d=1,p=c+1;p<b.length;++p)d*=b[p];var n=b[c];if(4===b.length-c){var u=b[c+1],t=b[c+2];b=b[c+3];for(p=0;p<n;++p)ib(a[p],
+u,t,b,e,f),f+=d}else for(p=0;p<n;++p)jb(a[p],b,c+1,e,f),f+=d}function Fa(a){return Ga[Object.prototype.toString.call(a)]|0}function kb(a,b){for(var c=0;c<b.length;++c)a[c]=b[c]}function lb(a,b,c,e,f,d,p){for(var n=0,u=0;u<c;++u)for(var t=0;t<e;++t)a[n++]=b[f*u+d*t+p]}function Kb(a,b,c,e){function f(b){this.id=u++;this.buffer=a.createBuffer();this.type=b;this.usage=35044;this.byteLength=0;this.dimension=1;this.dtype=5121;this.persistentData=null;c.profile&&(this.stats={size:0})}function d(b,c,l){b.byteLength=
+c.byteLength;a.bufferData(b.type,c,l)}function p(a,b,c,h,g,q){a.usage=c;if(Array.isArray(b)){if(a.dtype=h||5126,0<b.length)if(Array.isArray(b[0])){g=mb(b);for(var r=h=1;r<g.length;++r)h*=g[r];a.dimension=h;b=Sa(b,g,a.dtype);d(a,b,c);q?a.persistentData=b:E.freeType(b)}else"number"===typeof b[0]?(a.dimension=g,g=E.allocType(a.dtype,b.length),kb(g,b),d(a,g,c),q?a.persistentData=g:E.freeType(g)):M(b[0])&&(a.dimension=b[0].length,a.dtype=h||Fa(b[0])||5126,b=Sa(b,[b.length,b[0].length],a.dtype),d(a,b,c),
+q?a.persistentData=b:E.freeType(b))}else if(M(b))a.dtype=h||Fa(b),a.dimension=g,d(a,b,c),q&&(a.persistentData=new Uint8Array(new Uint8Array(b.buffer)));else if(da(b)){g=b.shape;var m=b.stride,r=b.offset,e=0,f=0,t=0,n=0;1===g.length?(e=g[0],f=1,t=m[0],n=0):2===g.length&&(e=g[0],f=g[1],t=m[0],n=m[1]);a.dtype=h||Fa(b.data)||5126;a.dimension=f;g=E.allocType(a.dtype,e*f);lb(g,b.data,e,f,t,n,r);d(a,g,c);q?a.persistentData=g:E.freeType(g)}else b instanceof ArrayBuffer&&(a.dtype=5121,a.dimension=g,d(a,b,
+c),q&&(a.persistentData=new Uint8Array(new Uint8Array(b))))}function n(c){b.bufferCount--;e(c);a.deleteBuffer(c.buffer);c.buffer=null;delete t[c.id]}var u=0,t={};f.prototype.bind=function(){a.bindBuffer(this.type,this.buffer)};f.prototype.destroy=function(){n(this)};var w=[];c.profile&&(b.getTotalBufferSize=function(){var a=0;Object.keys(t).forEach(function(b){a+=t[b].stats.size});return a});return{create:function(k,e,d,h){function g(b){var m=35044,k=null,e=0,d=0,f=1;Array.isArray(b)||M(b)||da(b)||
+b instanceof ArrayBuffer?k=b:"number"===typeof b?e=b|0:b&&("data"in b&&(k=b.data),"usage"in b&&(m=ob[b.usage]),"type"in b&&(d=Ia[b.type]),"dimension"in b&&(f=b.dimension|0),"length"in b&&(e=b.length|0));q.bind();k?p(q,k,m,d,f,h):(e&&a.bufferData(q.type,e,m),q.dtype=d||5121,q.usage=m,q.dimension=f,q.byteLength=e);c.profile&&(q.stats.size=q.byteLength*ha[q.dtype]);return g}b.bufferCount++;var q=new f(e);t[q.id]=q;d||g(k);g._reglType="buffer";g._buffer=q;g.subdata=function(b,c){var k=(c||0)|0,e;q.bind();
+if(M(b)||b instanceof ArrayBuffer)a.bufferSubData(q.type,k,b);else if(Array.isArray(b)){if(0<b.length)if("number"===typeof b[0]){var h=E.allocType(q.dtype,b.length);kb(h,b);a.bufferSubData(q.type,k,h);E.freeType(h)}else if(Array.isArray(b[0])||M(b[0]))e=mb(b),h=Sa(b,e,q.dtype),a.bufferSubData(q.type,k,h),E.freeType(h)}else if(da(b)){e=b.shape;var d=b.stride,f=h=0,l=0,O=0;1===e.length?(h=e[0],f=1,l=d[0],O=0):2===e.length&&(h=e[0],f=e[1],l=d[0],O=d[1]);e=Array.isArray(b.data)?q.dtype:Fa(b.data);e=E.allocType(e,
+h*f);lb(e,b.data,h,f,l,O,b.offset);a.bufferSubData(q.type,k,e);E.freeType(e)}return g};c.profile&&(g.stats=q.stats);g.destroy=function(){n(q)};return g},createStream:function(a,b){var c=w.pop();c||(c=new f(a));c.bind();p(c,b,35040,0,1,!1);return c},destroyStream:function(a){w.push(a)},clear:function(){S(t).forEach(n);w.forEach(n)},getBuffer:function(a){return a&&a._buffer instanceof f?a._buffer:null},restore:function(){S(t).forEach(function(b){b.buffer=a.createBuffer();a.bindBuffer(b.type,b.buffer);
+a.bufferData(b.type,b.persistentData||b.byteLength,b.usage)})},_initBuffer:p}}function Lb(a,b,c,e){function f(a){this.id=u++;n[this.id]=this;this.buffer=a;this.primType=4;this.type=this.vertCount=0}function d(e,d,f,h,g,q,r){e.buffer.bind();var m;d?((m=r)||M(d)&&(!da(d)||M(d.data))||(m=b.oes_element_index_uint?5125:5123),c._initBuffer(e.buffer,d,f,m,3)):(a.bufferData(34963,q,f),e.buffer.dtype=m||5121,e.buffer.usage=f,e.buffer.dimension=3,e.buffer.byteLength=q);m=r;if(!r){switch(e.buffer.dtype){case 5121:case 5120:m=
+5121;break;case 5123:case 5122:m=5123;break;case 5125:case 5124:m=5125}e.buffer.dtype=m}e.type=m;d=g;0>d&&(d=e.buffer.byteLength,5123===m?d>>=1:5125===m&&(d>>=2));e.vertCount=d;d=h;0>h&&(d=4,h=e.buffer.dimension,1===h&&(d=0),2===h&&(d=1),3===h&&(d=4));e.primType=d}function p(a){e.elementsCount--;delete n[a.id];a.buffer.destroy();a.buffer=null}var n={},u=0,t={uint8:5121,uint16:5123};b.oes_element_index_uint&&(t.uint32=5125);f.prototype.bind=function(){this.buffer.bind()};var w=[];return{create:function(a,
+b){function l(a){if(a)if("number"===typeof a)h(a),g.primType=4,g.vertCount=a|0,g.type=5121;else{var b=null,c=35044,e=-1,f=-1,k=0,n=0;if(Array.isArray(a)||M(a)||da(a))b=a;else if("data"in a&&(b=a.data),"usage"in a&&(c=ob[a.usage]),"primitive"in a&&(e=Ta[a.primitive]),"count"in a&&(f=a.count|0),"type"in a&&(n=t[a.type]),"length"in a)k=a.length|0;else if(k=f,5123===n||5122===n)k*=2;else if(5125===n||5124===n)k*=4;d(g,b,c,e,f,k,n)}else h(),g.primType=4,g.vertCount=0,g.type=5121;return l}var h=c.create(null,
+34963,!0),g=new f(h._buffer);e.elementsCount++;l(a);l._reglType="elements";l._elements=g;l.subdata=function(a,b){h.subdata(a,b);return l};l.destroy=function(){p(g)};return l},createStream:function(a){var b=w.pop();b||(b=new f(c.create(null,34963,!0,!1)._buffer));d(b,a,35040,-1,-1,0,0);return b},destroyStream:function(a){w.push(a)},getElements:function(a){return"function"===typeof a&&a._elements instanceof f?a._elements:null},clear:function(){S(n).forEach(p)}}}function pb(a){for(var b=E.allocType(5123,
+a.length),c=0;c<a.length;++c)if(isNaN(a[c]))b[c]=65535;else if(Infinity===a[c])b[c]=31744;else if(-Infinity===a[c])b[c]=64512;else{qb[0]=a[c];var e=Mb[0],f=e>>>31<<15,d=(e<<1>>>24)-127,e=e>>13&1023;b[c]=-24>d?f:-14>d?f+(e+1024>>-14-d):15<d?f+31744:f+(d+15<<10)+e}return b}function ma(a){return Array.isArray(a)||M(a)}function na(a){return"[object "+a+"]"}function rb(a){return Array.isArray(a)&&(0===a.length||"number"===typeof a[0])}function sb(a){return Array.isArray(a)&&0!==a.length&&ma(a[0])?!0:!1}
+function ea(a){return Object.prototype.toString.call(a)}function Ua(a){if(!a)return!1;var b=ea(a);return 0<=Nb.indexOf(b)?!0:rb(a)||sb(a)||da(a)}function tb(a,b){36193===a.type?(a.data=pb(b),E.freeType(b)):a.data=b}function Ja(a,b,c,e,f,d){a="undefined"!==typeof F[a]?F[a]:Q[a]*wa[b];d&&(a*=6);if(f){for(e=0;1<=c;)e+=a*c*c,c/=2;return e}return a*c*e}function Ob(a,b,c,e,f,d,p){function n(){this.format=this.internalformat=6408;this.type=5121;this.flipY=this.premultiplyAlpha=this.compressed=!1;this.unpackAlignment=
+1;this.colorSpace=37444;this.channels=this.height=this.width=0}function u(a,b){a.internalformat=b.internalformat;a.format=b.format;a.type=b.type;a.compressed=b.compressed;a.premultiplyAlpha=b.premultiplyAlpha;a.flipY=b.flipY;a.unpackAlignment=b.unpackAlignment;a.colorSpace=b.colorSpace;a.width=b.width;a.height=b.height;a.channels=b.channels}function t(a,b){if("object"===typeof b&&b){"premultiplyAlpha"in b&&(a.premultiplyAlpha=b.premultiplyAlpha);"flipY"in b&&(a.flipY=b.flipY);"alignment"in b&&(a.unpackAlignment=
+b.alignment);"colorSpace"in b&&(a.colorSpace=Pb[b.colorSpace]);"type"in b&&(a.type=N[b.type]);var c=a.width,g=a.height,e=a.channels,d=!1;"shape"in b?(c=b.shape[0],g=b.shape[1],3===b.shape.length&&(e=b.shape[2],d=!0)):("radius"in b&&(c=g=b.radius),"width"in b&&(c=b.width),"height"in b&&(g=b.height),"channels"in b&&(e=b.channels,d=!0));a.width=c|0;a.height=g|0;a.channels=e|0;c=!1;"format"in b&&(c=b.format,g=a.internalformat=C[c],a.format=P[g],c in N&&!("type"in b)&&(a.type=N[c]),c in v&&(a.compressed=
+!0),c=!0);!d&&c?a.channels=Q[a.format]:d&&!c&&a.channels!==Ma[a.format]&&(a.format=a.internalformat=Ma[a.channels])}}function w(b){a.pixelStorei(37440,b.flipY);a.pixelStorei(37441,b.premultiplyAlpha);a.pixelStorei(37443,b.colorSpace);a.pixelStorei(3317,b.unpackAlignment)}function k(){n.call(this);this.yOffset=this.xOffset=0;this.data=null;this.needsFree=!1;this.element=null;this.needsCopy=!1}function B(a,b){var c=null;Ua(b)?c=b:b&&(t(a,b),"x"in b&&(a.xOffset=b.x|0),"y"in b&&(a.yOffset=b.y|0),Ua(b.data)&&
+(c=b.data));if(b.copy){var g=f.viewportWidth,e=f.viewportHeight;a.width=a.width||g-a.xOffset;a.height=a.height||e-a.yOffset;a.needsCopy=!0}else if(!c)a.width=a.width||1,a.height=a.height||1,a.channels=a.channels||4;else if(M(c))a.channels=a.channels||4,a.data=c,"type"in b||5121!==a.type||(a.type=Ga[Object.prototype.toString.call(c)]|0);else if(rb(c)){a.channels=a.channels||4;g=c;e=g.length;switch(a.type){case 5121:case 5123:case 5125:case 5126:e=E.allocType(a.type,e);e.set(g);a.data=e;break;case 36193:a.data=
+pb(g)}a.alignment=1;a.needsFree=!0}else if(da(c)){g=c.data;Array.isArray(g)||5121!==a.type||(a.type=Ga[Object.prototype.toString.call(g)]|0);var e=c.shape,d=c.stride,h,r,m,q;3===e.length?(m=e[2],q=d[2]):q=m=1;h=e[0];r=e[1];e=d[0];d=d[1];a.alignment=1;a.width=h;a.height=r;a.channels=m;a.format=a.internalformat=Ma[m];a.needsFree=!0;h=q;c=c.offset;m=a.width;q=a.height;r=a.channels;for(var x=E.allocType(36193===a.type?5126:a.type,m*q*r),I=0,ja=0;ja<q;++ja)for(var ka=0;ka<m;++ka)for(var Va=0;Va<r;++Va)x[I++]=
+g[e*ka+d*ja+h*Va+c];tb(a,x)}else if(ea(c)===Wa||ea(c)===Xa||ea(c)===vb)ea(c)===Wa||ea(c)===Xa?a.element=c:a.element=c.canvas,a.width=a.element.width,a.height=a.element.height,a.channels=4;else if(ea(c)===wb)a.element=c,a.width=c.width,a.height=c.height,a.channels=4;else if(ea(c)===xb)a.element=c,a.width=c.naturalWidth,a.height=c.naturalHeight,a.channels=4;else if(ea(c)===yb)a.element=c,a.width=c.videoWidth,a.height=c.videoHeight,a.channels=4;else if(sb(c)){g=a.width||c[0].length;e=a.height||c.length;
+d=a.channels;d=ma(c[0][0])?d||c[0][0].length:d||1;h=Oa.shape(c);m=1;for(q=0;q<h.length;++q)m*=h[q];m=E.allocType(36193===a.type?5126:a.type,m);Oa.flatten(c,h,"",m);tb(a,m);a.alignment=1;a.width=g;a.height=e;a.channels=d;a.format=a.internalformat=Ma[d];a.needsFree=!0}}function l(b,c,g,d,h){var m=b.element,f=b.data,r=b.internalformat,q=b.format,l=b.type,x=b.width,I=b.height;w(b);m?a.texSubImage2D(c,h,g,d,q,l,m):b.compressed?a.compressedTexSubImage2D(c,h,g,d,r,x,I,f):b.needsCopy?(e(),a.copyTexSubImage2D(c,
+h,g,d,b.xOffset,b.yOffset,x,I)):a.texSubImage2D(c,h,g,d,x,I,q,l,f)}function h(){return J.pop()||new k}function g(a){a.needsFree&&E.freeType(a.data);k.call(a);J.push(a)}function q(){n.call(this);this.genMipmaps=!1;this.mipmapHint=4352;this.mipmask=0;this.images=Array(16)}function r(a,b,c){var g=a.images[0]=h();a.mipmask=1;g.width=a.width=b;g.height=a.height=c;g.channels=a.channels=4}function m(a,b){var c=null;if(Ua(b))c=a.images[0]=h(),u(c,a),B(c,b),a.mipmask=1;else if(t(a,b),Array.isArray(b.mipmap))for(var g=
+b.mipmap,e=0;e<g.length;++e)c=a.images[e]=h(),u(c,a),c.width>>=e,c.height>>=e,B(c,g[e]),a.mipmask|=1<<e;else c=a.images[0]=h(),u(c,a),B(c,b),a.mipmask=1;u(a,a.images[0])}function z(b,c){for(var g=b.images,d=0;d<g.length&&g[d];++d){var h=g[d],m=c,f=d,r=h.element,q=h.data,l=h.internalformat,x=h.format,I=h.type,ja=h.width,ka=h.height;w(h);r?a.texImage2D(m,f,x,x,I,r):h.compressed?a.compressedTexImage2D(m,f,l,ja,ka,0,q):h.needsCopy?(e(),a.copyTexImage2D(m,f,x,h.xOffset,h.yOffset,ja,ka,0)):a.texImage2D(m,
+f,x,ja,ka,0,x,I,q||null)}}function Ha(){var a=L.pop()||new q;n.call(a);for(var b=a.mipmask=0;16>b;++b)a.images[b]=null;return a}function nb(a){for(var b=a.images,c=0;c<b.length;++c)b[c]&&g(b[c]),b[c]=null;L.push(a)}function Z(){this.magFilter=this.minFilter=9728;this.wrapT=this.wrapS=33071;this.anisotropic=1;this.genMipmaps=!1;this.mipmapHint=4352}function G(a,b){"min"in b&&(a.minFilter=R[b.min],0<=Qb.indexOf(a.minFilter)&&!("faces"in b)&&(a.genMipmaps=!0));"mag"in b&&(a.magFilter=V[b.mag]);var c=
+a.wrapS,g=a.wrapT;if("wrap"in b){var e=b.wrap;"string"===typeof e?c=g=la[e]:Array.isArray(e)&&(c=la[e[0]],g=la[e[1]])}else"wrapS"in b&&(c=la[b.wrapS]),"wrapT"in b&&(g=la[b.wrapT]);a.wrapS=c;a.wrapT=g;"anisotropic"in b&&(a.anisotropic=b.anisotropic);if("mipmap"in b){c=!1;switch(typeof b.mipmap){case "string":a.mipmapHint=y[b.mipmap];c=a.genMipmaps=!0;break;case "boolean":c=a.genMipmaps=b.mipmap;break;case "object":a.genMipmaps=!1,c=!0}!c||"min"in b||(a.minFilter=9984)}}function H(c,g){a.texParameteri(g,
+10241,c.minFilter);a.texParameteri(g,10240,c.magFilter);a.texParameteri(g,10242,c.wrapS);a.texParameteri(g,10243,c.wrapT);b.ext_texture_filter_anisotropic&&a.texParameteri(g,34046,c.anisotropic);c.genMipmaps&&(a.hint(33170,c.mipmapHint),a.generateMipmap(g))}function O(b){n.call(this);this.mipmask=0;this.internalformat=6408;this.id=Y++;this.refCount=1;this.target=b;this.texture=a.createTexture();this.unit=-1;this.bindCount=0;this.texInfo=new Z;p.profile&&(this.stats={size:0})}function xa(b){a.activeTexture(33984);
+a.bindTexture(b.target,b.texture)}function ya(){var b=W[0];b?a.bindTexture(b.target,b.texture):a.bindTexture(3553,null)}function D(b){var c=b.texture,g=b.unit,e=b.target;0<=g&&(a.activeTexture(33984+g),a.bindTexture(e,null),W[g]=null);a.deleteTexture(c);b.texture=null;b.params=null;b.pixels=null;b.refCount=0;delete ia[b.id];d.textureCount--}var y={"don't care":4352,"dont care":4352,nice:4354,fast:4353},la={repeat:10497,clamp:33071,mirror:33648},V={nearest:9728,linear:9729},R=A({mipmap:9987,"nearest mipmap nearest":9984,
+"linear mipmap nearest":9985,"nearest mipmap linear":9986,"linear mipmap linear":9987},V),Pb={none:0,browser:37444},N={uint8:5121,rgba4:32819,rgb565:33635,"rgb5 a1":32820},C={alpha:6406,luminance:6409,"luminance alpha":6410,rgb:6407,rgba:6408,rgba4:32854,"rgb5 a1":32855,rgb565:36194},v={};b.ext_srgb&&(C.srgb=35904,C.srgba=35906);b.oes_texture_float&&(N.float32=N["float"]=5126);b.oes_texture_half_float&&(N.float16=N["half float"]=36193);b.webgl_depth_texture&&(A(C,{depth:6402,"depth stencil":34041}),
+A(N,{uint16:5123,uint32:5125,"depth stencil":34042}));b.webgl_compressed_texture_s3tc&&A(v,{"rgb s3tc dxt1":33776,"rgba s3tc dxt1":33777,"rgba s3tc dxt3":33778,"rgba s3tc dxt5":33779});b.webgl_compressed_texture_atc&&A(v,{"rgb atc":35986,"rgba atc explicit alpha":35987,"rgba atc interpolated alpha":34798});b.webgl_compressed_texture_pvrtc&&A(v,{"rgb pvrtc 4bppv1":35840,"rgb pvrtc 2bppv1":35841,"rgba pvrtc 4bppv1":35842,"rgba pvrtc 2bppv1":35843});b.webgl_compressed_texture_etc1&&(v["rgb etc1"]=36196);
+var F=Array.prototype.slice.call(a.getParameter(34467));Object.keys(v).forEach(function(a){var b=v[a];0<=F.indexOf(b)&&(C[a]=b)});var ta=Object.keys(C);c.textureFormats=ta;var aa=[];Object.keys(C).forEach(function(a){aa[C[a]]=a});var K=[];Object.keys(N).forEach(function(a){K[N[a]]=a});var fa=[];Object.keys(V).forEach(function(a){fa[V[a]]=a});var Da=[];Object.keys(R).forEach(function(a){Da[R[a]]=a});var ua=[];Object.keys(la).forEach(function(a){ua[la[a]]=a});var P=ta.reduce(function(a,c){var g=C[c];
+6409===g||6406===g||6409===g||6410===g||6402===g||34041===g||b.ext_srgb&&(35904===g||35906===g)?a[g]=g:32855===g||0<=c.indexOf("rgba")?a[g]=6408:a[g]=6407;return a},{}),J=[],L=[],Y=0,ia={},ga=c.maxTextureUnits,W=Array(ga).map(function(){return null});A(O.prototype,{bind:function(){this.bindCount+=1;var b=this.unit;if(0>b){for(var c=0;c<ga;++c){var g=W[c];if(g){if(0<g.bindCount)continue;g.unit=-1}W[c]=this;b=c;break}p.profile&&d.maxTextureUnits<b+1&&(d.maxTextureUnits=b+1);this.unit=b;a.activeTexture(33984+
+b);a.bindTexture(this.target,this.texture)}return b},unbind:function(){--this.bindCount},decRef:function(){0>=--this.refCount&&D(this)}});p.profile&&(d.getTotalTextureSize=function(){var a=0;Object.keys(ia).forEach(function(b){a+=ia[b].stats.size});return a});return{create2D:function(b,c){function e(a,b){var c=f.texInfo;Z.call(c);var g=Ha();"number"===typeof a?"number"===typeof b?r(g,a|0,b|0):r(g,a|0,a|0):a?(G(c,a),m(g,a)):r(g,1,1);c.genMipmaps&&(g.mipmask=(g.width<<1)-1);f.mipmask=g.mipmask;u(f,
+g);f.internalformat=g.internalformat;e.width=g.width;e.height=g.height;xa(f);z(g,3553);H(c,3553);ya();nb(g);p.profile&&(f.stats.size=Ja(f.internalformat,f.type,g.width,g.height,c.genMipmaps,!1));e.format=aa[f.internalformat];e.type=K[f.type];e.mag=fa[c.magFilter];e.min=Da[c.minFilter];e.wrapS=ua[c.wrapS];e.wrapT=ua[c.wrapT];return e}var f=new O(3553);ia[f.id]=f;d.textureCount++;e(b,c);e.subimage=function(a,b,c,d){b|=0;c|=0;d|=0;var m=h();u(m,f);m.width=0;m.height=0;B(m,a);m.width=m.width||(f.width>>
+d)-b;m.height=m.height||(f.height>>d)-c;xa(f);l(m,3553,b,c,d);ya();g(m);return e};e.resize=function(b,c){var g=b|0,d=c|0||g;if(g===f.width&&d===f.height)return e;e.width=f.width=g;e.height=f.height=d;xa(f);for(var h=0;f.mipmask>>h;++h){var m=g>>h,x=d>>h;if(!m||!x)break;a.texImage2D(3553,h,f.format,m,x,0,f.format,f.type,null)}ya();p.profile&&(f.stats.size=Ja(f.internalformat,f.type,g,d,!1,!1));return e};e._reglType="texture2d";e._texture=f;p.profile&&(e.stats=f.stats);e.destroy=function(){f.decRef()};
+return e},createCube:function(b,c,e,f,q,n){function k(a,b,c,g,e,d){var f,ca=y.texInfo;Z.call(ca);for(f=0;6>f;++f)D[f]=Ha();if("number"===typeof a||!a)for(a=a|0||1,f=0;6>f;++f)r(D[f],a,a);else if("object"===typeof a)if(b)m(D[0],a),m(D[1],b),m(D[2],c),m(D[3],g),m(D[4],e),m(D[5],d);else if(G(ca,a),t(y,a),"faces"in a)for(a=a.faces,f=0;6>f;++f)u(D[f],y),m(D[f],a[f]);else for(f=0;6>f;++f)m(D[f],a);u(y,D[0]);y.mipmask=ca.genMipmaps?(D[0].width<<1)-1:D[0].mipmask;y.internalformat=D[0].internalformat;k.width=
+D[0].width;k.height=D[0].height;xa(y);for(f=0;6>f;++f)z(D[f],34069+f);H(ca,34067);ya();p.profile&&(y.stats.size=Ja(y.internalformat,y.type,k.width,k.height,ca.genMipmaps,!0));k.format=aa[y.internalformat];k.type=K[y.type];k.mag=fa[ca.magFilter];k.min=Da[ca.minFilter];k.wrapS=ua[ca.wrapS];k.wrapT=ua[ca.wrapT];for(f=0;6>f;++f)nb(D[f]);return k}var y=new O(34067);ia[y.id]=y;d.cubeCount++;var D=Array(6);k(b,c,e,f,q,n);k.subimage=function(a,b,c,e,f){c|=0;e|=0;f|=0;var d=h();u(d,y);d.width=0;d.height=0;
+B(d,b);d.width=d.width||(y.width>>f)-c;d.height=d.height||(y.height>>f)-e;xa(y);l(d,34069+a,c,e,f);ya();g(d);return k};k.resize=function(b){b|=0;if(b!==y.width){k.width=y.width=b;k.height=y.height=b;xa(y);for(var c=0;6>c;++c)for(var g=0;y.mipmask>>g;++g)a.texImage2D(34069+c,g,y.format,b>>g,b>>g,0,y.format,y.type,null);ya();p.profile&&(y.stats.size=Ja(y.internalformat,y.type,k.width,k.height,!1,!0));return k}};k._reglType="textureCube";k._texture=y;p.profile&&(k.stats=y.stats);k.destroy=function(){y.decRef()};
+return k},clear:function(){for(var b=0;b<ga;++b)a.activeTexture(33984+b),a.bindTexture(3553,null),W[b]=null;S(ia).forEach(D);d.cubeCount=0;d.textureCount=0},getTexture:function(a){return null},restore:function(){for(var b=0;b<ga;++b){var c=W[b];c&&(c.bindCount=0,c.unit=-1,W[b]=null)}S(ia).forEach(function(b){b.texture=a.createTexture();a.bindTexture(b.target,b.texture);for(var c=0;32>c;++c)if(0!==(b.mipmask&1<<c))if(3553===b.target)a.texImage2D(3553,c,b.internalformat,b.width>>c,b.height>>c,0,b.internalformat,
+b.type,null);else for(var g=0;6>g;++g)a.texImage2D(34069+g,c,b.internalformat,b.width>>c,b.height>>c,0,b.internalformat,b.type,null);H(b.texInfo,b.target)})},refresh:function(){for(var b=0;b<ga;++b){var c=W[b];c&&(c.bindCount=0,c.unit=-1,W[b]=null);a.activeTexture(33984+b);a.bindTexture(3553,null);a.bindTexture(34067,null)}}}}function Rb(a,b,c,e,f,d){function p(a,b,c){this.target=a;this.texture=b;this.renderbuffer=c;var g=a=0;b?(a=b.width,g=b.height):c&&(a=c.width,g=c.height);this.width=a;this.height=
+g}function n(a){a&&(a.texture&&a.texture._texture.decRef(),a.renderbuffer&&a.renderbuffer._renderbuffer.decRef())}function u(a,b,c){a&&(a.texture?a.texture._texture.refCount+=1:a.renderbuffer._renderbuffer.refCount+=1)}function t(b,c){c&&(c.texture?a.framebufferTexture2D(36160,b,c.target,c.texture._texture.texture,0):a.framebufferRenderbuffer(36160,b,36161,c.renderbuffer._renderbuffer.renderbuffer))}function w(a){var b=3553,c=null,g=null,e=a;"object"===typeof a&&(e=a.data,"target"in a&&(b=a.target|
+0));a=e._reglType;"texture2d"===a?c=e:"textureCube"===a?c=e:"renderbuffer"===a&&(g=e,b=36161);return new p(b,c,g)}function k(a,b,c,g,d){if(c)return a=e.create2D({width:a,height:b,format:g,type:d}),a._texture.refCount=0,new p(3553,a,null);a=f.create({width:a,height:b,format:g});a._renderbuffer.refCount=0;return new p(36161,null,a)}function B(a){return a&&(a.texture||a.renderbuffer)}function l(a,b,c){a&&(a.texture?a.texture.resize(b,c):a.renderbuffer&&a.renderbuffer.resize(b,c),a.width=b,a.height=c)}
+function h(){this.id=G++;H[this.id]=this;this.framebuffer=a.createFramebuffer();this.height=this.width=0;this.colorAttachments=[];this.depthStencilAttachment=this.stencilAttachment=this.depthAttachment=null}function g(a){a.colorAttachments.forEach(n);n(a.depthAttachment);n(a.stencilAttachment);n(a.depthStencilAttachment)}function q(b){a.deleteFramebuffer(b.framebuffer);b.framebuffer=null;d.framebufferCount--;delete H[b.id]}function r(b){var g;a.bindFramebuffer(36160,b.framebuffer);var e=b.colorAttachments;
+for(g=0;g<e.length;++g)t(36064+g,e[g]);for(g=e.length;g<c.maxColorAttachments;++g)a.framebufferTexture2D(36160,36064+g,3553,null,0);a.framebufferTexture2D(36160,33306,3553,null,0);a.framebufferTexture2D(36160,36096,3553,null,0);a.framebufferTexture2D(36160,36128,3553,null,0);t(36096,b.depthAttachment);t(36128,b.stencilAttachment);t(33306,b.depthStencilAttachment);a.checkFramebufferStatus(36160);a.isContextLost();a.bindFramebuffer(36160,z.next?z.next.framebuffer:null);z.cur=z.next;a.getError()}function m(a,
+b){function c(a,b){var f,d=0,h=0,m=!0,q=!0;f=null;var l=!0,n="rgba",t="uint8",p=1,G=null,fa=null,z=null,O=!1;if("number"===typeof a)d=a|0,h=b|0||d;else if(a){"shape"in a?(h=a.shape,d=h[0],h=h[1]):("radius"in a&&(d=h=a.radius),"width"in a&&(d=a.width),"height"in a&&(h=a.height));if("color"in a||"colors"in a)f=a.color||a.colors,Array.isArray(f);if(!f){"colorCount"in a&&(p=a.colorCount|0);"colorTexture"in a&&(l=!!a.colorTexture,n="rgba4");if("colorType"in a&&(t=a.colorType,!l))if("half float"===t||"float16"===
+t)n="rgba16f";else if("float"===t||"float32"===t)n="rgba32f";"colorFormat"in a&&(n=a.colorFormat,0<=Ha.indexOf(n)?l=!0:0<=v.indexOf(n)&&(l=!1))}if("depthTexture"in a||"depthStencilTexture"in a)O=!(!a.depthTexture&&!a.depthStencilTexture);"depth"in a&&("boolean"===typeof a.depth?m=a.depth:(G=a.depth,q=!1));"stencil"in a&&("boolean"===typeof a.stencil?q=a.stencil:(fa=a.stencil,m=!1));"depthStencil"in a&&("boolean"===typeof a.depthStencil?m=q=a.depthStencil:(z=a.depthStencil,q=m=!1))}else d=h=1;var P=
+null,Z=null,H=null,A=null;if(Array.isArray(f))P=f.map(w);else if(f)P=[w(f)];else for(P=Array(p),f=0;f<p;++f)P[f]=k(d,h,l,n,t);d=d||P[0].width;h=h||P[0].height;G?Z=w(G):m&&!q&&(Z=k(d,h,O,"depth","uint32"));fa?H=w(fa):q&&!m&&(H=k(d,h,!1,"stencil","uint8"));z?A=w(z):!G&&!fa&&q&&m&&(A=k(d,h,O,"depth stencil","depth stencil"));m=null;for(f=0;f<P.length;++f)u(P[f],d,h),P[f]&&P[f].texture&&(q=Ya[P[f].texture._texture.format]*Pa[P[f].texture._texture.type],null===m&&(m=q));u(Z,d,h);u(H,d,h);u(A,d,h);g(e);
+e.width=d;e.height=h;e.colorAttachments=P;e.depthAttachment=Z;e.stencilAttachment=H;e.depthStencilAttachment=A;c.color=P.map(B);c.depth=B(Z);c.stencil=B(H);c.depthStencil=B(A);c.width=e.width;c.height=e.height;r(e);return c}var e=new h;d.framebufferCount++;c(a,b);return A(c,{resize:function(a,b){var g=Math.max(a|0,1),f=Math.max(b|0||g,1);if(g===e.width&&f===e.height)return c;for(var d=e.colorAttachments,h=0;h<d.length;++h)l(d[h],g,f);l(e.depthAttachment,g,f);l(e.stencilAttachment,g,f);l(e.depthStencilAttachment,
+g,f);e.width=c.width=g;e.height=c.height=f;r(e);return c},_reglType:"framebuffer",_framebuffer:e,destroy:function(){q(e);g(e)},use:function(a){z.setFBO({framebuffer:c},a)}})}var z={cur:null,next:null,dirty:!1,setFBO:null},Ha=["rgba"],v=["rgba4","rgb565","rgb5 a1"];b.ext_srgb&&v.push("srgba");b.ext_color_buffer_half_float&&v.push("rgba16f","rgb16f");b.webgl_color_buffer_float&&v.push("rgba32f");var Z=["uint8"];b.oes_texture_half_float&&Z.push("half float","float16");b.oes_texture_float&&Z.push("float",
+"float32");var G=0,H={};return A(z,{getFramebuffer:function(a){return"function"===typeof a&&"framebuffer"===a._reglType&&(a=a._framebuffer,a instanceof h)?a:null},create:m,createCube:function(a){function b(a){var g,f={color:null},d=0,h=null;g="rgba";var q="uint8",r=1;if("number"===typeof a)d=a|0;else if(a){"shape"in a?d=a.shape[0]:("radius"in a&&(d=a.radius|0),"width"in a?d=a.width|0:"height"in a&&(d=a.height|0));if("color"in a||"colors"in a)h=a.color||a.colors,Array.isArray(h);h||("colorCount"in
+a&&(r=a.colorCount|0),"colorType"in a&&(q=a.colorType),"colorFormat"in a&&(g=a.colorFormat));"depth"in a&&(f.depth=a.depth);"stencil"in a&&(f.stencil=a.stencil);"depthStencil"in a&&(f.depthStencil=a.depthStencil)}else d=1;if(h)if(Array.isArray(h))for(a=[],g=0;g<h.length;++g)a[g]=h[g];else a=[h];else for(a=Array(r),h={radius:d,format:g,type:q},g=0;g<r;++g)a[g]=e.createCube(h);f.color=Array(a.length);for(g=0;g<a.length;++g)r=a[g],d=d||r.width,f.color[g]={target:34069,data:a[g]};for(g=0;6>g;++g){for(r=
+0;r<a.length;++r)f.color[r].target=34069+g;0<g&&(f.depth=c[0].depth,f.stencil=c[0].stencil,f.depthStencil=c[0].depthStencil);if(c[g])c[g](f);else c[g]=m(f)}return A(b,{width:d,height:d,color:a})}var c=Array(6);b(a);return A(b,{faces:c,resize:function(a){var g=a|0;if(g===b.width)return b;var e=b.color;for(a=0;a<e.length;++a)e[a].resize(g);for(a=0;6>a;++a)c[a].resize(g);b.width=b.height=g;return b},_reglType:"framebufferCube",destroy:function(){c.forEach(function(a){a.destroy()})}})},clear:function(){S(H).forEach(q)},
+restore:function(){z.cur=null;z.next=null;z.dirty=!0;S(H).forEach(function(b){b.framebuffer=a.createFramebuffer();r(b)})}})}function Za(){this.w=this.z=this.y=this.x=this.state=0;this.buffer=null;this.size=0;this.normalized=!1;this.type=5126;this.divisor=this.stride=this.offset=0}function Sb(a,b,c,e,f){function d(a){if(a!==h.currentVAO){var c=b.oes_vertex_array_object;a?c.bindVertexArrayOES(a.vao):c.bindVertexArrayOES(null);h.currentVAO=a}}function p(c){if(c!==h.currentVAO){if(c)c.bindAttrs();else for(var e=
+b.angle_instanced_arrays,f=0;f<k.length;++f){var d=k[f];d.buffer?(a.enableVertexAttribArray(f),a.vertexAttribPointer(f,d.size,d.type,d.normalized,d.stride,d.offfset),e&&d.divisor&&e.vertexAttribDivisorANGLE(f,d.divisor)):(a.disableVertexAttribArray(f),a.vertexAttrib4f(f,d.x,d.y,d.z,d.w))}h.currentVAO=c}}function n(){S(l).forEach(function(a){a.destroy()})}function u(){this.id=++B;this.attributes=[];var a=b.oes_vertex_array_object;this.vao=a?a.createVertexArrayOES():null;l[this.id]=this;this.buffers=
+[]}function t(){b.oes_vertex_array_object&&S(l).forEach(function(a){a.refresh()})}var w=c.maxAttributes,k=Array(w);for(c=0;c<w;++c)k[c]=new Za;var B=0,l={},h={Record:Za,scope:{},state:k,currentVAO:null,targetVAO:null,restore:b.oes_vertex_array_object?t:function(){},createVAO:function(a){function b(a){var g={},e=c.attributes;e.length=a.length;for(var d=0;d<a.length;++d){var h=a[d],k=e[d]=new Za,l=h.data||h;if(Array.isArray(l)||M(l)||da(l)){var n;c.buffers[d]&&(n=c.buffers[d],M(l)&&n._buffer.byteLength>=
+l.byteLength?n.subdata(l):(n.destroy(),c.buffers[d]=null));c.buffers[d]||(n=c.buffers[d]=f.create(h,34962,!1,!0));k.buffer=f.getBuffer(n);k.size=k.buffer.dimension|0;k.normalized=!1;k.type=k.buffer.dtype;k.offset=0;k.stride=0;k.divisor=0;k.state=1;g[d]=1}else f.getBuffer(h)?(k.buffer=f.getBuffer(h),k.size=k.buffer.dimension|0,k.normalized=!1,k.type=k.buffer.dtype,k.offset=0,k.stride=0,k.divisor=0,k.state=1):f.getBuffer(h.buffer)?(k.buffer=f.getBuffer(h.buffer),k.size=(+h.size||k.buffer.dimension)|
+0,k.normalized=!!h.normalized||!1,k.type="type"in h?Ia[h.type]:k.buffer.dtype,k.offset=(h.offset||0)|0,k.stride=(h.stride||0)|0,k.divisor=(h.divisor||0)|0,k.state=1):"x"in h&&(k.x=+h.x||0,k.y=+h.y||0,k.z=+h.z||0,k.w=+h.w||0,k.state=2)}for(a=0;a<c.buffers.length;++a)!g[a]&&c.buffers[a]&&(c.buffers[a].destroy(),c.buffers[a]=null);c.refresh();return b}var c=new u;e.vaoCount+=1;b.destroy=function(){for(var a=0;a<c.buffers.length;++a)c.buffers[a]&&c.buffers[a].destroy();c.buffers.length=0;c.destroy()};
+b._vao=c;b._reglType="vao";return b(a)},getVAO:function(a){return"function"===typeof a&&a._vao?a._vao:null},destroyBuffer:function(b){for(var c=0;c<k.length;++c){var e=k[c];e.buffer===b&&(a.disableVertexAttribArray(c),e.buffer=null)}},setVAO:b.oes_vertex_array_object?d:p,clear:b.oes_vertex_array_object?n:function(){}};u.prototype.bindAttrs=function(){for(var c=b.angle_instanced_arrays,e=this.attributes,f=0;f<e.length;++f){var d=e[f];d.buffer?(a.enableVertexAttribArray(f),a.bindBuffer(34962,d.buffer.buffer),
+a.vertexAttribPointer(f,d.size,d.type,d.normalized,d.stride,d.offset),c&&d.divisor&&c.vertexAttribDivisorANGLE(f,d.divisor)):(a.disableVertexAttribArray(f),a.vertexAttrib4f(f,d.x,d.y,d.z,d.w))}for(c=e.length;c<w;++c)a.disableVertexAttribArray(c)};u.prototype.refresh=function(){var a=b.oes_vertex_array_object;a&&(a.bindVertexArrayOES(this.vao),this.bindAttrs(),h.currentVAO=this)};u.prototype.destroy=function(){if(this.vao){var a=b.oes_vertex_array_object;this===h.currentVAO&&(h.currentVAO=null,a.bindVertexArrayOES(null));
+a.deleteVertexArrayOES(this.vao);this.vao=null}l[this.id]&&(delete l[this.id],--e.vaoCount)};return h}function Tb(a,b,c,e){function f(a,b,c,e){this.name=a;this.id=b;this.location=c;this.info=e}function d(a,b){for(var c=0;c<a.length;++c)if(a[c].id===b.id){a[c].location=b.location;return}a.push(b)}function p(c,g,e){e=35632===c?t:w;var d=e[g];if(!d){var f=b.str(g),d=a.createShader(c);a.shaderSource(d,f);a.compileShader(d);e[g]=d}return d}function n(a,b){this.id=l++;this.fragId=a;this.vertId=b;this.program=
+null;this.uniforms=[];this.attributes=[];this.refCount=1;e.profile&&(this.stats={uniformsCount:0,attributesCount:0})}function u(c,g,k){var l;l=p(35632,c.fragId);var m=p(35633,c.vertId);g=c.program=a.createProgram();a.attachShader(g,l);a.attachShader(g,m);if(k)for(l=0;l<k.length;++l)m=k[l],a.bindAttribLocation(g,m[0],m[1]);a.linkProgram(g);m=a.getProgramParameter(g,35718);e.profile&&(c.stats.uniformsCount=m);var n=c.uniforms;for(l=0;l<m;++l)if(k=a.getActiveUniform(g,l))if(1<k.size)for(var t=0;t<k.size;++t){var u=
+k.name.replace("[0]","["+t+"]");d(n,new f(u,b.id(u),a.getUniformLocation(g,u),k))}else d(n,new f(k.name,b.id(k.name),a.getUniformLocation(g,k.name),k));m=a.getProgramParameter(g,35721);e.profile&&(c.stats.attributesCount=m);c=c.attributes;for(l=0;l<m;++l)(k=a.getActiveAttrib(g,l))&&d(c,new f(k.name,b.id(k.name),a.getAttribLocation(g,k.name),k))}var t={},w={},k={},B=[],l=0;e.profile&&(c.getMaxUniformsCount=function(){var a=0;B.forEach(function(b){b.stats.uniformsCount>a&&(a=b.stats.uniformsCount)});
+return a},c.getMaxAttributesCount=function(){var a=0;B.forEach(function(b){b.stats.attributesCount>a&&(a=b.stats.attributesCount)});return a});return{clear:function(){var b=a.deleteShader.bind(a);S(t).forEach(b);t={};S(w).forEach(b);w={};B.forEach(function(b){a.deleteProgram(b.program)});B.length=0;k={};c.shaderCount=0},program:function(b,e,d,f){var l=k[e];l||(l=k[e]={});var p=l[b];if(p&&(p.refCount++,!f))return p;var v=new n(e,b);c.shaderCount++;u(v,d,f);p||(l[b]=v);B.push(v);return A(v,{destroy:function(){v.refCount--;
+if(0>=v.refCount){a.deleteProgram(v.program);var b=B.indexOf(v);B.splice(b,1);c.shaderCount--}0>=l[v.vertId].refCount&&(a.deleteShader(w[v.vertId]),delete w[v.vertId],delete k[v.fragId][v.vertId]);Object.keys(k[v.fragId]).length||(a.deleteShader(t[v.fragId]),delete t[v.fragId],delete k[v.fragId])}})},restore:function(){t={};w={};for(var a=0;a<B.length;++a)u(B[a],null,B[a].attributes.map(function(a){return[a.location,a.name]}))},shader:p,frag:-1,vert:-1}}function Ub(a,b,c,e,f,d,p){function n(d){var f;
+f=null===b.next?5121:b.next.colorAttachments[0].texture._texture.type;var k=0,n=0,l=e.framebufferWidth,h=e.framebufferHeight,g=null;M(d)?g=d:d&&(k=d.x|0,n=d.y|0,l=(d.width||e.framebufferWidth-k)|0,h=(d.height||e.framebufferHeight-n)|0,g=d.data||null);c();d=l*h*4;g||(5121===f?g=new Uint8Array(d):5126===f&&(g=g||new Float32Array(d)));a.pixelStorei(3333,4);a.readPixels(k,n,l,h,6408,f,g);return g}function u(a){var c;b.setFBO({framebuffer:a.framebuffer},function(){c=n(a)});return c}return function(a){return a&&
+"framebuffer"in a?u(a):n(a)}}function za(a){return Array.prototype.slice.call(a)}function Aa(a){return za(a).join("")}function Vb(){function a(){var a=[],b=[];return A(function(){a.push.apply(a,za(arguments))},{def:function(){var d="v"+c++;b.push(d);0<arguments.length&&(a.push(d,"="),a.push.apply(a,za(arguments)),a.push(";"));return d},toString:function(){return Aa([0<b.length?"var "+b.join(",")+";":"",Aa(a)])}})}function b(){function b(a,e){d(a,e,"=",c.def(a,e),";")}var c=a(),d=a(),e=c.toString,
+f=d.toString;return A(function(){c.apply(c,za(arguments))},{def:c.def,entry:c,exit:d,save:b,set:function(a,d,e){b(a,d);c(a,d,"=",e,";")},toString:function(){return e()+f()}})}var c=0,e=[],f=[],d=a(),p={};return{global:d,link:function(a){for(var b=0;b<f.length;++b)if(f[b]===a)return e[b];b="g"+c++;e.push(b);f.push(a);return b},block:a,proc:function(a,c){function d(){var a="a"+e.length;e.push(a);return a}var e=[];c=c||0;for(var f=0;f<c;++f)d();var f=b(),B=f.toString;return p[a]=A(f,{arg:d,toString:function(){return Aa(["function(",
+e.join(),"){",B(),"}"])}})},scope:b,cond:function(){var a=Aa(arguments),c=b(),d=b(),e=c.toString,f=d.toString;return A(c,{then:function(){c.apply(c,za(arguments));return this},"else":function(){d.apply(d,za(arguments));return this},toString:function(){var b=f();b&&(b="else{"+b+"}");return Aa(["if(",a,"){",e(),"}",b])}})},compile:function(){var a=['"use strict";',d,"return {"];Object.keys(p).forEach(function(b){a.push('"',b,'":',p[b].toString(),",")});a.push("}");var b=Aa(a).replace(/;/g,";\n").replace(/}/g,
+"}\n").replace(/{/g,"{\n");return Function.apply(null,e.concat(b)).apply(null,f)}}}function Qa(a){return Array.isArray(a)||M(a)||da(a)}function zb(a){return a.sort(function(a,c){return"viewport"===a?-1:"viewport"===c?1:a<c?-1:1})}function K(a,b,c,e){this.thisDep=a;this.contextDep=b;this.propDep=c;this.append=e}function sa(a){return a&&!(a.thisDep||a.contextDep||a.propDep)}function v(a){return new K(!1,!1,!1,a)}function L(a,b){var c=a.type;if(0===c)return c=a.data.length,new K(!0,1<=c,2<=c,b);if(4===
+c)return c=a.data,new K(c.thisDep,c.contextDep,c.propDep,b);if(5===c)return new K(!1,!1,!1,b);if(6===c){for(var e=c=!1,f=!1,d=0;d<a.data.length;++d){var p=a.data[d];1===p.type?f=!0:2===p.type?e=!0:3===p.type?c=!0:0===p.type?(c=!0,p=p.data,1<=p&&(e=!0),2<=p&&(f=!0)):4===p.type&&(c=c||p.data.thisDep,e=e||p.data.contextDep,f=f||p.data.propDep)}return new K(c,e,f,b)}return new K(3===c,2===c,1===c,b)}function Wb(a,b,c,e,f,d,p,n,u,t,w,k,B,l,h){function g(a){return a.replace(".","_")}function q(a,b,c){var d=
+g(a);La.push(a);Ca[d]=pa[d]=!!c;qa[d]=b}function r(a,b,c){var d=g(a);La.push(a);Array.isArray(c)?(pa[d]=c.slice(),Ca[d]=c.slice()):pa[d]=Ca[d]=c;ra[d]=b}function m(){var a=Vb(),c=a.link,d=a.global;a.id=na++;a.batchId="0";var e=c(ub),f=a.shared={props:"a0"};Object.keys(ub).forEach(function(a){f[a]=d.def(e,".",a)});var g=a.next={},h=a.current={};Object.keys(ra).forEach(function(a){Array.isArray(pa[a])&&(g[a]=d.def(f.next,".",a),h[a]=d.def(f.current,".",a))});var ba=a.constants={};Object.keys(Na).forEach(function(a){ba[a]=
+d.def(JSON.stringify(Na[a]))});a.invoke=function(b,d){switch(d.type){case 0:var e=["this",f.context,f.props,a.batchId];return b.def(c(d.data),".call(",e.slice(0,Math.max(d.data.length+1,4)),")");case 1:return b.def(f.props,d.data);case 2:return b.def(f.context,d.data);case 3:return b.def("this",d.data);case 4:return d.data.append(a,b),d.data.ref;case 5:return d.data.toString();case 6:return d.data.map(function(c){return a.invoke(b,c)})}};a.attribCache={};var va={};a.scopeAttrib=function(a){a=b.id(a);
+if(a in va)return va[a];var d=t.scope[a];d||(d=t.scope[a]=new ga);return va[a]=c(d)};return a}function z(a){var b=a["static"];a=a.dynamic;var c;if("profile"in b){var d=!!b.profile;c=v(function(a,b){return d});c.enable=d}else if("profile"in a){var e=a.profile;c=L(e,function(a,b){return a.invoke(b,e)})}return c}function E(a,b){var c=a["static"],d=a.dynamic;if("framebuffer"in c){var e=c.framebuffer;return e?(e=n.getFramebuffer(e),v(function(a,b){var c=a.link(e),d=a.shared;b.set(d.framebuffer,".next",
+c);d=d.context;b.set(d,".framebufferWidth",c+".width");b.set(d,".framebufferHeight",c+".height");return c})):v(function(a,b){var c=a.shared;b.set(c.framebuffer,".next","null");c=c.context;b.set(c,".framebufferWidth",c+".drawingBufferWidth");b.set(c,".framebufferHeight",c+".drawingBufferHeight");return"null"})}if("framebuffer"in d){var f=d.framebuffer;return L(f,function(a,b){var c=a.invoke(b,f),d=a.shared,e=d.framebuffer,c=b.def(e,".getFramebuffer(",c,")");b.set(e,".next",c);d=d.context;b.set(d,".framebufferWidth",
+c+"?"+c+".width:"+d+".drawingBufferWidth");b.set(d,".framebufferHeight",c+"?"+c+".height:"+d+".drawingBufferHeight");return c})}return null}function F(a,b,c){function d(a){if(a in e){var c=e[a];a=!0;var g=c.x|0,x=c.y|0,h,k;"width"in c?h=c.width|0:a=!1;"height"in c?k=c.height|0:a=!1;return new K(!a&&b&&b.thisDep,!a&&b&&b.contextDep,!a&&b&&b.propDep,function(a,b){var d=a.shared.context,e=h;"width"in c||(e=b.def(d,".","framebufferWidth","-",g));var f=k;"height"in c||(f=b.def(d,".","framebufferHeight",
+"-",x));return[g,x,e,f]})}if(a in f){var ca=f[a];a=L(ca,function(a,b){var c=a.invoke(b,ca),d=a.shared.context,e=b.def(c,".x|0"),f=b.def(c,".y|0"),g=b.def('"width" in ',c,"?",c,".width|0:","(",d,".","framebufferWidth","-",e,")"),c=b.def('"height" in ',c,"?",c,".height|0:","(",d,".","framebufferHeight","-",f,")");return[e,f,g,c]});b&&(a.thisDep=a.thisDep||b.thisDep,a.contextDep=a.contextDep||b.contextDep,a.propDep=a.propDep||b.propDep);return a}return b?new K(b.thisDep,b.contextDep,b.propDep,function(a,
+b){var c=a.shared.context;return[0,0,b.def(c,".","framebufferWidth"),b.def(c,".","framebufferHeight")]}):null}var e=a["static"],f=a.dynamic;if(a=d("viewport")){var g=a;a=new K(a.thisDep,a.contextDep,a.propDep,function(a,b){var c=g.append(a,b),d=a.shared.context;b.set(d,".viewportWidth",c[2]);b.set(d,".viewportHeight",c[3]);return c})}return{viewport:a,scissor_box:d("scissor.box")}}function Z(a,b){var c=a["static"];if("string"===typeof c.frag&&"string"===typeof c.vert){if(0<Object.keys(b.dynamic).length)return null;
+var c=b["static"],d=Object.keys(c);if(0<d.length&&"number"===typeof c[d[0]]){for(var e=[],f=0;f<d.length;++f)e.push([c[d[f]]|0,d[f]]);return e}}return null}function G(a,c,d){function e(a){if(a in f){var c=b.id(f[a]);a=v(function(){return c});a.id=c;return a}if(a in g){var d=g[a];return L(d,function(a,b){var c=a.invoke(b,d);return b.def(a.shared.strings,".id(",c,")")})}return null}var f=a["static"],g=a.dynamic,h=e("frag"),ba=e("vert"),va=null;sa(h)&&sa(ba)?(va=w.program(ba.id,h.id,null,d),a=v(function(a,
+b){return a.link(va)})):a=new K(h&&h.thisDep||ba&&ba.thisDep,h&&h.contextDep||ba&&ba.contextDep,h&&h.propDep||ba&&ba.propDep,function(a,b){var c=a.shared.shader,d;d=h?h.append(a,b):b.def(c,".","frag");var e;e=ba?ba.append(a,b):b.def(c,".","vert");return b.def(c+".program("+e+","+d+")")});return{frag:h,vert:ba,progVar:a,program:va}}function H(a,b){function c(a,b){if(a in e){var d=e[a]|0;return v(function(a,c){b&&(a.OFFSET=d);return d})}if(a in f){var x=f[a];return L(x,function(a,c){var d=a.invoke(c,
+x);b&&(a.OFFSET=d);return d})}return b&&g?v(function(a,b){a.OFFSET="0";return 0}):null}var e=a["static"],f=a.dynamic,g=function(){if("elements"in e){var a=e.elements;Qa(a)?a=d.getElements(d.create(a,!0)):a&&(a=d.getElements(a));var b=v(function(b,c){if(a){var d=b.link(a);return b.ELEMENTS=d}return b.ELEMENTS=null});b.value=a;return b}if("elements"in f){var c=f.elements;return L(c,function(a,b){var d=a.shared,e=d.isBufferArgs,d=d.elements,f=a.invoke(b,c),g=b.def("null"),e=b.def(e,"(",f,")"),f=a.cond(e).then(g,
+"=",d,".createStream(",f,");")["else"](g,"=",d,".getElements(",f,");");b.entry(f);b.exit(a.cond(e).then(d,".destroyStream(",g,");"));return a.ELEMENTS=g})}return null}(),h=c("offset",!0);return{elements:g,primitive:function(){if("primitive"in e){var a=e.primitive;return v(function(b,c){return Ta[a]})}if("primitive"in f){var b=f.primitive;return L(b,function(a,c){var d=a.constants.primTypes,e=a.invoke(c,b);return c.def(d,"[",e,"]")})}return g?sa(g)?g.value?v(function(a,b){return b.def(a.ELEMENTS,".primType")}):
+v(function(){return 4}):new K(g.thisDep,g.contextDep,g.propDep,function(a,b){var c=a.ELEMENTS;return b.def(c,"?",c,".primType:",4)}):null}(),count:function(){if("count"in e){var a=e.count|0;return v(function(){return a})}if("count"in f){var b=f.count;return L(b,function(a,c){return a.invoke(c,b)})}return g?sa(g)?g?h?new K(h.thisDep,h.contextDep,h.propDep,function(a,b){return b.def(a.ELEMENTS,".vertCount-",a.OFFSET)}):v(function(a,b){return b.def(a.ELEMENTS,".vertCount")}):v(function(){return-1}):
+new K(g.thisDep||h.thisDep,g.contextDep||h.contextDep,g.propDep||h.propDep,function(a,b){var c=a.ELEMENTS;return a.OFFSET?b.def(c,"?",c,".vertCount-",a.OFFSET,":-1"):b.def(c,"?",c,".vertCount:-1")}):null}(),instances:c("instances",!1),offset:h}}function O(a,b){var c=a["static"],d=a.dynamic,e={};La.forEach(function(a){function b(g,x){if(a in c){var h=g(c[a]);e[f]=v(function(){return h})}else if(a in d){var I=d[a];e[f]=L(I,function(a,b){return x(a,b,a.invoke(b,I))})}}var f=g(a);switch(a){case "cull.enable":case "blend.enable":case "dither":case "stencil.enable":case "depth.enable":case "scissor.enable":case "polygonOffset.enable":case "sample.alpha":case "sample.enable":case "depth.mask":return b(function(a){return a},
+function(a,b,c){return c});case "depth.func":return b(function(a){return ab[a]},function(a,b,c){return b.def(a.constants.compareFuncs,"[",c,"]")});case "depth.range":return b(function(a){return a},function(a,b,c){a=b.def("+",c,"[0]");b=b.def("+",c,"[1]");return[a,b]});case "blend.func":return b(function(a){return[Ea["srcRGB"in a?a.srcRGB:a.src],Ea["dstRGB"in a?a.dstRGB:a.dst],Ea["srcAlpha"in a?a.srcAlpha:a.src],Ea["dstAlpha"in a?a.dstAlpha:a.dst]]},function(a,b,c){function d(a,e){return b.def('"',
+a,e,'" in ',c,"?",c,".",a,e,":",c,".",a)}a=a.constants.blendFuncs;var e=d("src","RGB"),f=d("dst","RGB"),e=b.def(a,"[",e,"]"),g=b.def(a,"[",d("src","Alpha"),"]"),f=b.def(a,"[",f,"]");a=b.def(a,"[",d("dst","Alpha"),"]");return[e,f,g,a]});case "blend.equation":return b(function(a){if("string"===typeof a)return[W[a],W[a]];if("object"===typeof a)return[W[a.rgb],W[a.alpha]]},function(a,b,c){var d=a.constants.blendEquations,e=b.def(),f=b.def();a=a.cond("typeof ",c,'==="string"');a.then(e,"=",f,"=",d,"[",
+c,"];");a["else"](e,"=",d,"[",c,".rgb];",f,"=",d,"[",c,".alpha];");b(a);return[e,f]});case "blend.color":return b(function(a){return J(4,function(b){return+a[b]})},function(a,b,c){return J(4,function(a){return b.def("+",c,"[",a,"]")})});case "stencil.mask":return b(function(a){return a|0},function(a,b,c){return b.def(c,"|0")});case "stencil.func":return b(function(a){return[ab[a.cmp||"keep"],a.ref||0,"mask"in a?a.mask:-1]},function(a,b,c){a=b.def('"cmp" in ',c,"?",a.constants.compareFuncs,"[",c,".cmp]",
+":",7680);var d=b.def(c,".ref|0");b=b.def('"mask" in ',c,"?",c,".mask|0:-1");return[a,d,b]});case "stencil.opFront":case "stencil.opBack":return b(function(b){return["stencil.opBack"===a?1029:1028,Ra[b.fail||"keep"],Ra[b.zfail||"keep"],Ra[b.zpass||"keep"]]},function(b,c,d){function e(a){return c.def('"',a,'" in ',d,"?",f,"[",d,".",a,"]:",7680)}var f=b.constants.stencilOps;return["stencil.opBack"===a?1029:1028,e("fail"),e("zfail"),e("zpass")]});case "polygonOffset.offset":return b(function(a){return[a.factor|
+0,a.units|0]},function(a,b,c){a=b.def(c,".factor|0");b=b.def(c,".units|0");return[a,b]});case "cull.face":return b(function(a){var b=0;"front"===a?b=1028:"back"===a&&(b=1029);return b},function(a,b,c){return b.def(c,'==="front"?',1028,":",1029)});case "lineWidth":return b(function(a){return a},function(a,b,c){return c});case "frontFace":return b(function(a){return Ab[a]},function(a,b,c){return b.def(c+'==="cw"?2304:2305')});case "colorMask":return b(function(a){return a.map(function(a){return!!a})},
+function(a,b,c){return J(4,function(a){return"!!"+c+"["+a+"]"})});case "sample.coverage":return b(function(a){return["value"in a?a.value:1,!!a.invert]},function(a,b,c){a=b.def('"value" in ',c,"?+",c,".value:1");b=b.def("!!",c,".invert");return[a,b]})}});return e}function M(a,b){var c=a["static"],d=a.dynamic,e={};Object.keys(c).forEach(function(a){var b=c[a],d;if("number"===typeof b||"boolean"===typeof b)d=v(function(){return b});else if("function"===typeof b){var f=b._reglType;if("texture2d"===f||
+"textureCube"===f)d=v(function(a){return a.link(b)});else if("framebuffer"===f||"framebufferCube"===f)d=v(function(a){return a.link(b.color[0])})}else ma(b)&&(d=v(function(a){return a.global.def("[",J(b.length,function(a){return b[a]}),"]")}));d.value=b;e[a]=d});Object.keys(d).forEach(function(a){var b=d[a];e[a]=L(b,function(a,c){return a.invoke(c,b)})});return e}function S(a,c){var d=a["static"],e=a.dynamic,g={};Object.keys(d).forEach(function(a){var c=d[a],e=b.id(a),x=new ga;if(Qa(c))x.state=1,
+x.buffer=f.getBuffer(f.create(c,34962,!1,!0)),x.type=0;else{var h=f.getBuffer(c);if(h)x.state=1,x.buffer=h,x.type=0;else if("constant"in c){var I=c.constant;x.buffer="null";x.state=2;"number"===typeof I?x.x=I:Ba.forEach(function(a,b){b<I.length&&(x[a]=I[b])})}else{var h=Qa(c.buffer)?f.getBuffer(f.create(c.buffer,34962,!1,!0)):f.getBuffer(c.buffer),k=c.offset|0,l=c.stride|0,m=c.size|0,ka=!!c.normalized,n=0;"type"in c&&(n=Ia[c.type]);c=c.divisor|0;x.buffer=h;x.state=1;x.size=m;x.normalized=ka;x.type=
+n||h.dtype;x.offset=k;x.stride=l;x.divisor=c}}g[a]=v(function(a,b){var c=a.attribCache;if(e in c)return c[e];var d={isStream:!1};Object.keys(x).forEach(function(a){d[a]=x[a]});x.buffer&&(d.buffer=a.link(x.buffer),d.type=d.type||d.buffer+".dtype");return c[e]=d})});Object.keys(e).forEach(function(a){var b=e[a];g[a]=L(b,function(a,c){function d(a){c(h[a],"=",e,".",a,"|0;")}var e=a.invoke(c,b),f=a.shared,g=a.constants,x=f.isBufferArgs,f=f.buffer,h={isStream:c.def(!1)},I=new ga;I.state=1;Object.keys(I).forEach(function(a){h[a]=
+c.def(""+I[a])});var k=h.buffer,l=h.type;c("if(",x,"(",e,")){",h.isStream,"=true;",k,"=",f,".createStream(",34962,",",e,");",l,"=",k,".dtype;","}else{",k,"=",f,".getBuffer(",e,");","if(",k,"){",l,"=",k,".dtype;",'}else if("constant" in ',e,"){",h.state,"=",2,";","if(typeof "+e+'.constant === "number"){',h[Ba[0]],"=",e,".constant;",Ba.slice(1).map(function(a){return h[a]}).join("="),"=0;","}else{",Ba.map(function(a,b){return h[a]+"="+e+".constant.length>"+b+"?"+e+".constant["+b+"]:0;"}).join(""),"}}else{",
+"if(",x,"(",e,".buffer)){",k,"=",f,".createStream(",34962,",",e,".buffer);","}else{",k,"=",f,".getBuffer(",e,".buffer);","}",l,'="type" in ',e,"?",g.glTypes,"[",e,".type]:",k,".dtype;",h.normalized,"=!!",e,".normalized;");d("size");d("offset");d("stride");d("divisor");c("}}");c.exit("if(",h.isStream,"){",f,".destroyStream(",k,");","}");return h})});return g}function D(a,b){var c=a["static"],d=a.dynamic;if("vao"in c){var e=c.vao;null!==e&&null===t.getVAO(e)&&(e=t.createVAO(e));return v(function(a){return a.link(t.getVAO(e))})}if("vao"in
+d){var f=d.vao;return L(f,function(a,b){var c=a.invoke(b,f);return b.def(a.shared.vao+".getVAO("+c+")")})}return null}function y(a){var b=a["static"],c=a.dynamic,d={};Object.keys(b).forEach(function(a){var c=b[a];d[a]=v(function(a,b){return"number"===typeof c||"boolean"===typeof c?""+c:a.link(c)})});Object.keys(c).forEach(function(a){var b=c[a];d[a]=L(b,function(a,c){return a.invoke(c,b)})});return d}function la(a,b,d,e,f){function h(a){var b=m[a];b&&($a[a]=b)}var k=Z(a,b),l=E(a,f),m=F(a,l,f),n=H(a,
+f),$a=O(a,f),p=G(a,f,k);h("viewport");h(g("scissor.box"));var q=0<Object.keys($a).length,l={framebuffer:l,draw:n,shader:p,state:$a,dirty:q,scopeVAO:null,drawVAO:null,useVAO:!1,attributes:{}};l.profile=z(a,f);l.uniforms=M(d,f);l.drawVAO=l.scopeVAO=D(a,f);if(!l.drawVAO&&p.program&&!k&&c.angle_instanced_arrays){var r=!0;a=p.program.attributes.map(function(a){a=b["static"][a];r=r&&!!a;return a});if(r&&0<a.length){var w=t.getVAO(t.createVAO(a));l.drawVAO=new K(null,null,null,function(a,b){return a.link(w)});
+l.useVAO=!0}}k?l.useVAO=!0:l.attributes=S(b,f);l.context=y(e,f);return l}function V(a,b,c){var d=a.shared.context,e=a.scope();Object.keys(c).forEach(function(f){b.save(d,"."+f);var g=c[f].append(a,b);Array.isArray(g)?e(d,".",f,"=[",g.join(),"];"):e(d,".",f,"=",g,";")});b(e)}function R(a,b,c,d){var e=a.shared,f=e.gl,g=e.framebuffer,h;Ka&&(h=b.def(e.extensions,".webgl_draw_buffers"));var k=a.constants,e=k.drawBuffer,k=k.backBuffer;a=c?c.append(a,b):b.def(g,".next");d||b("if(",a,"!==",g,".cur){");b("if(",
+a,"){",f,".bindFramebuffer(",36160,",",a,".framebuffer);");Ka&&b(h,".drawBuffersWEBGL(",e,"[",a,".colorAttachments.length]);");b("}else{",f,".bindFramebuffer(",36160,",null);");Ka&&b(h,".drawBuffersWEBGL(",k,");");b("}",g,".cur=",a,";");d||b("}")}function T(a,b,c){var d=a.shared,e=d.gl,f=a.current,h=a.next,k=d.current,l=d.next,m=a.cond(k,".dirty");La.forEach(function(b){b=g(b);if(!(b in c.state)){var d,I;if(b in h){d=h[b];I=f[b];var n=J(pa[b].length,function(a){return m.def(d,"[",a,"]")});m(a.cond(n.map(function(a,
+b){return a+"!=="+I+"["+b+"]"}).join("||")).then(e,".",ra[b],"(",n,");",n.map(function(a,b){return I+"["+b+"]="+a}).join(";"),";"))}else d=m.def(l,".",b),n=a.cond(d,"!==",k,".",b),m(n),b in qa?n(a.cond(d).then(e,".enable(",qa[b],");")["else"](e,".disable(",qa[b],");"),k,".",b,"=",d,";"):n(e,".",ra[b],"(",d,");",k,".",b,"=",d,";")}});0===Object.keys(c.state).length&&m(k,".dirty=false;");b(m)}function N(a,b,c,d){var e=a.shared,f=a.current,g=e.current,h=e.gl;zb(Object.keys(c)).forEach(function(e){var k=
+c[e];if(!d||d(k)){var l=k.append(a,b);if(qa[e]){var m=qa[e];sa(k)?l?b(h,".enable(",m,");"):b(h,".disable(",m,");"):b(a.cond(l).then(h,".enable(",m,");")["else"](h,".disable(",m,");"));b(g,".",e,"=",l,";")}else if(ma(l)){var n=f[e];b(h,".",ra[e],"(",l,");",l.map(function(a,b){return n+"["+b+"]="+a}).join(";"),";")}else b(h,".",ra[e],"(",l,");",g,".",e,"=",l,";")}})}function C(a,b){oa&&(a.instancing=b.def(a.shared.extensions,".angle_instanced_arrays"))}function Q(a,b,c,d,e){function f(){return"undefined"===
+typeof performance?"Date.now()":"performance.now()"}function g(a){r=b.def();a(r,"=",f(),";");"string"===typeof e?a(n,".count+=",e,";"):a(n,".count++;");l&&(d?(t=b.def(),a(t,"=",q,".getNumPendingQueries();")):a(q,".beginQuery(",n,");"))}function h(a){a(n,".cpuTime+=",f(),"-",r,";");l&&(d?a(q,".pushScopeStats(",t,",",q,".getNumPendingQueries(),",n,");"):a(q,".endQuery();"))}function k(a){var c=b.def(p,".profile");b(p,".profile=",a,";");b.exit(p,".profile=",c,";")}var m=a.shared,n=a.stats,p=m.current,
+q=m.timer;c=c.profile;var r,t;if(c){if(sa(c)){c.enable?(g(b),h(b.exit),k("true")):k("false");return}c=c.append(a,b);k(c)}else c=b.def(p,".profile");m=a.block();g(m);b("if(",c,"){",m,"}");a=a.block();h(a);b.exit("if(",c,"){",a,"}")}function U(a,b,c,d,e){function f(a){switch(a){case 35664:case 35667:case 35671:return 2;case 35665:case 35668:case 35672:return 3;case 35666:case 35669:case 35673:return 4;default:return 1}}function g(c,d,e){function f(){b("if(!",n,".buffer){",l,".enableVertexAttribArray(",
+m,");}");var c=e.type,g;g=e.size?b.def(e.size,"||",d):d;b("if(",n,".type!==",c,"||",n,".size!==",g,"||",q.map(function(a){return n+"."+a+"!=="+e[a]}).join("||"),"){",l,".bindBuffer(",34962,",",ja,".buffer);",l,".vertexAttribPointer(",[m,g,c,e.normalized,e.stride,e.offset],");",n,".type=",c,";",n,".size=",g,";",q.map(function(a){return n+"."+a+"="+e[a]+";"}).join(""),"}");oa&&(c=e.divisor,b("if(",n,".divisor!==",c,"){",a.instancing,".vertexAttribDivisorANGLE(",[m,c],");",n,".divisor=",c,";}"))}function k(){b("if(",
+n,".buffer){",l,".disableVertexAttribArray(",m,");",n,".buffer=null;","}if(",Ba.map(function(a,b){return n+"."+a+"!=="+p[b]}).join("||"),"){",l,".vertexAttrib4f(",m,",",p,");",Ba.map(function(a,b){return n+"."+a+"="+p[b]+";"}).join(""),"}")}var l=h.gl,m=b.def(c,".location"),n=b.def(h.attributes,"[",m,"]");c=e.state;var ja=e.buffer,p=[e.x,e.y,e.z,e.w],q=["buffer","normalized","offset","stride"];1===c?f():2===c?k():(b("if(",c,"===",1,"){"),f(),b("}else{"),k(),b("}"))}var h=a.shared;d.forEach(function(d){var h=
+d.name,k=c.attributes[h],l;if(k){if(!e(k))return;l=k.append(a,b)}else{if(!e(Bb))return;var m=a.scopeAttrib(h);l={};Object.keys(new ga).forEach(function(a){l[a]=b.def(m,".",a)})}g(a.link(d),f(d.info.type),l)})}function ta(a,c,d,e,f){for(var g=a.shared,h=g.gl,k,l=0;l<e.length;++l){var m=e[l],n=m.name,p=m.info.type,q=d.uniforms[n],m=a.link(m)+".location",r;if(q){if(!f(q))continue;if(sa(q)){n=q.value;if(35678===p||35680===p)p=a.link(n._texture||n.color[0]._texture),c(h,".uniform1i(",m,",",p+".bind());"),
+c.exit(p,".unbind();");else if(35674===p||35675===p||35676===p)n=a.global.def("new Float32Array(["+Array.prototype.slice.call(n)+"])"),q=2,35675===p?q=3:35676===p&&(q=4),c(h,".uniformMatrix",q,"fv(",m,",false,",n,");");else{switch(p){case 5126:k="1f";break;case 35664:k="2f";break;case 35665:k="3f";break;case 35666:k="4f";break;case 35670:k="1i";break;case 5124:k="1i";break;case 35671:k="2i";break;case 35667:k="2i";break;case 35672:k="3i";break;case 35668:k="3i";break;case 35673:k="4i";break;case 35669:k=
+"4i"}c(h,".uniform",k,"(",m,",",ma(n)?Array.prototype.slice.call(n):n,");")}continue}else r=q.append(a,c)}else{if(!f(Bb))continue;r=c.def(g.uniforms,"[",b.id(n),"]")}35678===p?c("if(",r,"&&",r,'._reglType==="framebuffer"){',r,"=",r,".color[0];","}"):35680===p&&c("if(",r,"&&",r,'._reglType==="framebufferCube"){',r,"=",r,".color[0];","}");n=1;switch(p){case 35678:case 35680:p=c.def(r,"._texture");c(h,".uniform1i(",m,",",p,".bind());");c.exit(p,".unbind();");continue;case 5124:case 35670:k="1i";break;
+case 35667:case 35671:k="2i";n=2;break;case 35668:case 35672:k="3i";n=3;break;case 35669:case 35673:k="4i";n=4;break;case 5126:k="1f";break;case 35664:k="2f";n=2;break;case 35665:k="3f";n=3;break;case 35666:k="4f";n=4;break;case 35674:k="Matrix2fv";break;case 35675:k="Matrix3fv";break;case 35676:k="Matrix4fv"}c(h,".uniform",k,"(",m,",");if("M"===k.charAt(0)){var m=Math.pow(p-35674+2,2),t=a.global.def("new Float32Array(",m,")");Array.isArray(r)?c("false,(",J(m,function(a){return t+"["+a+"]="+r[a]}),
+",",t,")"):c("false,(Array.isArray(",r,")||",r," instanceof Float32Array)?",r,":(",J(m,function(a){return t+"["+a+"]="+r+"["+a+"]"}),",",t,")")}else 1<n?c(J(n,function(a){return Array.isArray(r)?r[a]:r+"["+a+"]"})):c(r);c(");")}}function aa(a,b,c,d){function e(f){var g=m[f];return g?g.contextDep&&d.contextDynamic||g.propDep?g.append(a,c):g.append(a,b):b.def(l,".",f)}function f(){function a(){c(w,".drawElementsInstancedANGLE(",[p,q,u,r+"<<(("+u+"-5121)>>1)",t],");")}function b(){c(w,".drawArraysInstancedANGLE(",
+[p,r,q,t],");")}n?B?a():(c("if(",n,"){"),a(),c("}else{"),b(),c("}")):b()}function g(){function a(){c(k+".drawElements("+[p,q,u,r+"<<(("+u+"-5121)>>1)"]+");")}function b(){c(k+".drawArrays("+[p,r,q]+");")}n?B?a():(c("if(",n,"){"),a(),c("}else{"),b(),c("}")):b()}var h=a.shared,k=h.gl,l=h.draw,m=d.draw,n=function(){var e=m.elements,f=b;if(e){if(e.contextDep&&d.contextDynamic||e.propDep)f=c;e=e.append(a,f)}else e=f.def(l,".","elements");e&&f("if("+e+")"+k+".bindBuffer(34963,"+e+".buffer.buffer);");return e}(),
+p=e("primitive"),r=e("offset"),q=function(){var e=m.count,f=b;if(e){if(e.contextDep&&d.contextDynamic||e.propDep)f=c;e=e.append(a,f)}else e=f.def(l,".","count");return e}();if("number"===typeof q){if(0===q)return}else c("if(",q,"){"),c.exit("}");var t,w;oa&&(t=e("instances"),w=a.instancing);var u=n+".type",B=m.elements&&sa(m.elements);oa&&("number"!==typeof t||0<=t)?"string"===typeof t?(c("if(",t,">0){"),f(),c("}else if(",t,"<0){"),g(),c("}")):f():g()}function X(a,b,c,d,e){b=m();e=b.proc("body",e);
+oa&&(b.instancing=e.def(b.shared.extensions,".angle_instanced_arrays"));a(b,e,c,d);return b.compile().body}function fa(a,b,c,d){C(a,b);c.useVAO?c.drawVAO?b(a.shared.vao,".setVAO(",c.drawVAO.append(a,b),");"):b(a.shared.vao,".setVAO(",a.shared.vao,".targetVAO);"):(b(a.shared.vao,".setVAO(null);"),U(a,b,c,d.attributes,function(){return!0}));ta(a,b,c,d.uniforms,function(){return!0});aa(a,b,b,c)}function Da(a,b){var c=a.proc("draw",1);C(a,c);V(a,c,b.context);R(a,c,b.framebuffer);T(a,c,b);N(a,c,b.state);
+Q(a,c,b,!1,!0);var d=b.shader.progVar.append(a,c);c(a.shared.gl,".useProgram(",d,".program);");if(b.shader.program)fa(a,c,b,b.shader.program);else{c(a.shared.vao,".setVAO(null);");var e=a.global.def("{}"),f=c.def(d,".id"),g=c.def(e,"[",f,"]");c(a.cond(g).then(g,".call(this,a0);")["else"](g,"=",e,"[",f,"]=",a.link(function(c){return X(fa,a,b,c,1)}),"(",d,");",g,".call(this,a0);"))}0<Object.keys(b.state).length&&c(a.shared.current,".dirty=true;")}function ua(a,b,c,d){function e(){return!0}a.batchId=
+"a1";C(a,b);U(a,b,c,d.attributes,e);ta(a,b,c,d.uniforms,e);aa(a,b,b,c)}function P(a,b,c,d){function e(a){return a.contextDep&&g||a.propDep}function f(a){return!e(a)}C(a,b);var g=c.contextDep,h=b.def(),k=b.def();a.shared.props=k;a.batchId=h;var l=a.scope(),m=a.scope();b(l.entry,"for(",h,"=0;",h,"<","a1",";++",h,"){",k,"=","a0","[",h,"];",m,"}",l.exit);c.needsContext&&V(a,m,c.context);c.needsFramebuffer&&R(a,m,c.framebuffer);N(a,m,c.state,e);c.profile&&e(c.profile)&&Q(a,m,c,!1,!0);d?(c.useVAO?c.drawVAO?
+e(c.drawVAO)?m(a.shared.vao,".setVAO(",c.drawVAO.append(a,m),");"):l(a.shared.vao,".setVAO(",c.drawVAO.append(a,l),");"):l(a.shared.vao,".setVAO(",a.shared.vao,".targetVAO);"):(l(a.shared.vao,".setVAO(null);"),U(a,l,c,d.attributes,f),U(a,m,c,d.attributes,e)),ta(a,l,c,d.uniforms,f),ta(a,m,c,d.uniforms,e),aa(a,l,m,c)):(b=a.global.def("{}"),d=c.shader.progVar.append(a,m),k=m.def(d,".id"),l=m.def(b,"[",k,"]"),m(a.shared.gl,".useProgram(",d,".program);","if(!",l,"){",l,"=",b,"[",k,"]=",a.link(function(b){return X(ua,
+a,c,b,2)}),"(",d,");}",l,".call(this,a0[",h,"],",h,");"))}function da(a,b){function c(a){return a.contextDep&&e||a.propDep}var d=a.proc("batch",2);a.batchId="0";C(a,d);var e=!1,f=!0;Object.keys(b.context).forEach(function(a){e=e||b.context[a].propDep});e||(V(a,d,b.context),f=!1);var g=b.framebuffer,h=!1;g?(g.propDep?e=h=!0:g.contextDep&&e&&(h=!0),h||R(a,d,g)):R(a,d,null);b.state.viewport&&b.state.viewport.propDep&&(e=!0);T(a,d,b);N(a,d,b.state,function(a){return!c(a)});b.profile&&c(b.profile)||Q(a,
+d,b,!1,"a1");b.contextDep=e;b.needsContext=f;b.needsFramebuffer=h;f=b.shader.progVar;if(f.contextDep&&e||f.propDep)P(a,d,b,null);else if(f=f.append(a,d),d(a.shared.gl,".useProgram(",f,".program);"),b.shader.program)P(a,d,b,b.shader.program);else{d(a.shared.vao,".setVAO(null);");var g=a.global.def("{}"),h=d.def(f,".id"),k=d.def(g,"[",h,"]");d(a.cond(k).then(k,".call(this,a0,a1);")["else"](k,"=",g,"[",h,"]=",a.link(function(c){return X(P,a,b,c,2)}),"(",f,");",k,".call(this,a0,a1);"))}0<Object.keys(b.state).length&&
+d(a.shared.current,".dirty=true;")}function ea(a,c){function d(b){var g=c.shader[b];g&&e.set(f.shader,"."+b,g.append(a,e))}var e=a.proc("scope",3);a.batchId="a2";var f=a.shared,g=f.current;V(a,e,c.context);c.framebuffer&&c.framebuffer.append(a,e);zb(Object.keys(c.state)).forEach(function(b){var d=c.state[b].append(a,e);ma(d)?d.forEach(function(c,d){e.set(a.next[b],"["+d+"]",c)}):e.set(f.next,"."+b,d)});Q(a,e,c,!0,!0);["elements","offset","count","instances","primitive"].forEach(function(b){var d=
+c.draw[b];d&&e.set(f.draw,"."+b,""+d.append(a,e))});Object.keys(c.uniforms).forEach(function(d){var g=c.uniforms[d].append(a,e);Array.isArray(g)&&(g="["+g.join()+"]");e.set(f.uniforms,"["+b.id(d)+"]",g)});Object.keys(c.attributes).forEach(function(b){var d=c.attributes[b].append(a,e),f=a.scopeAttrib(b);Object.keys(new ga).forEach(function(a){e.set(f,"."+a,d[a])})});c.scopeVAO&&e.set(f.vao,".targetVAO",c.scopeVAO.append(a,e));d("vert");d("frag");0<Object.keys(c.state).length&&(e(g,".dirty=true;"),
+e.exit(g,".dirty=true;"));e("a1(",a.shared.context,",a0,",a.batchId,");")}function ha(a){if("object"===typeof a&&!ma(a)){for(var b=Object.keys(a),c=0;c<b.length;++c)if(Y.isDynamic(a[b[c]]))return!0;return!1}}function ia(a,b,c){function d(a,b){g.forEach(function(c){var d=e[c];Y.isDynamic(d)&&(d=a.invoke(b,d),b(m,".",c,"=",d,";"))})}var e=b["static"][c];if(e&&ha(e)){var f=a.global,g=Object.keys(e),h=!1,k=!1,l=!1,m=a.global.def("{}");g.forEach(function(b){var c=e[b];if(Y.isDynamic(c))"function"===typeof c&&
+(c=e[b]=Y.unbox(c)),b=L(c,null),h=h||b.thisDep,l=l||b.propDep,k=k||b.contextDep;else{f(m,".",b,"=");switch(typeof c){case "number":f(c);break;case "string":f('"',c,'"');break;case "object":Array.isArray(c)&&f("[",c.join(),"]");break;default:f(a.link(c))}f(";")}});b.dynamic[c]=new Y.DynamicVariable(4,{thisDep:h,contextDep:k,propDep:l,ref:m,append:d});delete b["static"][c]}}var ga=t.Record,W={add:32774,subtract:32778,"reverse subtract":32779};c.ext_blend_minmax&&(W.min=32775,W.max=32776);var oa=c.angle_instanced_arrays,
+Ka=c.webgl_draw_buffers,pa={dirty:!0,profile:h.profile},Ca={},La=[],qa={},ra={};q("dither",3024);q("blend.enable",3042);r("blend.color","blendColor",[0,0,0,0]);r("blend.equation","blendEquationSeparate",[32774,32774]);r("blend.func","blendFuncSeparate",[1,0,1,0]);q("depth.enable",2929,!0);r("depth.func","depthFunc",513);r("depth.range","depthRange",[0,1]);r("depth.mask","depthMask",!0);r("colorMask","colorMask",[!0,!0,!0,!0]);q("cull.enable",2884);r("cull.face","cullFace",1029);r("frontFace","frontFace",
+2305);r("lineWidth","lineWidth",1);q("polygonOffset.enable",32823);r("polygonOffset.offset","polygonOffset",[0,0]);q("sample.alpha",32926);q("sample.enable",32928);r("sample.coverage","sampleCoverage",[1,!1]);q("stencil.enable",2960);r("stencil.mask","stencilMask",-1);r("stencil.func","stencilFunc",[519,0,-1]);r("stencil.opFront","stencilOpSeparate",[1028,7680,7680,7680]);r("stencil.opBack","stencilOpSeparate",[1029,7680,7680,7680]);q("scissor.enable",3089);r("scissor.box","scissor",[0,0,a.drawingBufferWidth,
+a.drawingBufferHeight]);r("viewport","viewport",[0,0,a.drawingBufferWidth,a.drawingBufferHeight]);var ub={gl:a,context:B,strings:b,next:Ca,current:pa,draw:k,elements:d,buffer:f,shader:w,attributes:t.state,vao:t,uniforms:u,framebuffer:n,extensions:c,timer:l,isBufferArgs:Qa},Na={primTypes:Ta,compareFuncs:ab,blendFuncs:Ea,blendEquations:W,stencilOps:Ra,glTypes:Ia,orientationType:Ab};Ka&&(Na.backBuffer=[1029],Na.drawBuffer=J(e.maxDrawbuffers,function(a){return 0===a?[0]:J(a,function(a){return 36064+a})}));
+var na=0;return{next:Ca,current:pa,procs:function(){var a=m(),b=a.proc("poll"),d=a.proc("refresh"),f=a.block();b(f);d(f);var g=a.shared,h=g.gl,k=g.next,l=g.current;f(l,".dirty=false;");R(a,b);R(a,d,null,!0);var n;oa&&(n=a.link(oa));c.oes_vertex_array_object&&d(a.link(c.oes_vertex_array_object),".bindVertexArrayOES(null);");for(var p=0;p<e.maxAttributes;++p){var q=d.def(g.attributes,"[",p,"]"),r=a.cond(q,".buffer");r.then(h,".enableVertexAttribArray(",p,");",h,".bindBuffer(",34962,",",q,".buffer.buffer);",
+h,".vertexAttribPointer(",p,",",q,".size,",q,".type,",q,".normalized,",q,".stride,",q,".offset);")["else"](h,".disableVertexAttribArray(",p,");",h,".vertexAttrib4f(",p,",",q,".x,",q,".y,",q,".z,",q,".w);",q,".buffer=null;");d(r);oa&&d(n,".vertexAttribDivisorANGLE(",p,",",q,".divisor);")}d(a.shared.vao,".currentVAO=null;",a.shared.vao,".setVAO(",a.shared.vao,".targetVAO);");Object.keys(qa).forEach(function(c){var e=qa[c],g=f.def(k,".",c),m=a.block();m("if(",g,"){",h,".enable(",e,")}else{",h,".disable(",
+e,")}",l,".",c,"=",g,";");d(m);b("if(",g,"!==",l,".",c,"){",m,"}")});Object.keys(ra).forEach(function(c){var e=ra[c],g=pa[c],m,n,p=a.block();p(h,".",e,"(");ma(g)?(e=g.length,m=a.global.def(k,".",c),n=a.global.def(l,".",c),p(J(e,function(a){return m+"["+a+"]"}),");",J(e,function(a){return n+"["+a+"]="+m+"["+a+"];"}).join("")),b("if(",J(e,function(a){return m+"["+a+"]!=="+n+"["+a+"]"}).join("||"),"){",p,"}")):(m=f.def(k,".",c),n=f.def(l,".",c),p(m,");",l,".",c,"=",m,";"),b("if(",m,"!==",n,"){",p,"}"));
+d(p)});return a.compile()}(),compile:function(a,b,c,d,e){var f=m();f.stats=f.link(e);Object.keys(b["static"]).forEach(function(a){ia(f,b,a)});Xb.forEach(function(b){ia(f,a,b)});var g=la(a,b,c,d,f);Da(f,g);ea(f,g);da(f,g);return A(f.compile(),{destroy:function(){g.shader.program.destroy()}})}}}function Cb(a,b){for(var c=0;c<a.length;++c)if(a[c]===b)return c;return-1}var A=function(a,b){for(var c=Object.keys(b),e=0;e<c.length;++e)a[c[e]]=b[c[e]];return a},Eb=0,Y={DynamicVariable:U,define:function(a,
+b){return new U(a,cb(b+""))},isDynamic:function(a){return"function"===typeof a&&!a._reglType||a instanceof U},unbox:db,accessor:cb},bb={next:"function"===typeof requestAnimationFrame?function(a){return requestAnimationFrame(a)}:function(a){return setTimeout(a,16)},cancel:"function"===typeof cancelAnimationFrame?function(a){return cancelAnimationFrame(a)}:clearTimeout},Db="undefined"!==typeof performance&&performance.now?function(){return performance.now()}:function(){return+new Date},E=hb();E.zero=
+hb();var Yb=function(a,b){var c=1;b.ext_texture_filter_anisotropic&&(c=a.getParameter(34047));var e=1,f=1;b.webgl_draw_buffers&&(e=a.getParameter(34852),f=a.getParameter(36063));var d=!!b.oes_texture_float;if(d){d=a.createTexture();a.bindTexture(3553,d);a.texImage2D(3553,0,6408,1,1,0,6408,5126,null);var p=a.createFramebuffer();a.bindFramebuffer(36160,p);a.framebufferTexture2D(36160,36064,3553,d,0);a.bindTexture(3553,null);if(36053!==a.checkFramebufferStatus(36160))d=!1;else{a.viewport(0,0,1,1);a.clearColor(1,
+0,0,1);a.clear(16384);var n=E.allocType(5126,4);a.readPixels(0,0,1,1,6408,5126,n);a.getError()?d=!1:(a.deleteFramebuffer(p),a.deleteTexture(d),d=1===n[0]);E.freeType(n)}}n=!0;"undefined"!==typeof navigator&&(/MSIE/.test(navigator.userAgent)||/Trident\//.test(navigator.appVersion)||/Edge/.test(navigator.userAgent))||(n=a.createTexture(),p=E.allocType(5121,36),a.activeTexture(33984),a.bindTexture(34067,n),a.texImage2D(34069,0,6408,3,3,0,6408,5121,p),E.freeType(p),a.bindTexture(34067,null),a.deleteTexture(n),
+n=!a.getError());return{colorBits:[a.getParameter(3410),a.getParameter(3411),a.getParameter(3412),a.getParameter(3413)],depthBits:a.getParameter(3414),stencilBits:a.getParameter(3415),subpixelBits:a.getParameter(3408),extensions:Object.keys(b).filter(function(a){return!!b[a]}),maxAnisotropic:c,maxDrawbuffers:e,maxColorAttachments:f,pointSizeDims:a.getParameter(33901),lineWidthDims:a.getParameter(33902),maxViewportDims:a.getParameter(3386),maxCombinedTextureUnits:a.getParameter(35661),maxCubeMapSize:a.getParameter(34076),
+maxRenderbufferSize:a.getParameter(34024),maxTextureUnits:a.getParameter(34930),maxTextureSize:a.getParameter(3379),maxAttributes:a.getParameter(34921),maxVertexUniforms:a.getParameter(36347),maxVertexTextureUnits:a.getParameter(35660),maxVaryingVectors:a.getParameter(36348),maxFragmentUniforms:a.getParameter(36349),glsl:a.getParameter(35724),renderer:a.getParameter(7937),vendor:a.getParameter(7936),version:a.getParameter(7938),readFloat:d,npotTextureCube:n}},M=function(a){return a instanceof Uint8Array||
+a instanceof Uint16Array||a instanceof Uint32Array||a instanceof Int8Array||a instanceof Int16Array||a instanceof Int32Array||a instanceof Float32Array||a instanceof Float64Array||a instanceof Uint8ClampedArray},S=function(a){return Object.keys(a).map(function(b){return a[b]})},Oa={shape:function(a){for(var b=[];a.length;a=a[0])b.push(a.length);return b},flatten:function(a,b,c,e){var f=1;if(b.length)for(var d=0;d<b.length;++d)f*=b[d];else f=0;c=e||E.allocType(c,f);switch(b.length){case 0:break;case 1:e=
+b[0];for(b=0;b<e;++b)c[b]=a[b];break;case 2:e=b[0];b=b[1];for(d=f=0;d<e;++d)for(var p=a[d],n=0;n<b;++n)c[f++]=p[n];break;case 3:ib(a,b[0],b[1],b[2],c,0);break;default:jb(a,b,0,c,0)}return c}},Ga={"[object Int8Array]":5120,"[object Int16Array]":5122,"[object Int32Array]":5124,"[object Uint8Array]":5121,"[object Uint8ClampedArray]":5121,"[object Uint16Array]":5123,"[object Uint32Array]":5125,"[object Float32Array]":5126,"[object Float64Array]":5121,"[object ArrayBuffer]":5121},Ia={int8:5120,int16:5122,
+int32:5124,uint8:5121,uint16:5123,uint32:5125,"float":5126,float32:5126},ob={dynamic:35048,stream:35040,"static":35044},Sa=Oa.flatten,mb=Oa.shape,ha=[];ha[5120]=1;ha[5122]=2;ha[5124]=4;ha[5121]=1;ha[5123]=2;ha[5125]=4;ha[5126]=4;var Ta={points:0,point:0,lines:1,line:1,triangles:4,triangle:4,"line loop":2,"line strip":3,"triangle strip":5,"triangle fan":6},qb=new Float32Array(1),Mb=new Uint32Array(qb.buffer),Qb=[9984,9986,9985,9987],Ma=[0,6409,6410,6407,6408],Q={};Q[6409]=Q[6406]=Q[6402]=1;Q[34041]=
+Q[6410]=2;Q[6407]=Q[35904]=3;Q[6408]=Q[35906]=4;var Wa=na("HTMLCanvasElement"),Xa=na("OffscreenCanvas"),vb=na("CanvasRenderingContext2D"),wb=na("ImageBitmap"),xb=na("HTMLImageElement"),yb=na("HTMLVideoElement"),Nb=Object.keys(Ga).concat([Wa,Xa,vb,wb,xb,yb]),wa=[];wa[5121]=1;wa[5126]=4;wa[36193]=2;wa[5123]=2;wa[5125]=4;var F=[];F[32854]=2;F[32855]=2;F[36194]=2;F[34041]=4;F[33776]=.5;F[33777]=.5;F[33778]=1;F[33779]=1;F[35986]=.5;F[35987]=1;F[34798]=1;F[35840]=.5;F[35841]=.25;F[35842]=.5;F[35843]=.25;
+F[36196]=.5;var T=[];T[32854]=2;T[32855]=2;T[36194]=2;T[33189]=2;T[36168]=1;T[34041]=4;T[35907]=4;T[34836]=16;T[34842]=8;T[34843]=6;var Zb=function(a,b,c,e,f){function d(a){this.id=t++;this.refCount=1;this.renderbuffer=a;this.format=32854;this.height=this.width=0;f.profile&&(this.stats={size:0})}function p(b){var c=b.renderbuffer;a.bindRenderbuffer(36161,null);a.deleteRenderbuffer(c);b.renderbuffer=null;b.refCount=0;delete w[b.id];e.renderbufferCount--}var n={rgba4:32854,rgb565:36194,"rgb5 a1":32855,
+depth:33189,stencil:36168,"depth stencil":34041};b.ext_srgb&&(n.srgba=35907);b.ext_color_buffer_half_float&&(n.rgba16f=34842,n.rgb16f=34843);b.webgl_color_buffer_float&&(n.rgba32f=34836);var u=[];Object.keys(n).forEach(function(a){u[n[a]]=a});var t=0,w={};d.prototype.decRef=function(){0>=--this.refCount&&p(this)};f.profile&&(e.getTotalRenderbufferSize=function(){var a=0;Object.keys(w).forEach(function(b){a+=w[b].stats.size});return a});return{create:function(b,c){function l(b,c){var d=0,e=0,k=32854;
+"object"===typeof b&&b?("shape"in b?(e=b.shape,d=e[0]|0,e=e[1]|0):("radius"in b&&(d=e=b.radius|0),"width"in b&&(d=b.width|0),"height"in b&&(e=b.height|0)),"format"in b&&(k=n[b.format])):"number"===typeof b?(d=b|0,e="number"===typeof c?c|0:d):b||(d=e=1);if(d!==h.width||e!==h.height||k!==h.format)return l.width=h.width=d,l.height=h.height=e,h.format=k,a.bindRenderbuffer(36161,h.renderbuffer),a.renderbufferStorage(36161,k,d,e),f.profile&&(h.stats.size=T[h.format]*h.width*h.height),l.format=u[h.format],
+l}var h=new d(a.createRenderbuffer());w[h.id]=h;e.renderbufferCount++;l(b,c);l.resize=function(b,c){var d=b|0,e=c|0||d;if(d===h.width&&e===h.height)return l;l.width=h.width=d;l.height=h.height=e;a.bindRenderbuffer(36161,h.renderbuffer);a.renderbufferStorage(36161,h.format,d,e);f.profile&&(h.stats.size=T[h.format]*h.width*h.height);return l};l._reglType="renderbuffer";l._renderbuffer=h;f.profile&&(l.stats=h.stats);l.destroy=function(){h.decRef()};return l},clear:function(){S(w).forEach(p)},restore:function(){S(w).forEach(function(b){b.renderbuffer=
+a.createRenderbuffer();a.bindRenderbuffer(36161,b.renderbuffer);a.renderbufferStorage(36161,b.format,b.width,b.height)});a.bindRenderbuffer(36161,null)}}},Ya=[];Ya[6408]=4;Ya[6407]=3;var Pa=[];Pa[5121]=1;Pa[5126]=4;Pa[36193]=2;var Ba=["x","y","z","w"],Xb="blend.func blend.equation stencil.func stencil.opFront stencil.opBack sample.coverage viewport scissor.box polygonOffset.offset".split(" "),Ea={0:0,1:1,zero:0,one:1,"src color":768,"one minus src color":769,"src alpha":770,"one minus src alpha":771,
+"dst color":774,"one minus dst color":775,"dst alpha":772,"one minus dst alpha":773,"constant color":32769,"one minus constant color":32770,"constant alpha":32771,"one minus constant alpha":32772,"src alpha saturate":776},ab={never:512,less:513,"<":513,equal:514,"=":514,"==":514,"===":514,lequal:515,"<=":515,greater:516,">":516,notequal:517,"!=":517,"!==":517,gequal:518,">=":518,always:519},Ra={0:0,zero:0,keep:7680,replace:7681,increment:7682,decrement:7683,"increment wrap":34055,"decrement wrap":34056,
+invert:5386},Ab={cw:2304,ccw:2305},Bb=new K(!1,!1,!1,function(){}),$b=function(a,b){function c(){this.endQueryIndex=this.startQueryIndex=-1;this.sum=0;this.stats=null}function e(a,b,d){var e=p.pop()||new c;e.startQueryIndex=a;e.endQueryIndex=b;e.sum=0;e.stats=d;n.push(e)}if(!b.ext_disjoint_timer_query)return null;var f=[],d=[],p=[],n=[],u=[],t=[];return{beginQuery:function(a){var c=f.pop()||b.ext_disjoint_timer_query.createQueryEXT();b.ext_disjoint_timer_query.beginQueryEXT(35007,c);d.push(c);e(d.length-
+1,d.length,a)},endQuery:function(){b.ext_disjoint_timer_query.endQueryEXT(35007)},pushScopeStats:e,update:function(){var a,c;a=d.length;if(0!==a){t.length=Math.max(t.length,a+1);u.length=Math.max(u.length,a+1);u[0]=0;var e=t[0]=0;for(c=a=0;c<d.length;++c){var l=d[c];b.ext_disjoint_timer_query.getQueryObjectEXT(l,34919)?(e+=b.ext_disjoint_timer_query.getQueryObjectEXT(l,34918),f.push(l)):d[a++]=l;u[c+1]=e;t[c+1]=a}d.length=a;for(c=a=0;c<n.length;++c){var e=n[c],h=e.startQueryIndex,l=e.endQueryIndex;
+e.sum+=u[l]-u[h];h=t[h];l=t[l];l===h?(e.stats.gpuTime+=e.sum/1E6,p.push(e)):(e.startQueryIndex=h,e.endQueryIndex=l,n[a++]=e)}n.length=a}},getNumPendingQueries:function(){return d.length},clear:function(){f.push.apply(f,d);for(var a=0;a<f.length;a++)b.ext_disjoint_timer_query.deleteQueryEXT(f[a]);d.length=0;f.length=0},restore:function(){d.length=0;f.length=0}}};return function(a){function b(){if(0===C.length)z&&z.update(),aa=null;else{aa=bb.next(b);w();for(var a=C.length-1;0<=a;--a){var c=C[a];c&&
+c(G,null,0)}l.flush();z&&z.update()}}function c(){!aa&&0<C.length&&(aa=bb.next(b))}function e(){aa&&(bb.cancel(b),aa=null)}function f(a){a.preventDefault();e();S.forEach(function(a){a()})}function d(a){l.getError();g.restore();D.restore();O.restore();y.restore();L.restore();V.restore();J.restore();z&&z.restore();R.procs.refresh();c();T.forEach(function(a){a()})}function p(a){function b(a,c){var d={},e={};Object.keys(a).forEach(function(b){var f=a[b];if(Y.isDynamic(f))e[b]=Y.unbox(f,b);else{if(c&&
+Array.isArray(f))for(var g=0;g<f.length;++g)if(Y.isDynamic(f[g])){e[b]=Y.unbox(f,b);return}d[b]=f}});return{dynamic:e,"static":d}}function c(a){for(;n.length<a;)n.push(null);return n}var d=b(a.context||{},!0),e=b(a.uniforms||{},!0),f=b(a.attributes||{},!1);a=b(function(a){function b(a){if(a in c){var d=c[a];delete c[a];Object.keys(d).forEach(function(b){c[a+"."+b]=d[b]})}}var c=A({},a);delete c.uniforms;delete c.attributes;delete c.context;delete c.vao;"stencil"in c&&c.stencil.op&&(c.stencil.opBack=
+c.stencil.opFront=c.stencil.op,delete c.stencil.op);b("blend");b("depth");b("cull");b("stencil");b("polygonOffset");b("scissor");b("sample");"vao"in a&&(c.vao=a.vao);return c}(a),!1);var g={gpuTime:0,cpuTime:0,count:0},h=R.compile(a,f,e,d,g),k=h.draw,l=h.batch,m=h.scope,n=[];return A(function(a,b){var d;if("function"===typeof a)return m.call(this,null,a,0);if("function"===typeof b)if("number"===typeof a)for(d=0;d<a;++d)m.call(this,null,b,d);else if(Array.isArray(a))for(d=0;d<a.length;++d)m.call(this,
+a[d],b,d);else return m.call(this,a,b,0);else if("number"===typeof a){if(0<a)return l.call(this,c(a|0),a|0)}else if(Array.isArray(a)){if(a.length)return l.call(this,a,a.length)}else return k.call(this,a)},{stats:g,destroy:function(){h.destroy()}})}function n(a,b){var c=0;R.procs.poll();var d=b.color;d&&(l.clearColor(+d[0]||0,+d[1]||0,+d[2]||0,+d[3]||0),c|=16384);"depth"in b&&(l.clearDepth(+b.depth),c|=256);"stencil"in b&&(l.clearStencil(b.stencil|0),c|=1024);l.clear(c)}function u(a){C.push(a);c();
+return{cancel:function(){function b(){var a=Cb(C,b);C[a]=C[C.length-1];--C.length;0>=C.length&&e()}var c=Cb(C,a);C[c]=b}}}function t(){var a=Q.viewport,b=Q.scissor_box;a[0]=a[1]=b[0]=b[1]=0;G.viewportWidth=G.framebufferWidth=G.drawingBufferWidth=a[2]=b[2]=l.drawingBufferWidth;G.viewportHeight=G.framebufferHeight=G.drawingBufferHeight=a[3]=b[3]=l.drawingBufferHeight}function w(){G.tick+=1;G.time=v();t();R.procs.poll()}function k(){y.refresh();t();R.procs.refresh();z&&z.update()}function v(){return(Db()-
+E)/1E3}a=Ib(a);if(!a)return null;var l=a.gl,h=l.getContextAttributes();l.isContextLost();var g=Jb(l,a);if(!g)return null;var q=Fb(),r={vaoCount:0,bufferCount:0,elementsCount:0,framebufferCount:0,shaderCount:0,textureCount:0,cubeCount:0,renderbufferCount:0,maxTextureUnits:0},m=g.extensions,z=$b(l,m),E=Db(),F=l.drawingBufferWidth,K=l.drawingBufferHeight,G={tick:0,time:0,viewportWidth:F,viewportHeight:K,framebufferWidth:F,framebufferHeight:K,drawingBufferWidth:F,drawingBufferHeight:K,pixelRatio:a.pixelRatio},
+H=Yb(l,m),O=Kb(l,r,a,function(a){return J.destroyBuffer(a)}),J=Sb(l,m,H,r,O),M=Lb(l,m,O,r),D=Tb(l,q,r,a),y=Ob(l,m,H,function(){R.procs.poll()},G,r,a),L=Zb(l,m,H,r,a),V=Rb(l,m,H,y,L,r),R=Wb(l,q,m,H,O,M,y,V,{},J,D,{elements:null,primitive:4,count:-1,offset:0,instances:-1},G,z,a),q=Ub(l,V,R.procs.poll,G,h,m,H),Q=R.next,N=l.canvas,C=[],S=[],T=[],U=[a.onDestroy],aa=null;N&&(N.addEventListener("webglcontextlost",f,!1),N.addEventListener("webglcontextrestored",d,!1));var X=V.setFBO=p({framebuffer:Y.define.call(null,
+1,"framebuffer")});k();h=A(p,{clear:function(a){if("framebuffer"in a)if(a.framebuffer&&"framebufferCube"===a.framebuffer_reglType)for(var b=0;6>b;++b)X(A({framebuffer:a.framebuffer.faces[b]},a),n);else X(a,n);else n(null,a)},prop:Y.define.bind(null,1),context:Y.define.bind(null,2),"this":Y.define.bind(null,3),draw:p({}),buffer:function(a){return O.create(a,34962,!1,!1)},elements:function(a){return M.create(a,!1)},texture:y.create2D,cube:y.createCube,renderbuffer:L.create,framebuffer:V.create,framebufferCube:V.createCube,
+vao:J.createVAO,attributes:h,frame:u,on:function(a,b){var c;switch(a){case "frame":return u(b);case "lost":c=S;break;case "restore":c=T;break;case "destroy":c=U}c.push(b);return{cancel:function(){for(var a=0;a<c.length;++a)if(c[a]===b){c[a]=c[c.length-1];c.pop();break}}}},limits:H,hasExtension:function(a){return 0<=H.extensions.indexOf(a.toLowerCase())},read:q,destroy:function(){C.length=0;e();N&&(N.removeEventListener("webglcontextlost",f),N.removeEventListener("webglcontextrestored",d));D.clear();
+V.clear();L.clear();y.clear();M.clear();O.clear();J.clear();z&&z.clear();U.forEach(function(a){a()})},_gl:l,_refresh:k,poll:function(){w();z&&z.update()},now:v,stats:r});a.onDone(null,h);return h}});
 
 },{}],9:[function(require,module,exports){
 (function (global){(function (){
@@ -1050,14 +1064,11 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
 var _sandbox = _interopRequireDefault(require("./lib/sandbox.js"));
-
 var _arrayUtils = _interopRequireDefault(require("./lib/array-utils.js"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 // handles code evaluation and attaching relevant objects to global and evaluation contexts
+
 class EvalSandbox {
   constructor(parent, makeGlobal, userProps = []) {
     this.makeGlobal = makeGlobal;
@@ -1067,36 +1078,32 @@ class EvalSandbox {
     properties.forEach(property => this.add(property));
     this.userProps = userProps;
   }
-
   add(name) {
-    if (this.makeGlobal) window[name] = this.parent[name]; // this.sandbox.addToContext(name, `parent.${name}`)
-  } // sets on window as well as synth object if global (not needed for objects, which can be set directly)
+    if (this.makeGlobal) window[name] = this.parent[name];
+    // this.sandbox.addToContext(name, `parent.${name}`)
+  }
 
+  // sets on window as well as synth object if global (not needed for objects, which can be set directly)
 
   set(property, value) {
     if (this.makeGlobal) {
       window[property] = value;
     }
-
     this.parent[property] = value;
   }
-
   tick() {
     if (this.makeGlobal) {
       this.userProps.forEach(property => {
         this.parent[property] = window[property];
-      }); //  this.parent.speed = window.speed
+      });
+      //  this.parent.speed = window.speed
     } else {}
   }
-
   eval(code) {
     this.sandbox.eval(code);
   }
-
 }
-
-var _default = EvalSandbox;
-exports.default = _default;
+var _default = exports.default = EvalSandbox;
 
 },{"./lib/array-utils.js":20,"./lib/sandbox.js":25}],11:[function(require,module,exports){
 "use strict";
@@ -1105,11 +1112,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = formatArguments;
-
 var _arrayUtils = _interopRequireDefault(require("./lib/array-utils.js"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 // [WIP] how to treat different dimensions (?)
 const DEFAULT_CONVERSIONS = {
   float: {
@@ -1123,7 +1127,6 @@ const DEFAULT_CONVERSIONS = {
     }
   }
 };
-
 function fillArrayWithDefaults(arr, len) {
   // fill the array with default values if it's too short
   while (arr.length < len) {
@@ -1134,20 +1137,15 @@ function fillArrayWithDefaults(arr, len) {
       arr.push(0.0);
     }
   }
-
   return arr.slice(0, len);
 }
-
 const ensure_decimal_dot = val => {
   val = val.toString();
-
   if (val.indexOf('.') < 0) {
     val += '.';
   }
-
   return val;
 };
-
 function formatArguments(transform, startIndex, synthContext) {
   const defaultArgs = transform.transform.inputs;
   const userArgs = transform.userArgs;
@@ -1157,7 +1155,6 @@ function formatArguments(transform, startIndex, synthContext) {
   const {
     src
   } = generators; // depends on synth having src() function
-
   return defaultArgs.map((input, index) => {
     const typedArg = {
       value: input.default,
@@ -1165,29 +1162,27 @@ function formatArguments(transform, startIndex, synthContext) {
       //
       isUniform: false,
       name: input.name,
-      vecLen: 0 //  generateGlsl: null // function for creating glsl
-
+      vecLen: 0
+      //  generateGlsl: null // function for creating glsl
     };
     if (typedArg.type === 'float') typedArg.value = ensure_decimal_dot(input.default);
-
     if (input.type.startsWith('vec')) {
       try {
         typedArg.vecLen = Number.parseInt(input.type.substr(3));
       } catch (e) {
         console.log(`Error determining length of vector input type ${input.type} (${input.name})`);
       }
-    } // if user has input something for this argument
+    }
 
-
+    // if user has input something for this argument
     if (userArgs.length > index) {
       typedArg.value = userArgs[index];
-
       if (typedArg.type === 'vec4') {
         if (!(typedArg.value.type === "GlslSource" || typedArg.value.getTexture)) {
           throw new Error("Arguments must be a texture or GlslSource");
         }
-      } // do something if a composite or transform
-
+      }
+      // do something if a composite or transform
 
       if (typeof userArgs[index] === 'function') {
         // if (typedArg.vecLen > 0) { // expected input is a vector, not a scalar
@@ -1196,20 +1191,18 @@ function formatArguments(transform, startIndex, synthContext) {
         typedArg.value = (context, props, batchId) => {
           try {
             const val = userArgs[index](props);
-
             if (typeof val === 'number') {
               return val;
             } else {
               console.warn('function does not return a number', userArgs[index]);
             }
-
             return input.default;
           } catch (e) {
             console.warn('ERROR', e);
             return input.default;
           }
-        }; //  }
-
+        };
+        //  }
 
         typedArg.isUniform = true;
       } else if (userArgs[index].constructor === Array) {
@@ -1222,21 +1215,17 @@ function formatArguments(transform, startIndex, synthContext) {
         // const filteredArray = userArgs[index].filter((val) => typeof val === 'number')
         // typedArg.value = (context, props, batchId) => arrayUtils.getValue(filteredArray)(props)
         typedArg.value = (context, props, batchId) => _arrayUtils.default.getValue(userArgs[index])(props);
-
-        typedArg.isUniform = true; // }
+        typedArg.isUniform = true;
+        // }
       }
     }
-
     if (startIndex < 0) {} else {
       if (typedArg.value && typedArg.value.transforms) {
         const final_transform = typedArg.value.transforms[typedArg.value.transforms.length - 1];
-
         if (final_transform.transform.glsl_return_type !== input.type) {
           const defaults = DEFAULT_CONVERSIONS[input.type];
-
           if (typeof defaults !== 'undefined') {
             const default_def = defaults[final_transform.transform.glsl_return_type];
-
             if (typeof default_def !== 'undefined') {
               const {
                 name,
@@ -1246,7 +1235,6 @@ function formatArguments(transform, startIndex, synthContext) {
             }
           }
         }
-
         typedArg.isUniform = false;
       } else if (typedArg.type === 'float' && typeof typedArg.value === 'number') {
         typedArg.value = ensure_decimal_dot(typedArg.value);
@@ -1256,9 +1244,7 @@ function formatArguments(transform, startIndex, synthContext) {
       } else if (input.type === 'sampler2D') {
         // typedArg.tex = typedArg.value
         var x = typedArg.value;
-
         typedArg.value = () => x.getTexture();
-
         typedArg.isUniform = true;
       } else {
         // if passing in a texture reference, when function asks for vec4, convert to vec4
@@ -1267,15 +1253,16 @@ function formatArguments(transform, startIndex, synthContext) {
           typedArg.value = src(x1);
           typedArg.isUniform = false;
         }
-      } // add tp uniform array if is a function that will pass in a different value on each render frame,
+      }
+
+      // add tp uniform array if is a function that will pass in a different value on each render frame,
       // or a texture/ external source
 
-
       if (typedArg.isUniform) {
-        typedArg.name += startIndex; //  shaderParams.uniforms.push(typedArg)
+        typedArg.name += startIndex;
+        //  shaderParams.uniforms.push(typedArg)
       }
     }
-
     return typedArg;
   });
 }
@@ -1287,14 +1274,11 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = _default;
-
 var _formatArguments = _interopRequireDefault(require("./format-arguments.js"));
-
 var _arrayUtils = _interopRequireDefault(require("./lib/array-utils.js"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 // Add extra functionality to Array.prototype for generating sequences in time
+
 // converts a tree of javascript functions to a shader
 function _default(transforms) {
   var shaderParams = {
@@ -1304,33 +1288,31 @@ function _default(transforms) {
     // list of functions used in shader
     fragColor: ''
   };
-  var gen = generateGlsl(transforms, shaderParams)('c', 'st'); // console.log(gen)
+  var gen = generateGlsl(transforms, shaderParams)('c', 'st');
+  // console.log(gen)
 
-  shaderParams.fragColor = gen; // remove uniforms with duplicate names
-
+  shaderParams.fragColor = gen;
+  // remove uniforms with duplicate names
   let uniforms = {};
   shaderParams.uniforms.forEach(uniform => uniforms[uniform.name] = uniform);
   shaderParams.uniforms = Object.values(uniforms);
   return shaderParams;
 }
-
 function generateInputName(v, index) {
   return `${v}_i${index}`;
 }
-
 function generateGlsl(transforms, shaderParams) {
   var generator = (c, uv) => '';
-
   transforms.forEach((transform, i) => {
     // Accumulate uniforms to lazily add them to the output shader
     let inputs = (0, _formatArguments.default)(transform, shaderParams.uniforms.length);
     inputs.forEach(input => {
       if (input.isUniform) shaderParams.uniforms.push(input);
-    }); // Lazily generate glsl function definition
+    });
 
+    // Lazily generate glsl function definition
     if (!contains(transform, shaderParams.glslFunctions)) shaderParams.glslFunctions.push(transform);
     var prev = generator;
-
     if (transform.transform.type === 'src') {
       generator = (c, uv) => `${generateInputs(inputs, shaderParams)(`${c}${i}`, uv)}
          vec4 ${c} = ${shaderString(`${c}${i}`, uv, transform.name, inputs)};`;
@@ -1343,7 +1325,8 @@ function generateGlsl(transforms, shaderParams) {
          ${uv} = ${shaderString(`${c}${i}`, `${uv}`, transform.name, inputs)};
          ${prev(c, uv)}`;
     } else if (transform.transform.type === 'combine') {
-      generator = (c, uv) => // combining two generated shader strings (i.e. for blend, mult, add funtions)
+      generator = (c, uv) =>
+      // combining two generated shader strings (i.e. for blend, mult, add funtions)
       `${generateInputs(inputs, shaderParams)(`${c}${i}`, uv)}
          ${prev(c, uv)}
          ${c} = ${shaderString(`${c}${i}`, `${c}`, transform.name, inputs)};`;
@@ -1356,15 +1339,12 @@ function generateGlsl(transforms, shaderParams) {
   });
   return generator;
 }
-
 function generateInputs(inputs, shaderParams) {
   let generator = (c, uv) => '';
-
   var prev = generator;
   inputs.forEach((input, i) => {
     if (input.value.transforms) {
       prev = generator;
-
       generator = (c, uv) => {
         let ci = generateInputName(c, i);
         let uvi = generateInputName(`${uv}_${c}`, i);
@@ -1374,9 +1354,9 @@ function generateInputs(inputs, shaderParams) {
     }
   });
   return generator;
-} // assembles a shader string containing the arguments and the function name, i.e. 'osc(uv, frequency)'
+}
 
-
+// assembles a shader string containing the arguments and the function name, i.e. 'osc(uv, frequency)'
 function shaderString(c, uv, method, inputs) {
   const str = inputs.map((input, i) => {
     if (input.isUniform) {
@@ -1386,25 +1366,23 @@ function shaderString(c, uv, method, inputs) {
       // use the variable created for generator inputs in `generateInputs`
       return generateInputName(c, i);
     }
-
     return input.value;
   }).reduce((p, c) => `${p}, ${c}`, '');
   return `${method}(${uv}${str})`;
-} // merge two arrays and remove duplicates
+}
 
-
+// merge two arrays and remove duplicates
 function mergeArrays(a, b) {
   return a.concat(b.filter(function (item) {
     return a.indexOf(item) < 0;
   }));
-} // check whether array
+}
 
-
+// check whether array
 function contains(object, arr) {
   for (var i = 0; i < arr.length; i++) {
     if (object.name == arr[i].name) return true;
   }
-
   return false;
 }
 
@@ -1415,28 +1393,25 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
 var _glslSource = _interopRequireDefault(require("./glsl-source.js"));
-
 var _glslFunctions = _interopRequireDefault(require("./glsl/glsl-functions.js"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 class GeneratorFactory {
   constructor({
     defaultUniforms,
     defaultOutput,
     extendTransforms = [],
-    changeListener = () => {}
+    changeListener = () => {},
+    renderer = null
   } = {}) {
     this.defaultOutput = defaultOutput;
     this.defaultUniforms = defaultUniforms;
     this.changeListener = changeListener;
     this.extendTransforms = extendTransforms;
+    this.renderer = renderer;
     this.generators = {};
     this.init();
   }
-
   init() {
     const functions = (0, _glslFunctions.default)();
     this.glslTransforms = {};
@@ -1448,25 +1423,21 @@ class GeneratorFactory {
       });
       return prev;
     }, {});
-
     this.sourceClass = (() => {
       return class extends _glslSource.default {};
-    })(); // add user definied transforms
+    })();
 
-
+    // add user definied transforms
     if (Array.isArray(this.extendTransforms)) {
       functions.concat(this.extendTransforms);
     } else if (typeof this.extendTransforms === 'object' && this.extendTransforms.type) {
       functions.push(this.extendTransforms);
     }
-
     return functions.map(transform => this.setFunction(transform));
   }
-
   _addMethod(method, transform) {
     const self = this;
     this.glslTransforms[method] = transform;
-
     if (transform.type === 'src') {
       const func = (...args) => new this.sourceClass({
         name: method,
@@ -1476,7 +1447,6 @@ class GeneratorFactory {
         defaultUniforms: this.defaultUniforms,
         synth: self
       });
-
       this.generators[method] = func;
       this.changeListener({
         type: 'add',
@@ -1495,17 +1465,13 @@ class GeneratorFactory {
         return this;
       };
     }
-
     return undefined;
   }
-
   setFunction(obj) {
     var processedGlsl = processGlsl(obj);
     if (processedGlsl) this._addMethod(obj.name, processedGlsl);
   }
-
 }
-
 const typeLookup = {
   'src': {
     returnType: 'vec4',
@@ -1548,7 +1514,8 @@ const typeLookup = {
       name: '_c0'
     }]
   }
-}; // expects glsl of format
+};
+// expects glsl of format
 // {
 //   name: 'osc', // name that will be used to access function as well as within glsl
 //   type: 'src', // can be src: vec4(vec2 _st), coord: vec2(vec2 _st), color: vec4(vec4 _c0), combine: vec4(vec4 _c0, vec4 _c1), combineCoord: vec2(vec2 _st, vec4 _c0)
@@ -1577,6 +1544,7 @@ const typeLookup = {
 //    return vec4(r, g, b, 1.0);
 // `
 // }
+
 // // generates glsl function:
 // `vec4 osc(vec2 _st, float freq, float sync, float offset){
 //  vec2 st = _st;
@@ -1588,17 +1556,17 @@ const typeLookup = {
 
 function processGlsl(obj) {
   let t = typeLookup[obj.type];
-
   if (t) {
     let inputs = t.args.concat(obj.inputs);
-    let args = inputs.map(input => `${input.type} ${input.name}`).join(', '); // console.log('args are ', args)
+    let args = inputs.map(input => `${input.type} ${input.name}`).join(', ');
+    // console.log('args are ', args)
 
     let glslFunction = `
   ${t.returnType} ${obj.name}(${args}) {
       ${obj.glsl}
   }
-`; // First input gets handled specially by generator
-
+`;
+    // First input gets handled specially by generator
     obj.inputs = inputs.slice(1);
     return Object.assign({}, obj, {
       glsl: glslFunction
@@ -1607,9 +1575,7 @@ function processGlsl(obj) {
     console.warn(`type ${obj.type} not recognized`, obj, typeLookup);
   }
 }
-
-var _default = GeneratorFactory;
-exports.default = _default;
+var _default = exports.default = GeneratorFactory;
 
 },{"./glsl-source.js":14,"./glsl/glsl-functions.js":15}],14:[function(require,module,exports){
 "use strict";
@@ -1618,15 +1584,13 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
 var _generateGlsl = _interopRequireDefault(require("./generate-glsl.js"));
-
 var _utilityFunctions = _interopRequireDefault(require("./glsl/utility-functions.js"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 // const formatArguments = require('./glsl-utils.js').formatArguments
+
 // const glslTransforms = require('./glsl/composable-glsl-functions.js')
+
 var GlslSource = function (obj) {
   this.transforms = [];
   this.transforms.push(obj);
@@ -1636,14 +1600,13 @@ var GlslSource = function (obj) {
   this.defaultUniforms = obj.defaultUniforms;
   return this;
 };
-
 GlslSource.prototype.addTransform = function (obj) {
   this.transforms.push(obj);
 };
-
 GlslSource.prototype.out = function (_output) {
-  var output = _output || this.defaultOutput; // output.renderPasses(glsl)
+  var output = _output || this.defaultOutput;
 
+  // output.renderPasses(glsl)
   if (output) try {
     var glsl = this.glsl(output);
     this.synth.currentFunctions = [];
@@ -1652,15 +1615,14 @@ GlslSource.prototype.out = function (_output) {
     console.warn('shader could not compile', error);
   }
 };
-
 GlslSource.prototype.glsl = function () {
   //var output = _output || this.defaultOutput
-  var self = this; // uniforms included in all shaders
+  var self = this;
+  // uniforms included in all shaders
   //  this.defaultUniforms = output.uniforms
-
   var passes = [];
-  var transforms = []; //  console.log('output', output)
-
+  var transforms = [];
+  //  console.log('output', output)
   this.transforms.forEach(transform => {
     if (transform.transform.type === 'renderpass') {
       // if (transforms.length > 0) passes.push(this.compile(transforms, output))
@@ -1682,44 +1644,52 @@ GlslSource.prototype.glsl = function () {
   if (transforms.length > 0) passes.push(this.compile(transforms));
   return passes;
 };
-
 GlslSource.prototype.compile = function (transforms) {
   var shaderInfo = (0, _generateGlsl.default)(transforms, this.synth);
   var uniforms = {};
   shaderInfo.uniforms.forEach(uniform => {
     uniforms[uniform.name] = uniform.value;
   });
-  var frag = `
+
+  // Use renderer's buildShader hook if available (plugin architecture)
+  // Otherwise fall back to built-in GLSL generation
+  const renderer = this.synth && this.synth.renderer;
+  var frag;
+  if (renderer && typeof renderer.buildShader === 'function') {
+    frag = renderer.buildShader(shaderInfo, {
+      precision: this.defaultOutput.precision
+    });
+  } else {
+    // Fallback: built-in GLSL generation
+    frag = `
   precision ${this.defaultOutput.precision} float;
   ${Object.values(shaderInfo.uniforms).map(uniform => {
-    let type = uniform.type;
-
-    switch (uniform.type) {
-      case 'texture':
-        type = 'sampler2D';
-        break;
-    }
-
-    return `
+      let type = uniform.type;
+      switch (uniform.type) {
+        case 'texture':
+          type = 'sampler2D';
+          break;
+      }
+      return `
       uniform ${type} ${uniform.name};`;
-  }).join('')}
+    }).join('')}
   uniform float time;
   uniform vec2 resolution;
   varying vec2 uv;
   uniform sampler2D prevBuffer;
 
   ${Object.values(_utilityFunctions.default).map(transform => {
-    //  console.log(transform.glsl)
-    return `
+      //  console.log(transform.glsl)
+      return `
             ${transform.glsl}
           `;
-  }).join('')}
+    }).join('')}
 
   ${shaderInfo.glslFunctions.map(transform => {
-    return `
+      return `
             ${transform.transform.glsl}
           `;
-  }).join('')}
+    }).join('')}
 
   void main () {
     vec2 st = gl_FragCoord.xy/resolution.xy;
@@ -1728,14 +1698,13 @@ GlslSource.prototype.compile = function (transforms) {
     gl_FragColor = c;
   }
   `;
+  }
   return {
     frag: frag,
     uniforms: Object.assign({}, this.defaultUniforms, uniforms)
   };
 };
-
-var _default = GlslSource;
-exports.default = _default;
+var _default = exports.default = GlslSource;
 
 },{"./generate-glsl.js":12,"./glsl/utility-functions.js":16}],15:[function(require,module,exports){
 "use strict";
@@ -1744,7 +1713,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
 /*
 Format for adding functions to hydra. For each entry in this file, hydra automatically generates a glsl function and javascript function with the same name. You can also ass functions dynamically using setFunction(object).
 
@@ -2591,7 +2559,6 @@ var _default = () => [{
   }],
   glsl: `   return vec4(_c0.a * scale + offset);`
 }];
-
 exports.default = _default;
 
 },{}],16:[function(require,module,exports){
@@ -2602,7 +2569,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 // functions that are only used within other functions
-var _default = {
+var _default = exports.default = {
   _luminance: {
     type: 'util',
     glsl: `float _luminance(vec3 rgb){
@@ -2709,7 +2676,6 @@ var _default = {
     }`
   }
 };
-exports.default = _default;
 
 },{}],17:[function(require,module,exports){
 "use strict";
@@ -2718,13 +2684,9 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
 var _webcam = _interopRequireDefault(require("./lib/webcam.js"));
-
 var _screenmedia = _interopRequireDefault(require("./lib/screenmedia.js"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 class HydraSource {
   constructor({
     regl,
@@ -2745,7 +2707,6 @@ class HydraSource {
     });
     this.pb = pb;
   }
-
   init(opts, params) {
     if ('src' in opts) {
       this.src = opts.src;
@@ -2754,10 +2715,8 @@ class HydraSource {
         ...params
       });
     }
-
     if ('dynamic' in opts) this.dynamic = opts.dynamic;
   }
-
   initCam(index, params) {
     const self = this;
     (0, _webcam.default)(index).then(response => {
@@ -2769,7 +2728,6 @@ class HydraSource {
       });
     }).catch(err => console.log('could not get camera', err));
   }
-
   initVideo(url = '', params) {
     // const self = this
     const vid = document.createElement('video');
@@ -2777,7 +2735,6 @@ class HydraSource {
     vid.autoplay = true;
     vid.loop = true;
     vid.muted = true; // mute in order to load without user interaction
-
     const onload = vid.addEventListener('loadeddata', () => {
       this.src = vid;
       vid.play();
@@ -2789,12 +2746,10 @@ class HydraSource {
     });
     vid.src = url;
   }
-
   initImage(url = '', params) {
     const img = document.createElement('img');
     img.crossOrigin = 'anonymous';
     img.src = url;
-
     img.onload = () => {
       this.src = img;
       this.dynamic = false;
@@ -2804,11 +2759,9 @@ class HydraSource {
       });
     };
   }
-
   initStream(streamName, params) {
     //  console.log("initing stream!", streamName)
     let self = this;
-
     if (streamName && this.pb) {
       this.pb.initSource(streamName);
       this.pb.on('got video', function (nick, video) {
@@ -2822,9 +2775,9 @@ class HydraSource {
         }
       });
     }
-  } // index only relevant in atom-hydra + desktop apps
+  }
 
-
+  // index only relevant in atom-hydra + desktop apps
   initScreen(index = 0, params) {
     const self = this;
     (0, _screenmedia.default)().then(function (response) {
@@ -2833,55 +2786,50 @@ class HydraSource {
         data: self.src,
         ...params
       });
-      self.dynamic = true; //  console.log("received screen input")
+      self.dynamic = true;
+      //  console.log("received screen input")
     }).catch(err => console.log('could not get screen', err));
-  } // cache for the canvases, so we don't create them every time
+  }
 
+  // cache for the canvases, so we don't create them every time
+  canvases = {};
 
-  canvases = {}; // Creates a canvas and returns the 2d context
-
+  // Creates a canvas and returns the 2d context
   initCanvas(width = 1000, height = 1000) {
     if (this.canvases[this.label] == undefined) {
       const canvas = document.createElement("canvas");
       const ctx = canvas.getContext('2d');
       if (ctx != null) this.canvases[this.label] = ctx;
     }
-
     const ctx = this.canvases[this.label];
     const canvas = ctx.canvas;
-
     if (canvas.width !== width && canvas.height !== height) {
       canvas.width = width;
       canvas.height = height;
     } else {
       ctx.clearRect(0, 0, width, height);
     }
-
     this.init({
       src: canvas
     });
     this.dynamic = true;
     return ctx;
   }
-
   resize(width, height) {
     this.width = width;
     this.height = height;
   }
-
   clear() {
     if (this.src && this.src.srcObject) {
       if (this.src.srcObject.getTracks) {
         this.src.srcObject.getTracks().forEach(track => track.stop());
       }
     }
-
     this.src = null;
     this.tex = this.regl.texture({
       shape: [1, 1]
     });
   }
-
   tick(time) {
     //  console.log(this.src, this.tex.width, this.tex.height)
     if (this.src && this.dynamic === true) {
@@ -2889,23 +2837,17 @@ class HydraSource {
         console.log(this.src.videoWidth, this.src.videoHeight, this.tex.width, this.tex.height);
         this.tex.resize(this.src.videoWidth, this.src.videoHeight);
       }
-
       if (this.src.width && this.src.width !== this.tex.width) {
         this.tex.resize(this.src.width, this.src.height);
       }
-
       this.tex.subimage(this.src);
     }
   }
-
   getTexture() {
     return this.tex;
   }
-
 }
-
-var _default = HydraSource;
-exports.default = _default;
+var _default = exports.default = HydraSource;
 
 },{"./lib/screenmedia.js":26,"./lib/webcam.js":28}],18:[function(require,module,exports){
 "use strict";
@@ -2914,33 +2856,21 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
-var _output = _interopRequireDefault(require("./output.js"));
-
 var _rafLoop = _interopRequireDefault(require("raf-loop"));
-
-var _hydraSource = _interopRequireDefault(require("./hydra-source.js"));
-
 var _mouse = _interopRequireDefault(require("./lib/mouse.js"));
-
 var _audio = _interopRequireDefault(require("./lib/audio.js"));
-
 var _videoRecorder = _interopRequireDefault(require("./lib/video-recorder.js"));
-
 var _arrayUtils = _interopRequireDefault(require("./lib/array-utils.js"));
-
 var _evalSandbox = _interopRequireDefault(require("./eval-sandbox.js"));
-
 var _generatorFactory = _interopRequireDefault(require("./generator-factory.js"));
-
-var _regl = _interopRequireDefault(require("regl"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+var _index = require("./renderer/index.js");
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 // import strudel from './lib/strudel.js'
-// const window = global.window
-const Mouse = (0, _mouse.default)(); // to do: add ability to pass in certain uniforms and transforms
 
+// const window = global.window
+
+const Mouse = (0, _mouse.default)();
+// to do: add ability to pass in certain uniforms and transforms
 class HydraRenderer {
   constructor({
     pb = null,
@@ -2955,20 +2885,17 @@ class HydraRenderer {
     canvas,
     precision,
     extendTransforms = {} // add your own functions on init
-
   } = {}) {
     _arrayUtils.default.init();
-
     this.pb = pb;
     this.width = width;
     this.height = height;
     this.renderAll = false;
     this.detectAudio = detectAudio;
+    this._initCanvas(canvas);
 
-    this._initCanvas(canvas); //global.window.test = 'hi'
+    //global.window.test = 'hi'
     // object that contains all properties that will be made available on the global context and during local evaluation
-
-
     this.synth = {
       time: 0,
       bpm: 30,
@@ -2992,12 +2919,12 @@ class HydraRenderer {
     if (makeGlobal) window.loadScript = this.loadScript;
     this.timeSinceLastUpdate = 0;
     this._time = 0; // for internal use, only to use for deciding when to render frames
+
     // only allow valid precision options
-
     let precisionOptions = ['lowp', 'mediump', 'highp'];
-
     if (precision && precisionOptions.includes(precision.toLowerCase())) {
-      this.precision = precision.toLowerCase(); //
+      this.precision = precision.toLowerCase();
+      //
       // if(!precisionValid){
       //   console.warn('[hydra-synth warning]\nConstructor was provided an invalid floating point precision value of "' + precision + '". Using default value of "mediump" instead.')
       // }
@@ -3005,52 +2932,56 @@ class HydraRenderer {
       let isIOS = (/iPad|iPhone|iPod/.test(navigator.platform) || navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1) && !window.MSStream;
       this.precision = isIOS ? 'highp' : 'mediump';
     }
+    this.extendTransforms = extendTransforms;
 
-    this.extendTransforms = extendTransforms; // boolean to store when to save screenshot
+    // boolean to store when to save screenshot
+    this.saveFrame = false;
 
-    this.saveFrame = false; // if stream capture is enabled, this object contains the capture stream
-
+    // if stream capture is enabled, this object contains the capture stream
     this.captureStream = null;
     this.generator = undefined;
 
-    this._initRegl();
+    // Initialize renderer
+    this.renderer = new _index.WebGL1Renderer();
+    this.renderer.init(this.canvas, {
+      precision: this.precision,
+      width: this.width,
+      height: this.height,
+      pb: this.pb
+    });
 
+    // Expose renderer and regl for backward compatibility
+    this.regl = this.renderer.regl;
+    this.synth.renderer = this.renderer;
     this._initOutputs(numOutputs);
-
     this._initSources(numSources);
-
     this._generateGlslTransforms();
-
     this.synth.screencap = () => {
       this.saveFrame = true;
     };
-
     if (enableStreamCapture) {
       try {
-        this.captureStream = this.canvas.captureStream(25); // to do: enable capture stream of specific sources and outputs
-
+        this.captureStream = this.canvas.captureStream(25);
+        // to do: enable capture stream of specific sources and outputs
         this.synth.vidRecorder = new _videoRecorder.default(this.captureStream);
       } catch (e) {
         console.warn('[hydra-synth warning]\nnew MediaSource() is not currently supported on iOS.');
         console.error(e);
       }
     }
-
     if (detectAudio) this._initAudio();
-    if (autoLoop) (0, _rafLoop.default)(this.tick.bind(this)).start(); // final argument is properties that the user can set, all others are treated as read-only
+    if (autoLoop) (0, _rafLoop.default)(this.tick.bind(this)).start();
 
+    // final argument is properties that the user can set, all others are treated as read-only
     this.sandbox = new _evalSandbox.default(this.synth, makeGlobal, ['speed', 'update', 'afterUpdate', 'bpm', 'fps']);
   }
-
   eval(code) {
     this.sandbox.eval(code);
   }
-
   getScreenImage(callback) {
     this.imageCallback = callback;
     this.saveFrame = true;
   }
-
   hush() {
     this.s.forEach(source => {
       source.clear();
@@ -3058,55 +2989,37 @@ class HydraRenderer {
     this.o.forEach(output => {
       this.synth.solid(0, 0, 0, 0).out(output);
     });
-    this.synth.render(this.o[0]); // this.synth.update = (dt) => {}
-
+    this.synth.render(this.o[0]);
+    // this.synth.update = (dt) => {}
     this.sandbox.set('update', dt => {});
     this.sandbox.set('afterUpdate', dt => {});
   }
-
   loadScript(url = "") {
     const p = new Promise((res, rej) => {
       var script = document.createElement("script");
-
       script.onload = function () {
         console.log(`loaded script ${url}`);
         res();
       };
-
       script.onerror = err => {
         console.log(`error loading script ${url}`, "log-error");
         res();
       };
-
       script.src = url;
       document.head.appendChild(script);
     });
     return p;
   }
-
   setResolution(width, height) {
     //  console.log(width, height)
-    this.canvas.width = width;
-    this.canvas.height = height;
-    this.width = width; // is this necessary?
-
-    this.height = height; // ?
-
+    this.width = width;
+    this.height = height;
     this.sandbox.set('width', width);
     this.sandbox.set('height', height);
     console.log(this.width);
-    this.o.forEach(output => {
-      output.resize(width, height);
-    });
-    this.s.forEach(source => {
-      source.resize(width, height);
-    });
-
-    this.regl._refresh();
-
+    this.renderer.resize(width, height);
     console.log(this.canvas.width);
   }
-
   canvasToImage(callback) {
     const a = document.createElement('a');
     a.style.display = 'none';
@@ -3129,12 +3042,12 @@ class HydraRenderer {
       window.URL.revokeObjectURL(a.href);
     }, 300);
   }
-
   _initAudio() {
     const that = this;
     this.synth.a = new _audio.default({
       numBins: 4,
-      parentEl: this.canvas.parentNode // changeListener: ({audio}) => {
+      parentEl: this.canvas.parentNode
+      // changeListener: ({audio}) => {
       //   that.a = audio.bins.map((_, index) =>
       //     (scale = 1, offset = 0) => () => (audio.fft[index] * scale + offset)
       //   )
@@ -3146,11 +3059,10 @@ class HydraRenderer {
       //     })
       //   }
       // }
-
     });
-  } // create main output canvas and add to screen
+  }
 
-
+  // create main output canvas and add to screen
   _initCanvas(canvas) {
     if (canvas) {
       this.canvas = canvas;
@@ -3166,143 +3078,29 @@ class HydraRenderer {
       document.body.appendChild(this.canvas);
     }
   }
-
-  _initRegl() {
-    this.regl = (0, _regl.default)({
-      //  profile: true,
-      canvas: this.canvas,
-      pixelRatio: 1 //,
-      // extensions: [
-      //   'oes_texture_half_float',
-      //   'oes_texture_half_float_linear'
-      // ],
-      // optionalExtensions: [
-      //   'oes_texture_float',
-      //   'oes_texture_float_linear'
-      //]
-
-    }); // This clears the color buffer to black and the depth buffer to 1
-
-    this.regl.clear({
-      color: [0, 0, 0, 1]
-    });
-    this.renderAll = this.regl({
-      frag: `
-      precision ${this.precision} float;
-      varying vec2 uv;
-      uniform sampler2D tex0;
-      uniform sampler2D tex1;
-      uniform sampler2D tex2;
-      uniform sampler2D tex3;
-
-      void main () {
-        vec2 st = vec2(1.0 - uv.x, uv.y);
-        st*= vec2(2);
-        vec2 q = floor(st).xy*(vec2(2.0, 1.0));
-        int quad = int(q.x) + int(q.y);
-        st.x += step(1., mod(st.y,2.0));
-        st.y += step(1., mod(st.x,2.0));
-        st = fract(st);
-        if(quad==0){
-          gl_FragColor = texture2D(tex0, st);
-        } else if(quad==1){
-          gl_FragColor = texture2D(tex1, st);
-        } else if (quad==2){
-          gl_FragColor = texture2D(tex2, st);
-        } else {
-          gl_FragColor = texture2D(tex3, st);
-        }
-
-      }
-      `,
-      vert: `
-      precision ${this.precision} float;
-      attribute vec2 position;
-      varying vec2 uv;
-
-      void main () {
-        uv = position;
-        gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
-      }`,
-      attributes: {
-        position: [[-2, 0], [0, -2], [2, 2]]
-      },
-      uniforms: {
-        tex0: this.regl.prop('tex0'),
-        tex1: this.regl.prop('tex1'),
-        tex2: this.regl.prop('tex2'),
-        tex3: this.regl.prop('tex3')
-      },
-      count: 3,
-      depth: {
-        enable: false
-      }
-    });
-    this.renderFbo = this.regl({
-      frag: `
-      precision ${this.precision} float;
-      varying vec2 uv;
-      uniform vec2 resolution;
-      uniform sampler2D tex0;
-
-      void main () {
-        gl_FragColor = texture2D(tex0, vec2(1.0 - uv.x, uv.y));
-      }
-      `,
-      vert: `
-      precision ${this.precision} float;
-      attribute vec2 position;
-      varying vec2 uv;
-
-      void main () {
-        uv = position;
-        gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
-      }`,
-      attributes: {
-        position: [[-2, 0], [0, -2], [2, 2]]
-      },
-      uniforms: {
-        tex0: this.regl.prop('tex0'),
-        resolution: this.regl.prop('resolution')
-      },
-      count: 3,
-      depth: {
-        enable: false
-      }
-    });
-  }
-
   _initOutputs(numOutputs) {
     const self = this;
     this.o = Array(numOutputs).fill().map((el, index) => {
-      var o = new _output.default({
-        regl: this.regl,
+      var o = this.renderer.createOutput(index, {
         width: this.width,
         height: this.height,
-        precision: this.precision,
         label: `o${index}`
-      }); //  o.render()
-
-      o.id = index;
+      });
       self.synth['o' + index] = o;
       return o;
-    }); // set default output
+    });
 
+    // set default output
     this.output = this.o[0];
   }
-
   _initSources(numSources) {
     this.s = [];
-
     for (var i = 0; i < numSources; i++) {
       this.createSource(i);
     }
   }
-
   createSource(i) {
-    let s = new _hydraSource.default({
-      regl: this.regl,
-      pb: this.pb,
+    let s = this.renderer.createSource(this.s.length, {
       width: this.width,
       height: this.height,
       label: `s${i}`
@@ -3311,13 +3109,13 @@ class HydraRenderer {
     this.s.push(s);
     return s;
   }
-
   _generateGlslTransforms() {
     var self = this;
     this.generator = new _generatorFactory.default({
       defaultOutput: this.o[0],
       defaultUniforms: this.o[0].uniforms,
       extendTransforms: this.extendTransforms,
+      renderer: this.renderer,
       changeListener: ({
         type,
         method,
@@ -3326,15 +3124,15 @@ class HydraRenderer {
         if (type === 'add') {
           self.synth[method] = synth.generators[method];
           if (self.sandbox) self.sandbox.add(method);
-        } else if (type === 'remove') {// what to do here? dangerously deleting window methods
+        } else if (type === 'remove') {
+          // what to do here? dangerously deleting window methods
           //delete window[method]
-        } //  }
-
+        }
+        //  }
       }
     });
     this.synth.setFunction = this.generator.setFunction.bind(this.generator);
   }
-
   _render(output) {
     if (output) {
       this.output = output;
@@ -3342,37 +3140,32 @@ class HydraRenderer {
     } else {
       this.isRenderingAll = true;
     }
-  } // dt in ms
+  }
 
-
+  // dt in ms
   tick(dt, uniforms) {
     try {
       this.sandbox.tick();
-      if (this.detectAudio === true) this.synth.a.tick(); //  let updateInterval = 1000/this.synth.fps // ms
-
+      if (this.detectAudio === true) this.synth.a.tick();
+      //  let updateInterval = 1000/this.synth.fps // ms
       this.sandbox.set('time', this.synth.time += dt * 0.001 * this.synth.speed);
       this.timeSinceLastUpdate += dt;
-
       if (!this.synth.fps || this.timeSinceLastUpdate >= 1000 / this.synth.fps) {
         //  console.log(1000/this.timeSinceLastUpdate)
         this.synth.stats.fps = Math.ceil(1000 / this.timeSinceLastUpdate);
-
         if (this.synth.update) {
           try {
             this.synth.update(this.timeSinceLastUpdate);
           } catch (e) {
             console.log(e);
           }
-        } //  console.log(this.synth.speed, this.synth.time)
-
-
+        }
+        //  console.log(this.synth.speed, this.synth.time)
         for (let i = 0; i < this.s.length; i++) {
           this.s[i].tick(this.synth.time);
-        } //  console.log(this.canvas.width, this.canvas.height)
-
-
+        }
+        //  console.log(this.canvas.width, this.canvas.height)
         const currentTime = this.synth.time;
-
         for (let i = 0; i < this.o.length; i++) {
           this.o[i].tick({
             time: currentTime,
@@ -3381,22 +3174,11 @@ class HydraRenderer {
             resolution: [this.canvas.width, this.canvas.height]
           });
         }
-
         if (this.isRenderingAll) {
-          this.renderAll({
-            tex0: this.o[0].getCurrent(),
-            tex1: this.o[1].getCurrent(),
-            tex2: this.o[2].getCurrent(),
-            tex3: this.o[3].getCurrent(),
-            resolution: [this.canvas.width, this.canvas.height]
-          });
+          this.renderer.renderAllToScreen(this.o);
         } else {
-          this.renderFbo({
-            tex0: this.output.getCurrent(),
-            resolution: [this.canvas.width, this.canvas.height]
-          });
+          this.renderer.renderToScreen(this.output);
         }
-
         if (this.synth.afterUpdate) {
           try {
             this.synth.afterUpdate(this.timeSinceLastUpdate);
@@ -3404,31 +3186,25 @@ class HydraRenderer {
             console.log(e);
           }
         }
-
         this.timeSinceLastUpdate = 0;
       }
-
       if (this.saveFrame === true) {
         this.canvasToImage();
         this.saveFrame = false;
       }
     } catch (e) {
-      console.warn('Error during tick():', e); //  this.regl.poll()
+      console.warn('Error during tick():', e);
+      //  this.regl.poll()
     }
   }
-
 }
+var _default = exports.default = HydraRenderer;
 
-var _default = HydraRenderer;
-exports.default = _default;
-
-},{"./eval-sandbox.js":10,"./generator-factory.js":13,"./hydra-source.js":17,"./lib/array-utils.js":20,"./lib/audio.js":21,"./lib/mouse.js":24,"./lib/video-recorder.js":27,"./output.js":29,"raf-loop":6,"regl":8}],19:[function(require,module,exports){
+},{"./eval-sandbox.js":10,"./generator-factory.js":13,"./lib/array-utils.js":20,"./lib/audio.js":21,"./lib/mouse.js":24,"./lib/video-recorder.js":27,"./renderer/index.js":32,"raf-loop":6}],19:[function(require,module,exports){
 "use strict";
 
 var _hydraSynth = _interopRequireDefault(require("./hydra-synth.js"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 //import ShaderGenerator = require('./shader-generator.js')
 // alert('hi')
 // export default Synth
@@ -3441,38 +3217,33 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
 var _easingFunctions = _interopRequireDefault(require("./easing-functions.js"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 // WIP utils for working with arrays
 // Possibly should be integrated with lfo extension, etc.
 // to do: transform time rather than array values, similar to working with coordinates in hydra
+
 var map = (num, in_min, in_max, out_min, out_max) => {
   return (num - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
-}; // The '%' operator is a remainder operator, and Javascript lacks a dedicated
+};
+
+// The '%' operator is a remainder operator, and Javascript lacks a dedicated
 // modulo operator. This function is an implementation of the operation
 // copied-n-pasted from
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder#description
-
-
 var modulo = (n, d) => {
   return (n % d + d) % d;
 };
-
-var _default = {
+var _default = exports.default = {
   init: () => {
     Array.prototype.fast = function (speed = 1) {
       this._speed = speed;
       return this;
     };
-
     Array.prototype.smooth = function (smooth = 1) {
       this._smooth = smooth;
       return this;
     };
-
     Array.prototype.ease = function (ease = 'linear') {
       if (typeof ease == 'function') {
         this._smooth = 1;
@@ -3481,18 +3252,17 @@ var _default = {
         this._smooth = 1;
         this._ease = _easingFunctions.default[ease];
       }
-
       return this;
     };
-
     Array.prototype.offset = function (offset = 0.5) {
       this._offset = offset % 1.0;
       return this;
-    }; // Array.prototype.bounce = function() {
+    };
+
+    // Array.prototype.bounce = function() {
     //   this.modifiers.bounce = true
     //   return this
     // }
-
 
     Array.prototype.fit = function (low = 0, high = 1) {
       let lowest = Math.min(...this);
@@ -3511,27 +3281,24 @@ var _default = {
     let speed = arr._speed ? arr._speed : 1;
     let smooth = arr._smooth ? arr._smooth : 0;
     let index = time * speed * (bpm / 60) + (arr._offset || 0);
-
     if (smooth !== 0) {
       let ease = arr._ease ? arr._ease : _easingFunctions.default['linear'];
-
-      let _index = index - smooth / 2; // Compute the first value used for the interpolation: wrap _index inside the range [0, arr.length), then round the resulting value towards 0.
+      let _index = index - smooth / 2;
+      // Compute the first value used for the interpolation: wrap _index inside the range [0, arr.length), then round the resulting value towards 0.
       // Note that, during the first seconds Hydra is running, _index may assume a negative value.
       // If we wrapped _index inside the range [0, arr.length) using the regular remainder operator, the result would be negative.
       // Passing a negative index to an array returns undefined, which ultimately causes a number of graphical glitches.
       // We need to use the modulo operation to prevent this.
-
-
-      let currValue = arr[Math.floor(modulo(_index, arr.length))]; // Compute the second value used for the interpolation, in a similar fashion to 'currValue'.
+      let currValue = arr[Math.floor(modulo(_index, arr.length))];
+      // Compute the second value used for the interpolation, in a similar fashion to 'currValue'.
       // The above reasoning about the choice of the modulo operation applies for 'nextValue', too.
-
-      let nextValue = arr[Math.floor(modulo(_index + 1, arr.length))]; // Compute the time parameter for the interpolation.
+      let nextValue = arr[Math.floor(modulo(_index + 1, arr.length))];
+      // Compute the time parameter for the interpolation.
       // Note that, during the first seconds Hydra is running, _index may assume a negative value.
       // Assuming 'smooth' is positive, if we wrapped _index in the range [0, 1) using the regular remainder operator, t would become negative as a result.
       // This would cause the final interpolation to assume values inconsistent with the later ones.
       // E.g. [0, 1].smooth() should always generate values between 0 and 1, but the initial values would be negative.
       // We need to use the modulo operation to prevent this.
-
       let t = Math.min(modulo(_index, 1) / smooth, 1);
       return ease(t) * (nextValue - currValue) + currValue;
     } else {
@@ -3540,7 +3307,6 @@ var _default = {
     }
   }
 };
-exports.default = _default;
 
 },{"./easing-functions.js":22}],21:[function(require,module,exports){
 "use strict";
@@ -3549,11 +3315,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
 var _meyda = _interopRequireDefault(require("meyda"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 class Audio {
   constructor({
     numBins = 4,
@@ -3569,8 +3332,9 @@ class Audio {
     this.max = max;
     this.cutoff = cutoff;
     this.smooth = smooth;
-    this.setBins(numBins); // beat detection from: https://github.com/therewasaguy/p5-music-viz/blob/gh-pages/demos/01d_beat_detect_amplitude/sketch.js
+    this.setBins(numBins);
 
+    // beat detection from: https://github.com/therewasaguy/p5-music-viz/blob/gh-pages/demos/01d_beat_detect_amplitude/sketch.js
     this.beat = {
       holdFrames: 20,
       threshold: 40,
@@ -3578,12 +3342,10 @@ class Audio {
       // adaptive based on sound state
       decay: 0.98,
       _framesSinceBeat: 0 // keeps track of frames
-
     };
-
-    this.onBeat = () => {//  console.log("beat")
+    this.onBeat = () => {
+      //  console.log("beat")
     };
-
     this.canvas = document.createElement('canvas');
     this.canvas.width = 100;
     this.canvas.height = 80;
@@ -3598,7 +3360,6 @@ class Audio {
     this.ctx.fillStyle = "#DFFFFF";
     this.ctx.strokeStyle = "#0ff";
     this.ctx.lineWidth = 0.5;
-
     if (window.navigator.mediaDevices) {
       window.navigator.mediaDevices.getUserMedia({
         video: false,
@@ -3606,14 +3367,16 @@ class Audio {
       }).then(stream => {
         //  console.log('got mic stream', stream)
         this.stream = stream;
-        this.context = new AudioContext(); //  this.context = new AudioContext()
+        this.context = new AudioContext();
+        //  this.context = new AudioContext()
+        let audio_stream = this.context.createMediaStreamSource(stream);
 
-        let audio_stream = this.context.createMediaStreamSource(stream); //  console.log(this.context)
-
+        //  console.log(this.context)
         this.meyda = _meyda.default.createMeydaAnalyzer({
           audioContext: this.context,
           source: audio_stream,
-          featureExtractors: ['loudness' //  'perceptualSpread',
+          featureExtractors: ['loudness'
+          //  'perceptualSpread',
           //  'perceptualSharpness',
           //  'spectralCentroid'
           ]
@@ -3621,7 +3384,6 @@ class Audio {
       }).catch(err => console.log('ERROR', err));
     }
   }
-
   detectBeat(level) {
     //console.log(level,   this.beat._cutoff)
     if (level > this.beat._cutoff && level > this.beat.threshold) {
@@ -3637,40 +3399,38 @@ class Audio {
       }
     }
   }
-
   tick() {
     if (this.meyda) {
       var features = this.meyda.get();
-
       if (features && features !== null) {
         this.vol = features.loudness.total;
-        this.detectBeat(this.vol); // reduce loudness array to number of bins
-
+        this.detectBeat(this.vol);
+        // reduce loudness array to number of bins
         const reducer = (accumulator, currentValue) => accumulator + currentValue;
-
         let spacing = Math.floor(features.loudness.specific.length / this.bins.length);
         this.prevBins = this.bins.slice(0);
         this.bins = this.bins.map((bin, index) => {
           return features.loudness.specific.slice(index * spacing, (index + 1) * spacing).reduce(reducer);
         }).map((bin, index) => {
           // map to specified range
+
           // return (bin * (1.0 - this.smooth) + this.prevBins[index] * this.smooth)
           return bin * (1.0 - this.settings[index].smooth) + this.prevBins[index] * this.settings[index].smooth;
-        }); // var y = this.canvas.height - scale*this.settings[index].cutoff
+        });
+        // var y = this.canvas.height - scale*this.settings[index].cutoff
         // this.ctx.beginPath()
         // this.ctx.moveTo(index*spacing, y)
         // this.ctx.lineTo((index+1)*spacing, y)
         // this.ctx.stroke()
         //
         // var yMax = this.canvas.height - scale*(this.settings[index].scale + this.settings[index].cutoff)
-
-        this.fft = this.bins.map((bin, index) => // Math.max(0, (bin - this.cutoff) / (this.max - this.cutoff))
+        this.fft = this.bins.map((bin, index) =>
+        // Math.max(0, (bin - this.cutoff) / (this.max - this.cutoff))
         Math.max(0, (bin - this.settings[index].cutoff) / this.settings[index].scale));
         if (this.isDrawing) this.draw();
       }
     }
   }
-
   setCutoff(cutoff) {
     this.cutoff = cutoff;
     this.settings = this.settings.map(el => {
@@ -3678,7 +3438,6 @@ class Audio {
       return el;
     });
   }
-
   setSmooth(smooth) {
     this.smooth = smooth;
     this.settings = this.settings.map(el => {
@@ -3686,7 +3445,6 @@ class Audio {
       return el;
     });
   }
-
   setBins(numBins) {
     this.bins = Array(numBins).fill(0);
     this.prevBins = Array(numBins).fill(0);
@@ -3695,13 +3453,13 @@ class Audio {
       cutoff: this.cutoff,
       scale: this.scale,
       smooth: this.smooth
-    })); // to do: what to do in non-global mode?
-
+    }));
+    // to do: what to do in non-global mode?
     this.bins.forEach((bin, index) => {
       window['a' + index] = (scale = 1, offset = 0) => () => a.fft[index] * scale + offset;
-    }); //  console.log(this.settings)
+    });
+    //  console.log(this.settings)
   }
-
   setScale(scale) {
     this.scale = scale;
     this.settings = this.settings.map(el => {
@@ -3709,31 +3467,28 @@ class Audio {
       return el;
     });
   }
-
   setMax(max) {
     this.max = max;
     console.log('set max is deprecated');
   }
-
   hide() {
     this.isDrawing = false;
     this.canvas.style.display = 'none';
   }
-
   show() {
     this.isDrawing = true;
     this.canvas.style.display = 'block';
   }
-
   draw() {
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     var spacing = this.canvas.width / this.bins.length;
-    var scale = this.canvas.height / (this.max * 2); //  console.log(this.bins)
-
+    var scale = this.canvas.height / (this.max * 2);
+    //  console.log(this.bins)
     this.bins.forEach((bin, index) => {
       var height = bin * scale;
-      this.ctx.fillRect(index * spacing, this.canvas.height - height, spacing, height); //   console.log(this.settings[index])
+      this.ctx.fillRect(index * spacing, this.canvas.height - height, spacing, height);
 
+      //   console.log(this.settings[index])
       var y = this.canvas.height - scale * this.settings[index].cutoff;
       this.ctx.beginPath();
       this.ctx.moveTo(index * spacing, y);
@@ -3745,6 +3500,7 @@ class Audio {
       this.ctx.lineTo((index + 1) * spacing, yMax);
       this.ctx.stroke();
     });
+
     /*var y = this.canvas.height - scale*this.cutoff
     this.ctx.beginPath()
     this.ctx.moveTo(0, y)
@@ -3756,11 +3512,8 @@ class Audio {
     this.ctx.lineTo(this.canvas.width, yMax)
     this.ctx.stroke()*/
   }
-
 }
-
-var _default = Audio;
-exports.default = _default;
+var _default = exports.default = Audio;
 
 },{"meyda":3}],22:[function(require,module,exports){
 "use strict";
@@ -3770,7 +3523,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 // from https://gist.github.com/gre/1650294
-var _default = {
+var _default = exports.default = {
   // no easing, no acceleration
   linear: function (t) {
     return t;
@@ -3828,7 +3581,6 @@ var _default = {
     return (1 + Math.sin(Math.PI * t - Math.PI / 2)) / 2;
   }
 };
-exports.default = _default;
 
 },{}],23:[function(require,module,exports){
 "use strict";
@@ -3838,15 +3590,14 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 // https://github.com/mikolalysenko/mouse-event
-const mouse = {};
 
+const mouse = {};
 function mouseButtons(ev) {
   if (typeof ev === 'object') {
     if ('buttons' in ev) {
       return ev.buttons;
     } else if ('which' in ev) {
       var b = ev.which;
-
       if (b === 2) {
         return 4;
       } else if (b === 3) {
@@ -3856,7 +3607,6 @@ function mouseButtons(ev) {
       }
     } else if ('button' in ev) {
       var b = ev.button;
-
       if (b === 1) {
         return 4;
       } else if (b === 2) {
@@ -3866,43 +3616,32 @@ function mouseButtons(ev) {
       }
     }
   }
-
   return 0;
 }
-
 mouse.buttons = mouseButtons;
-
 function mouseElement(ev) {
   return ev.target || ev.srcElement || window;
 }
-
 mouse.element = mouseElement;
-
 function mouseRelativeX(ev) {
   if (typeof ev === 'object') {
     if ('pageX' in ev) {
       return ev.pageX;
     }
   }
-
   return 0;
 }
-
 mouse.x = mouseRelativeX;
-
 function mouseRelativeY(ev) {
   if (typeof ev === 'object') {
     if ('pageY' in ev) {
       return ev.pageY;
     }
   }
-
   return 0;
 }
-
 mouse.y = mouseRelativeY;
-var _default = mouse;
-exports.default = _default;
+var _default = exports.default = mouse;
 
 },{}],24:[function(require,module,exports){
 "use strict";
@@ -3911,21 +3650,15 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
 var _mouseEvent = _interopRequireDefault(require("./mouse-event.js"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 // based on https://github.com/mikolalysenko/mouse-change
-var _default = mouseListen;
-exports.default = _default;
-
+var _default = exports.default = mouseListen;
 function mouseListen(element, callback) {
   if (!callback) {
     callback = element;
     element = window;
   }
-
   var buttonState = 0;
   var x = 0;
   var y = 0;
@@ -3936,42 +3669,32 @@ function mouseListen(element, callback) {
     meta: false
   };
   var attached = false;
-
   function updateMods(ev) {
     var changed = false;
-
     if ('altKey' in ev) {
       changed = changed || ev.altKey !== mods.alt;
       mods.alt = !!ev.altKey;
     }
-
     if ('shiftKey' in ev) {
       changed = changed || ev.shiftKey !== mods.shift;
       mods.shift = !!ev.shiftKey;
     }
-
     if ('ctrlKey' in ev) {
       changed = changed || ev.ctrlKey !== mods.control;
       mods.control = !!ev.ctrlKey;
     }
-
     if ('metaKey' in ev) {
       changed = changed || ev.metaKey !== mods.meta;
       mods.meta = !!ev.metaKey;
     }
-
     return changed;
   }
-
   function handleEvent(nextButtons, ev) {
     var nextX = _mouseEvent.default.x(ev);
-
     var nextY = _mouseEvent.default.y(ev);
-
     if ('buttons' in ev) {
       nextButtons = ev.buttons | 0;
     }
-
     if (nextButtons !== buttonState || nextX !== x || nextY !== y || updateMods(ev)) {
       buttonState = nextButtons | 0;
       x = nextX || 0;
@@ -3979,11 +3702,9 @@ function mouseListen(element, callback) {
       callback && callback(buttonState, x, y, mods);
     }
   }
-
   function clearState(ev) {
     handleEvent(0, ev);
   }
-
   function handleBlur() {
     if (buttonState || x || y || mods.shift || mods.alt || mods.meta || mods.control) {
       x = y = 0;
@@ -3992,13 +3713,11 @@ function mouseListen(element, callback) {
       callback && callback(0, 0, 0, mods);
     }
   }
-
   function handleMods(ev) {
     if (updateMods(ev)) {
       callback && callback(buttonState, x, y, mods);
     }
   }
-
   function handleMouseMove(ev) {
     if (_mouseEvent.default.buttons(ev) === 0) {
       handleEvent(0, ev);
@@ -4006,20 +3725,16 @@ function mouseListen(element, callback) {
       handleEvent(buttonState, ev);
     }
   }
-
   function handleMouseDown(ev) {
     handleEvent(buttonState | _mouseEvent.default.buttons(ev), ev);
   }
-
   function handleMouseUp(ev) {
     handleEvent(buttonState & ~_mouseEvent.default.buttons(ev), ev);
   }
-
   function attachListeners() {
     if (attached) {
       return;
     }
-
     attached = true;
     element.addEventListener('mousemove', handleMouseMove);
     element.addEventListener('mousedown', handleMouseDown);
@@ -4032,7 +3747,6 @@ function mouseListen(element, callback) {
     element.addEventListener('keyup', handleMods);
     element.addEventListener('keydown', handleMods);
     element.addEventListener('keypress', handleMods);
-
     if (element !== window) {
       window.addEventListener('blur', handleBlur);
       window.addEventListener('keyup', handleMods);
@@ -4040,12 +3754,10 @@ function mouseListen(element, callback) {
       window.addEventListener('keypress', handleMods);
     }
   }
-
   function detachListeners() {
     if (!attached) {
       return;
     }
-
     attached = false;
     element.removeEventListener('mousemove', handleMouseMove);
     element.removeEventListener('mousedown', handleMouseDown);
@@ -4058,16 +3770,15 @@ function mouseListen(element, callback) {
     element.removeEventListener('keyup', handleMods);
     element.removeEventListener('keydown', handleMods);
     element.removeEventListener('keypress', handleMods);
-
     if (element !== window) {
       window.removeEventListener('blur', handleBlur);
       window.removeEventListener('keyup', handleMods);
       window.removeEventListener('keydown', handleMods);
       window.removeEventListener('keypress', handleMods);
     }
-  } // Attach listeners
+  }
 
-
+  // Attach listeners
   attachListeners();
   var result = {
     element: element
@@ -4121,40 +3832,35 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
 // attempt custom evaluation sandbox for hydra functions
 // for now, just avoids polluting the global namespace
 // should probably be replaced with an abstract syntax tree
 var _default = parent => {
   var initialCode = ``;
   var sandbox = createSandbox(initialCode);
-
   var addToContext = (name, object) => {
     initialCode += `
       var ${name} = ${object}
     `;
     sandbox = createSandbox(initialCode);
   };
-
   return {
     addToContext: addToContext,
     eval: code => sandbox.eval(code)
   };
-
   function createSandbox(initial) {
-    globalThis.eval(initial); // optional params
-
+    globalThis.eval(initial);
+    // optional params
     var localEval = function (code) {
       globalThis.eval(code);
-    }; // API/data for end-user
+    };
 
-
+    // API/data for end-user
     return {
       eval: localEval
     };
   }
 };
-
 exports.default = _default;
 
 },{}],26:[function(require,module,exports){
@@ -4164,7 +3870,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = _default;
-
 function _default(options) {
   return new Promise(function (resolve, reject) {
     //  async function startCapture(displayMediaOptions) {
@@ -4188,12 +3893,12 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
 class VideoRecorder {
   constructor(stream) {
     this.mediaSource = new MediaSource();
-    this.stream = stream; // testing using a recording as input
+    this.stream = stream;
 
+    // testing using a recording as input
     this.output = document.createElement('video');
     this.output.autoplay = true;
     this.output.loop = true;
@@ -4204,20 +3909,18 @@ class VideoRecorder {
       console.log('Source buffer: ', sourceBuffer);
     });
   }
-
   start() {
     //  let options = {mimeType: 'video/webm'};
+
     //   let options = {mimeType: 'video/webm;codecs=h264'};
     let options = {
       mimeType: 'video/webm;codecs=vp9'
     };
     this.recordedBlobs = [];
-
     try {
       this.mediaRecorder = new MediaRecorder(this.stream, options);
     } catch (e0) {
       console.log('Unable to create MediaRecorder with options Object: ', e0);
-
       try {
         options = {
           mimeType: 'video/webm,codecs=vp9'
@@ -4225,10 +3928,8 @@ class VideoRecorder {
         this.mediaRecorder = new MediaRecorder(this.stream, options);
       } catch (e1) {
         console.log('Unable to create MediaRecorder with options Object: ', e1);
-
         try {
           options = 'video/vp8'; // Chrome 47
-
           this.mediaRecorder = new MediaRecorder(this.stream, options);
         } catch (e2) {
           alert('MediaRecorder is not supported by this browser.\n\n' + 'Try Firefox 29 or later, or Chrome 47 or later, ' + 'with Enable experimental Web Platform features enabled from chrome://flags.');
@@ -4237,19 +3938,15 @@ class VideoRecorder {
         }
       }
     }
-
     console.log('Created MediaRecorder', this.mediaRecorder, 'with options', options);
     this.mediaRecorder.onstop = this._handleStop.bind(this);
     this.mediaRecorder.ondataavailable = this._handleDataAvailable.bind(this);
     this.mediaRecorder.start(100); // collect 100ms of data
-
     console.log('MediaRecorder started', this.mediaRecorder);
   }
-
   stop() {
     this.mediaRecorder.stop();
   }
-
   _handleStop() {
     //const superBuffer = new Blob(recordedBlobs, {type: 'video/webm'})
     // const blob = new Blob(this.recordedBlobs, {type: 'video/webm;codecs=h264'})
@@ -4270,17 +3967,13 @@ class VideoRecorder {
       window.URL.revokeObjectURL(url);
     }, 300);
   }
-
   _handleDataAvailable(event) {
     if (event.data && event.data.size > 0) {
       this.recordedBlobs.push(event.data);
     }
   }
-
 }
-
-var _default = VideoRecorder;
-exports.default = _default;
+var _default = exports.default = VideoRecorder;
 
 },{}],28:[function(require,module,exports){
 "use strict";
@@ -4289,31 +3982,29 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = _default;
-
 //const enumerateDevices = require('enumerate-devices')
+
 function _default(deviceId) {
   return navigator.mediaDevices.enumerateDevices().then(devices => devices.filter(devices => devices.kind === 'videoinput')).then(cameras => {
     let constraints = {
       audio: false,
       video: true
     };
-
     if (cameras[deviceId]) {
       constraints['video'] = {
         deviceId: {
           exact: cameras[deviceId].deviceId
         }
       };
-    } //  console.log(cameras)
-
-
+    }
+    //  console.log(cameras)
     return window.navigator.mediaDevices.getUserMedia(constraints);
   }).then(stream => {
     const video = document.createElement('video');
     video.setAttribute('autoplay', '');
     video.setAttribute('muted', '');
-    video.setAttribute('playsinline', ''); //  video.src = window.URL.createObjectURL(stream)
-
+    video.setAttribute('playsinline', '');
+    //  video.src = window.URL.createObjectURL(stream)
     video.srcObject = stream;
     return new Promise((resolve, reject) => {
       video.addEventListener('loadedmetadata', () => {
@@ -4332,8 +4023,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
 //const transforms = require('./glsl-transforms.js')
+
 var Output = function ({
   regl,
   precision,
@@ -4345,12 +4036,11 @@ var Output = function ({
   this.precision = precision;
   this.label = label;
   this.positionBuffer = this.regl.buffer([[-2, 0], [0, -2], [2, 2]]);
-
   this.draw = () => {};
-
   this.init();
-  this.pingPongIndex = 0; // for each output, create two fbos for pingponging
+  this.pingPongIndex = 0;
 
+  // for each output, create two fbos for pingponging
   this.fbos = Array(2).fill().map(() => this.regl.framebuffer({
     color: this.regl.texture({
       mag: 'nearest',
@@ -4359,25 +4049,24 @@ var Output = function ({
       format: 'rgba'
     }),
     depthStencil: false
-  })); // array containing render passes
+  }));
+
+  // array containing render passes
   //  this.passes = []
 };
-
 Output.prototype.resize = function (width, height) {
   this.fbos.forEach(fbo => {
     fbo.resize(width, height);
-  }); //  console.log(this)
+  });
+  //  console.log(this)
 };
-
 Output.prototype.getCurrent = function () {
   return this.fbos[this.pingPongIndex];
 };
-
 Output.prototype.getTexture = function () {
   var index = this.pingPongIndex ? 0 : 1;
   return this.fbos[index];
 };
-
 Output.prototype.init = function () {
   //  console.log('clearing')
   this.transformIndex = 0;
@@ -4416,10 +4105,9 @@ Output.prototype.init = function () {
   `;
   return this;
 };
-
 Output.prototype.render = function (passes) {
-  let pass = passes[0]; //console.log('pass', pass, this.pingPongIndex)
-
+  let pass = passes[0];
+  //console.log('pass', pass, this.pingPongIndex)
   var self = this;
   var uniforms = Object.assign(pass.uniforms, {
     prevBuffer: () => {
@@ -4441,14 +4129,614 @@ Output.prototype.render = function (passes) {
     }
   });
 };
-
 Output.prototype.tick = function (props) {
   //  console.log(props)
   this.draw(props);
 };
+var _default = exports.default = Output;
 
-var _default = Output;
-exports.default = _default;
+},{}],30:[function(require,module,exports){
+"use strict";
 
-},{}]},{},[19])(19)
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = exports.RendererInterface = void 0;
+/**
+ * Abstract Renderer Interface
+ *
+ * All rendering backends (WebGL1, WebGL2, WebGPU) must implement this interface.
+ * This allows Hydra core to remain renderer-agnostic.
+ *
+ * The renderer provides hooks for:
+ * - Shader generation (which language, how to build shader strings)
+ * - Output/Source management
+ * - Rendering execution
+ */
+
+class RendererInterface {
+  /**
+   * Initialize the renderer with a canvas
+   * @param {HTMLCanvasElement} canvas - Target canvas
+   * @param {Object} options - Renderer options
+   * @param {string} options.precision - Float precision ('lowp', 'mediump', 'highp')
+   * @param {number} options.width - Initial width
+   * @param {number} options.height - Initial height
+   * @returns {void|Promise<void>} - May be sync (WebGL) or async (WebGPU)
+   */
+  init(canvas, options = {}) {
+    throw new Error('RendererInterface.init() must be implemented');
+  }
+
+  /**
+   * Clean up all resources
+   */
+  destroy() {
+    throw new Error('RendererInterface.destroy() must be implemented');
+  }
+
+  /**
+   * Resize all outputs and refresh context
+   * @param {number} width
+   * @param {number} height
+   */
+  resize(width, height) {
+    throw new Error('RendererInterface.resize() must be implemented');
+  }
+
+  // ============================================================
+  // Output Management
+  // ============================================================
+
+  /**
+   * Create an output buffer (o0, o1, o2, o3)
+   * @param {number} index - Output index
+   * @param {Object} options - { width, height, label }
+   * @returns {OutputBuffer} - Renderer-specific output buffer
+   */
+  createOutput(index, options = {}) {
+    throw new Error('RendererInterface.createOutput() must be implemented');
+  }
+
+  /**
+   * Get an output by index
+   * @param {number} index
+   * @returns {OutputBuffer}
+   */
+  getOutput(index) {
+    throw new Error('RendererInterface.getOutput() must be implemented');
+  }
+
+  // ============================================================
+  // Source Management
+  // ============================================================
+
+  /**
+   * Create a source for external input (video, image, canvas)
+   * @param {number} index - Source index
+   * @param {Object} options - { width, height, label }
+   * @returns {Source} - Renderer-specific source
+   */
+  createSource(index, options = {}) {
+    throw new Error('RendererInterface.createSource() must be implemented');
+  }
+
+  // ============================================================
+  // Rendering
+  // ============================================================
+
+  /**
+   * Render a compiled pass to an output
+   * Called by Output.render() internally
+   * @param {OutputBuffer} output - Target output
+   * @param {Object} pass - { frag, uniforms }
+   */
+  renderPass(output, pass) {
+    throw new Error('RendererInterface.renderPass() must be implemented');
+  }
+
+  /**
+   * Execute a tick on an output (runs the compiled draw command)
+   * @param {OutputBuffer} output
+   * @param {Object} props - { time, mouse, bpm, resolution }
+   */
+  tickOutput(output, props) {
+    throw new Error('RendererInterface.tickOutput() must be implemented');
+  }
+
+  /**
+   * Render a single output to the canvas
+   * @param {OutputBuffer} output - Source output to display
+   */
+  renderToScreen(output) {
+    throw new Error('RendererInterface.renderToScreen() must be implemented');
+  }
+
+  /**
+   * Render all 4 outputs in a 2x2 grid to the canvas
+   * @param {Array<OutputBuffer>} outputs - Array of 4 outputs
+   */
+  renderAllToScreen(outputs) {
+    throw new Error('RendererInterface.renderAllToScreen() must be implemented');
+  }
+
+  // ============================================================
+  // Capabilities & Info
+  // ============================================================
+
+  /**
+   * Get renderer capabilities
+   * @returns {Object} - { name, glslVersion, ... }
+   */
+  get capabilities() {
+    throw new Error('RendererInterface.capabilities must be implemented');
+  }
+
+  /**
+   * Get the underlying canvas
+   * @returns {HTMLCanvasElement}
+   */
+  get canvas() {
+    throw new Error('RendererInterface.canvas must be implemented');
+  }
+
+  /**
+   * Get current width
+   * @returns {number}
+   */
+  get width() {
+    throw new Error('RendererInterface.width must be implemented');
+  }
+
+  /**
+   * Get current height
+   * @returns {number}
+   */
+  get height() {
+    throw new Error('RendererInterface.height must be implemented');
+  }
+
+  // ============================================================
+  // Shader Generation Hooks
+  // ============================================================
+
+  /**
+   * Get the shader language this renderer uses.
+   * Used to select 'glsl' or 'wgsl' property from function dictionary.
+   * @returns {string} - 'glsl' or 'wgsl'
+   */
+  get shaderLanguage() {
+    return 'glsl';
+  }
+
+  /**
+   * Get utility functions in the renderer's shader language.
+   * @returns {Object} - Map of function name to shader code
+   */
+  getUtilityFunctions() {
+    throw new Error('RendererInterface.getUtilityFunctions() must be implemented');
+  }
+
+  /**
+   * Build a complete shader from transform info.
+   * @param {Object} shaderInfo - { fragColor, uniforms, glslFunctions }
+   * @param {Object} options - { precision }
+   * @returns {string} - Complete shader source code
+   */
+  buildShader(shaderInfo, options = {}) {
+    throw new Error('RendererInterface.buildShader() must be implemented');
+  }
+
+  // ============================================================
+  // Extension Points (optional overrides)
+  // ============================================================
+
+  /**
+   * Called before each frame
+   */
+  beginFrame() {}
+
+  /**
+   * Called after each frame
+   */
+  endFrame() {}
+
+  /**
+   * Hook called when a new transform function is registered.
+   * Allows renderer to add shader templates in its native language.
+   * @param {Object} transform - Transform definition
+   */
+  onTransformRegistered(transform) {
+    // Optional: renderer can add missing shader templates
+  }
+}
+exports.RendererInterface = RendererInterface;
+var _default = exports.default = RendererInterface;
+
+},{}],31:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = exports.WebGL1Renderer = void 0;
+var _RendererInterface = require("./RendererInterface.js");
+var _output = _interopRequireDefault(require("../output.js"));
+var _hydraSource = _interopRequireDefault(require("../hydra-source.js"));
+var _regl = _interopRequireDefault(require("regl"));
+var _utilityFunctions = _interopRequireDefault(require("../glsl/utility-functions.js"));
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+/**
+ * WebGL1 Renderer Implementation
+ *
+ * Wraps existing regl-based rendering code to implement the RendererInterface.
+ * This is the default renderer for hydra-synth.
+ */
+
+class WebGL1Renderer extends _RendererInterface.RendererInterface {
+  constructor() {
+    super();
+    this._canvas = null;
+    this._regl = null;
+    this._width = 0;
+    this._height = 0;
+    this._precision = 'mediump';
+    this._outputs = [];
+    this._sources = [];
+
+    // Compiled regl commands for screen rendering
+    this._renderFboCommand = null;
+    this._renderAllCommand = null;
+  }
+  init(canvas, options = {}) {
+    const {
+      precision = 'mediump',
+      width = canvas.width || 1280,
+      height = canvas.height || 720,
+      pb = null
+    } = options;
+    this._canvas = canvas;
+    this._width = width;
+    this._height = height;
+    this._precision = precision;
+    this._pb = pb;
+
+    // Initialize regl context
+    this._regl = (0, _regl.default)({
+      canvas: this._canvas,
+      pixelRatio: 1
+    });
+
+    // Clear to black
+    this._regl.clear({
+      color: [0, 0, 0, 1]
+    });
+
+    // Create the renderFbo command (single output to screen)
+    this._renderFboCommand = this._regl({
+      frag: `
+      precision ${this._precision} float;
+      varying vec2 uv;
+      uniform vec2 resolution;
+      uniform sampler2D tex0;
+
+      void main () {
+        gl_FragColor = texture2D(tex0, vec2(1.0 - uv.x, uv.y));
+      }
+      `,
+      vert: `
+      precision ${this._precision} float;
+      attribute vec2 position;
+      varying vec2 uv;
+
+      void main () {
+        uv = position;
+        gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
+      }`,
+      attributes: {
+        position: [[-2, 0], [0, -2], [2, 2]]
+      },
+      uniforms: {
+        tex0: this._regl.prop('tex0'),
+        resolution: this._regl.prop('resolution')
+      },
+      count: 3,
+      depth: {
+        enable: false
+      }
+    });
+
+    // Create the renderAll command (4-up grid)
+    this._renderAllCommand = this._regl({
+      frag: `
+      precision ${this._precision} float;
+      varying vec2 uv;
+      uniform sampler2D tex0;
+      uniform sampler2D tex1;
+      uniform sampler2D tex2;
+      uniform sampler2D tex3;
+
+      void main () {
+        vec2 st = vec2(1.0 - uv.x, uv.y);
+        st*= vec2(2);
+        vec2 q = floor(st).xy*(vec2(2.0, 1.0));
+        int quad = int(q.x) + int(q.y);
+        st.x += step(1., mod(st.y,2.0));
+        st.y += step(1., mod(st.x,2.0));
+        st = fract(st);
+        if(quad==0){
+          gl_FragColor = texture2D(tex0, st);
+        } else if(quad==1){
+          gl_FragColor = texture2D(tex1, st);
+        } else if (quad==2){
+          gl_FragColor = texture2D(tex2, st);
+        } else {
+          gl_FragColor = texture2D(tex3, st);
+        }
+
+      }
+      `,
+      vert: `
+      precision ${this._precision} float;
+      attribute vec2 position;
+      varying vec2 uv;
+
+      void main () {
+        uv = position;
+        gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
+      }`,
+      attributes: {
+        position: [[-2, 0], [0, -2], [2, 2]]
+      },
+      uniforms: {
+        tex0: this._regl.prop('tex0'),
+        tex1: this._regl.prop('tex1'),
+        tex2: this._regl.prop('tex2'),
+        tex3: this._regl.prop('tex3')
+      },
+      count: 3,
+      depth: {
+        enable: false
+      }
+    });
+  }
+  destroy() {
+    if (this._regl) {
+      this._regl.destroy();
+      this._regl = null;
+    }
+    this._outputs = [];
+    this._sources = [];
+  }
+  resize(width, height) {
+    this._width = width;
+    this._height = height;
+    this._canvas.width = width;
+    this._canvas.height = height;
+
+    // Resize all outputs
+    this._outputs.forEach(output => {
+      output.resize(width, height);
+    });
+
+    // Resize all sources
+    this._sources.forEach(source => {
+      source.resize(width, height);
+    });
+
+    // Refresh regl state
+    this._regl._refresh();
+  }
+
+  // ============================================================
+  // Output Management
+  // ============================================================
+
+  createOutput(index, options = {}) {
+    const output = new _output.default({
+      regl: this._regl,
+      width: options.width || this._width,
+      height: options.height || this._height,
+      precision: this._precision,
+      label: options.label || `o${index}`
+    });
+    output.id = index;
+    this._outputs[index] = output;
+    return output;
+  }
+  getOutput(index) {
+    return this._outputs[index];
+  }
+
+  // ============================================================
+  // Source Management
+  // ============================================================
+
+  createSource(index, options = {}) {
+    const source = new _hydraSource.default({
+      regl: this._regl,
+      pb: this._pb,
+      width: options.width || this._width,
+      height: options.height || this._height,
+      label: options.label || `s${index}`
+    });
+    this._sources[index] = source;
+    return source;
+  }
+
+  // ============================================================
+  // Rendering
+  // ============================================================
+
+  renderPass(output, pass) {
+    // This delegates to Output.render() which sets up the draw command
+    output.render([pass]);
+  }
+  tickOutput(output, props) {
+    output.tick(props);
+  }
+  renderToScreen(output) {
+    this._renderFboCommand({
+      tex0: output.getCurrent(),
+      resolution: [this._width, this._height]
+    });
+  }
+  renderAllToScreen(outputs) {
+    this._renderAllCommand({
+      tex0: outputs[0].getCurrent(),
+      tex1: outputs[1].getCurrent(),
+      tex2: outputs[2].getCurrent(),
+      tex3: outputs[3].getCurrent(),
+      resolution: [this._width, this._height]
+    });
+  }
+
+  // ============================================================
+  // Capabilities & Info
+  // ============================================================
+
+  get capabilities() {
+    const gl = this._regl._gl;
+    return {
+      name: 'webgl1',
+      glslVersion: '100',
+      instancing: !!gl.getExtension('ANGLE_instanced_arrays'),
+      floatTextures: !!gl.getExtension('OES_texture_float'),
+      halfFloatTextures: !!gl.getExtension('OES_texture_half_float'),
+      maxTextureSize: gl.getParameter(gl.MAX_TEXTURE_SIZE),
+      maxTextureUnits: gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS)
+    };
+  }
+  get canvas() {
+    return this._canvas;
+  }
+  get width() {
+    return this._width;
+  }
+  get height() {
+    return this._height;
+  }
+
+  // ============================================================
+  // Additional accessors for compatibility
+  // ============================================================
+
+  get regl() {
+    return this._regl;
+  }
+  get precision() {
+    return this._precision;
+  }
+  get outputs() {
+    return this._outputs;
+  }
+  get sources() {
+    return this._sources;
+  }
+
+  // ============================================================
+  // Shader Generation Hooks
+  // ============================================================
+
+  get shaderLanguage() {
+    return 'glsl';
+  }
+  getUtilityFunctions() {
+    return _utilityFunctions.default;
+  }
+  buildShader(shaderInfo, options = {}) {
+    const precision = options.precision || this._precision;
+    return `
+  precision ${precision} float;
+  ${Object.values(shaderInfo.uniforms).map(uniform => {
+      let type = uniform.type;
+      switch (uniform.type) {
+        case 'texture':
+          type = 'sampler2D';
+          break;
+      }
+      return `
+      uniform ${type} ${uniform.name};`;
+    }).join('')}
+  uniform float time;
+  uniform vec2 resolution;
+  varying vec2 uv;
+  uniform sampler2D prevBuffer;
+
+  ${Object.values(_utilityFunctions.default).map(transform => {
+      return `
+            ${transform.glsl}
+          `;
+    }).join('')}
+
+  ${shaderInfo.glslFunctions.map(transform => {
+      const shaderCode = transform.transform[this.shaderLanguage] || transform.transform.glsl;
+      return `
+            ${shaderCode}
+          `;
+    }).join('')}
+
+  void main () {
+    vec2 st = gl_FragCoord.xy/resolution.xy;
+
+    ${shaderInfo.fragColor}
+    gl_FragColor = c;
+  }
+  `;
+  }
+}
+exports.WebGL1Renderer = WebGL1Renderer;
+var _default = exports.default = WebGL1Renderer;
+
+},{"../glsl/utility-functions.js":16,"../hydra-source.js":17,"../output.js":29,"./RendererInterface.js":30,"regl":8}],32:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+Object.defineProperty(exports, "RendererInterface", {
+  enumerable: true,
+  get: function () {
+    return _RendererInterface.RendererInterface;
+  }
+});
+Object.defineProperty(exports, "WebGL1Renderer", {
+  enumerable: true,
+  get: function () {
+    return _WebGL1Renderer.WebGL1Renderer;
+  }
+});
+exports.createRenderer = createRenderer;
+Object.defineProperty(exports, "default", {
+  enumerable: true,
+  get: function () {
+    return _WebGL1Renderer.WebGL1Renderer;
+  }
+});
+var _RendererInterface = require("./RendererInterface.js");
+var _WebGL1Renderer = require("./WebGL1Renderer.js");
+/**
+ * Renderer Module
+ *
+ * Exports the renderer interface and available implementations.
+ */
+
+// Default renderer
+
+/**
+ * Create a renderer by name
+ * @param {string} name - 'webgl1', 'webgl', or 'auto'
+ * @returns {RendererInterface}
+ */
+function createRenderer(name = 'webgl1') {
+  switch (name.toLowerCase()) {
+    case 'webgl1':
+    case 'webgl':
+    case 'auto':
+    default:
+      return new WebGL1Renderer();
+  }
+}
+
+},{"./RendererInterface.js":30,"./WebGL1Renderer.js":31}]},{},[19])(19)
 });

--- a/extensions/vertex/README.md
+++ b/extensions/vertex/README.md
@@ -1,0 +1,157 @@
+# Hydra Vertex Shader Extension
+
+Adds 3D vertex shader capabilities to [hydra-synth](https://hydra.ojack.xyz/), including geometry primitives, lighting, model loading, and WebGPU support.
+
+## Installation
+
+### WebGL Mode (works with vanilla hydra-synth)
+
+```javascript
+// In hydra editor or your own setup
+await import('https://your-host.com/vertex/index.js')
+  .then(m => m.install(window.hydraSynth))
+
+// Now use 3D features
+osc(10).out(o0, sphere().perspective(60).rotateY(() => time))
+```
+
+### WebGPU Mode (experimental, better performance)
+
+```javascript
+import { createHydra } from 'hydra-vertex-extension'
+
+const hydra = await createHydra({
+  useWGSL: true,  // Enable WebGPU
+  makeGlobal: true
+})
+
+// Same API as WebGL mode
+osc(10).out(o0, sphere().perspective(60).rotateY(() => time))
+```
+
+## Features
+
+### Geometry Primitives
+
+| Function | Description |
+|----------|-------------|
+| `tri(size)` | Triangle |
+| `quad(size)` | Quad/rectangle |
+| `poly(sides, size)` | Regular polygon |
+| `circle(radius, segments)` | Circle |
+| `ring(inner, outer, segments)` | Ring/annulus |
+| `line(points)` | Line strip |
+| `cube(size)` | 3D cube |
+| `sphere(radius, segments)` | 3D sphere |
+| `plane(width, height)` | 3D plane |
+| `torus(radius, tube, segments)` | 3D torus |
+| `cylinder(radius, height, segments)` | 3D cylinder |
+| `cone(radius, height, segments)` | 3D cone |
+
+### Model Loading
+
+```javascript
+// Load GLB/GLTF models
+loadGlb('https://example.com/model.glb').then(model => {
+  osc(10).out(o0, model.rotateY(() => time).perspective(45))
+})
+
+// Load OBJ models
+loadObj('https://example.com/model.obj').then(model => {
+  solid(1, 0, 0).out(o0, model.scale(0.5))
+})
+```
+
+### Vertex Transforms
+
+Chain these on geometry:
+
+```javascript
+sphere()
+  .rotateX(angle)      // Rotate around X axis
+  .rotateY(angle)      // Rotate around Y axis
+  .rotateZ(angle)      // Rotate around Z axis
+  .scale(x, y, z)      // Scale geometry
+  .translate(x, y, z)  // Move geometry
+  .perspective(fov)    // Apply perspective projection
+  .grid(nx, ny, nz, spacing)  // Create grid of instances
+```
+
+### Lighting Functions
+
+```javascript
+osc(10)
+  .diffuse(lightX, lightY, lightZ)     // Diffuse lighting
+  .specular(lightX, lightY, lightZ, shininess)  // Specular highlights
+  .fresnel(power, bias)                // Fresnel rim lighting
+  .out(o0, sphere().perspective(60))
+```
+
+### Sprite Layers
+
+Multiple geometry layers with blending:
+
+```javascript
+// Level 0 clears, level 1+ composites
+solid(1, 0, 0).out(o0, cube(), { level: 0 })
+solid(0, 1, 0).out(o0, sphere(), { level: 1, blend: 'add' })
+```
+
+Blend modes: `'normal'`, `'add'`, `'multiply'`, `'screen'`
+
+### Varying Proxy (v)
+
+Access vertex shader data in fragment shaders:
+
+```javascript
+// Use vertex normal for coloring
+solid(v.normal.x, v.normal.y, v.normal.z)
+  .out(o0, sphere().perspective(60))
+
+// Available: v.position, v.normal, v.uv, v.depth, v.viewDir
+```
+
+## Examples
+
+```javascript
+// Spinning cube with oscillator texture
+osc(10, 0.1, 1).out(o0, cube().rotateY(() => time).perspective(60))
+
+// Lit sphere
+osc(5).diffuse(1, 1, 1).specular(1, 1, 1, 32)
+  .out(o0, sphere().perspective(60).rotateY(() => time))
+
+// Load and display 3D model
+loadGlb('https://example.com/cat.glb').then(m => {
+  osc(10).out(o0, m.scale(2).rotateY(() => time).perspective(45))
+})
+
+// Grid of rotating cubes
+noise(3).out(o0, cube(0.1).grid(3, 3, 1, 0.3).rotateY(() => time).perspective(60))
+```
+
+## API Reference
+
+### `install(hydra)`
+
+Patches an existing hydra-synth instance to add vertex features. Works with vanilla hydra-synth (WebGL).
+
+### `createHydra(options)`
+
+Creates a new hydra instance with vertex extension pre-installed. Supports both WebGL and WebGPU.
+
+Options:
+- `useWGSL: boolean` - Enable WebGPU mode (default: false)
+- `width, height: number` - Canvas dimensions
+- `makeGlobal: boolean` - Expose functions globally (default: true)
+- `canvas: HTMLCanvasElement` - Custom canvas element
+- `detectAudio: boolean` - Enable audio reactivity
+
+## Browser Support
+
+- **WebGL mode**: All modern browsers
+- **WebGPU mode**: Chrome 113+, Edge 113+, Firefox (behind flag)
+
+## License
+
+MIT

--- a/extensions/vertex/array-utils.js
+++ b/extensions/vertex/array-utils.js
@@ -1,0 +1,96 @@
+// WIP utils for working with arrays
+// Possibly should be integrated with lfo extension, etc.
+// to do: transform time rather than array values, similar to working with coordinates in hydra
+
+import easing from './easing-functions.js'
+
+var map = (num, in_min, in_max, out_min, out_max) => {
+  return (num - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+}
+
+// The '%' operator is a remainder operator, and Javascript lacks a dedicated
+// modulo operator. This function is an implementation of the operation
+// copied-n-pasted from
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder#description
+var modulo = (n, d) => {
+    return ((n % d) + d) % d;
+}
+
+export default {
+  init: () => {
+
+    Array.prototype.fast = function(speed = 1) {
+      this._speed = speed
+      return this
+    }
+
+    Array.prototype.smooth = function(smooth = 1) {
+      this._smooth = smooth
+      return this
+    }
+
+    Array.prototype.ease = function(ease = 'linear') {
+      if (typeof ease == 'function') {
+        this._smooth = 1
+        this._ease = ease
+      }
+      else if (easing[ease]){
+        this._smooth = 1
+        this._ease = easing[ease]
+      }
+      return this
+    }
+
+    Array.prototype.offset = function(offset = 0.5) {
+      this._offset = offset%1.0
+      return this
+    }
+
+    // Array.prototype.bounce = function() {
+    //   this.modifiers.bounce = true
+    //   return this
+    // }
+
+    Array.prototype.fit = function(low = 0, high =1) {
+      let lowest = Math.min(...this)
+      let highest =  Math.max(...this)
+      var newArr = this.map((num) => map(num, lowest, highest, low, high))
+      newArr._speed = this._speed
+      newArr._smooth = this._smooth
+      newArr._ease = this._ease
+      return newArr
+    }
+  },
+
+  getValue: (arr = []) => ({time, bpm}) =>{
+    let speed = arr._speed ? arr._speed : 1
+    let smooth = arr._smooth ? arr._smooth : 0
+    let index = time * speed * (bpm / 60) + (arr._offset || 0)
+
+    if (smooth!==0) {
+      let ease = arr._ease ? arr._ease : easing['linear']
+      let _index = index - (smooth / 2)
+      // Compute the first value used for the interpolation: wrap _index inside the range [0, arr.length), then round the resulting value towards 0.
+      // Note that, during the first seconds Hydra is running, _index may assume a negative value.
+      // If we wrapped _index inside the range [0, arr.length) using the regular remainder operator, the result would be negative.
+      // Passing a negative index to an array returns undefined, which ultimately causes a number of graphical glitches.
+      // We need to use the modulo operation to prevent this.
+      let currValue = arr[Math.floor(modulo(_index, arr.length))]
+      // Compute the second value used for the interpolation, in a similar fashion to 'currValue'.
+      // The above reasoning about the choice of the modulo operation applies for 'nextValue', too.
+      let nextValue = arr[Math.floor(modulo(_index + 1, arr.length))]
+      // Compute the time parameter for the interpolation.
+      // Note that, during the first seconds Hydra is running, _index may assume a negative value.
+      // Assuming 'smooth' is positive, if we wrapped _index in the range [0, 1) using the regular remainder operator, t would become negative as a result.
+      // This would cause the final interpolation to assume values inconsistent with the later ones.
+      // E.g. [0, 1].smooth() should always generate values between 0 and 1, but the initial values would be negative.
+      // We need to use the modulo operation to prevent this.
+      let t = Math.min(modulo(_index, 1)/smooth,1)
+      return ease(t) * (nextValue - currValue) + currValue
+    }
+    else {
+      const val = arr[Math.floor(index % (arr.length))]
+      return arr[Math.floor(index % (arr.length))]
+    }
+  }
+}

--- a/extensions/vertex/createHydra.js
+++ b/extensions/vertex/createHydra.js
@@ -1,0 +1,484 @@
+/**
+ * Hydra Factory with WebGL + WebGPU support
+ *
+ * This factory creates Hydra instances that work with both rendering backends.
+ * For WebGL, it uses vanilla hydra-synth. For WebGPU, it initializes the WGSL pipeline.
+ */
+
+// WebGPU imports (from extension's wgsl folder)
+import { wgslHydra } from './wgsl/wgsl-hydra.js'
+import { OutputWgsl } from './wgsl/outputWgsl.js'
+
+// We need these from hydra-synth for initialization
+import Output from '../../src/output.js'
+import Source from '../../src/hydra-source.js'
+import MouseTools from '../../src/lib/mouse.js'
+import Audio from '../../src/lib/audio.js'
+import VidRecorder from '../../src/lib/video-recorder.js'
+import ArrayUtils from '../../src/lib/array-utils.js'
+import Sandbox from '../../src/eval-sandbox.js'
+import Generator from '../../src/generator-factory.js'
+import regl from 'regl'
+
+// RAF loop - use a simple implementation
+function createLoop(fn) {
+  let running = false
+  let lastTime = performance.now()
+  let rafId = null
+
+  function tick() {
+    if (!running) return
+    const now = performance.now()
+    const dt = now - lastTime
+    lastTime = now
+    fn(dt)
+    rafId = requestAnimationFrame(tick)
+  }
+
+  return {
+    start() {
+      if (running) return this
+      running = true
+      lastTime = performance.now()
+      rafId = requestAnimationFrame(tick)
+      return this
+    },
+    stop() {
+      running = false
+      if (rafId) cancelAnimationFrame(rafId)
+      return this
+    }
+  }
+}
+
+// Mouse singleton
+let Mouse
+if (typeof window !== 'undefined') {
+  Mouse = MouseTools()
+} else {
+  Mouse = { x: 0, y: 0 }
+}
+
+/**
+ * Create a Hydra instance with optional WebGPU support
+ */
+export async function createHydra({
+  pb = null,
+  width = 1280,
+  height = 720,
+  numSources = 4,
+  numOutputs = 4,
+  makeGlobal = true,
+  autoLoop = true,
+  detectAudio = true,
+  enableStreamCapture = true,
+  useWGSL = false,
+  canvas,
+  precision,
+  extendTransforms = {},
+  gpuDevice = null,
+  preserveDrawingBuffer = false
+} = {}) {
+
+  // Create the hydra instance object
+  const hydra = {
+    pb,
+    width,
+    height,
+    renderAll: false,
+    detectAudio,
+    useWGSL,
+    preserveDrawingBuffer,
+    gpuDevice,
+    numOutputs,
+    o: [],
+    s: [],
+    synth: {
+      time: 0,
+      bpm: 30,
+      width,
+      height,
+      fps: undefined,
+      stats: { fps: 0 },
+      speed: 1,
+      mouse: Mouse,
+      isWGSL: useWGSL
+    },
+    timeSinceLastUpdate: 0,
+    _time: 0
+  }
+
+  ArrayUtils.init()
+
+  // Determine precision
+  const precisionOptions = ['lowp', 'mediump', 'highp']
+  if (precision && precisionOptions.includes(precision.toLowerCase())) {
+    hydra.precision = precision.toLowerCase()
+  } else {
+    const isIOS = typeof navigator !== 'undefined' &&
+      ((/iPad|iPhone|iPod/.test(navigator.platform) ||
+        (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) &&
+      !window.MSStream)
+    hydra.precision = isIOS ? 'highp' : 'mediump'
+  }
+
+  hydra.extendTransforms = extendTransforms
+
+  // Initialize canvas
+  if (canvas) {
+    hydra.canvas = canvas
+  } else if (typeof document !== 'undefined') {
+    // Ensure body fills viewport
+    document.body.style.margin = '0'
+    document.body.style.padding = '0'
+    document.body.style.overflow = 'hidden'
+    document.body.style.width = '100vw'
+    document.body.style.height = '100vh'
+    document.body.style.background = '#000'
+    document.documentElement.style.margin = '0'
+    document.documentElement.style.padding = '0'
+    document.documentElement.style.width = '100%'
+    document.documentElement.style.height = '100%'
+
+    // Hide any existing app div
+    const appDiv = document.getElementById('app')
+    if (appDiv) appDiv.style.display = 'none'
+
+    hydra.canvas = document.createElement('canvas')
+    hydra.canvas.style.position = 'fixed'
+    hydra.canvas.style.top = '0'
+    hydra.canvas.style.left = '0'
+    hydra.canvas.style.width = '100%'
+    hydra.canvas.style.height = '100%'
+    hydra.canvas.style.display = 'block'
+    hydra.canvas.style.imageRendering = 'pixelated'
+    document.body.appendChild(hydra.canvas)
+
+    // Use actual display size for canvas dimensions
+    const rect = hydra.canvas.getBoundingClientRect()
+    const displayWidth = Math.round(rect.width * (window.devicePixelRatio || 1))
+    const displayHeight = Math.round(rect.height * (window.devicePixelRatio || 1))
+    hydra.canvas.width = displayWidth || width
+    hydra.canvas.height = displayHeight || height
+    hydra.width = hydra.canvas.width
+    hydra.height = hydra.canvas.height
+    hydra.synth.width = hydra.canvas.width
+    hydra.synth.height = hydra.canvas.height
+  }
+
+  // Bind methods to synth
+  hydra.synth.render = hydra._render = function(output) {
+    if (output) {
+      hydra.output = output
+      hydra.isRenderingAll = false
+    } else {
+      hydra.isRenderingAll = true
+    }
+  }.bind(hydra)
+
+  hydra.synth.setResolution = hydra.setResolution = function(w, h) {
+    // Guard against invalid dimensions
+    if (!w || !h || w <= 0 || h <= 0) {
+      console.warn(`[hydra] setResolution called with invalid dimensions: ${w}x${h}`)
+      return
+    }
+    hydra.canvas.width = w
+    hydra.canvas.height = h
+    hydra.width = w
+    hydra.height = h
+    hydra.synth.width = w
+    hydra.synth.height = h
+    if (hydra.wgslHydra) {
+      hydra.wgslHydra.resizeOutputsTo(w, h)
+    }
+    hydra.o.forEach(o => o.resize && o.resize(w, h))
+  }.bind(hydra)
+
+  hydra.synth.hush = hydra.hush = function() {
+    hydra.s.forEach(source => source.clear && source.clear())
+    hydra.o.forEach(output => {
+      if (output.clearSprites) output.clearSprites()
+    })
+    hydra.synth.render(hydra.o[0])
+  }.bind(hydra)
+
+  hydra.synth.update = (dt) => {}
+  hydra.synth.tick = hydra.tick = createTick(hydra)
+
+  // Initialize based on mode
+  if (useWGSL) {
+    // WebGPU mode
+    hydra.wgslHydra = new wgslHydra(hydra, hydra.canvas, numOutputs, gpuDevice)
+
+    // Initialize outputs
+    hydra.o = Array(numOutputs).fill().map((_, index) => {
+      const o = new OutputWgsl({
+        wgslHydra: hydra.wgslHydra,
+        hydraSynth: hydra,
+        width: hydra.width,
+        height: hydra.height,
+        chanNum: index,
+        label: `o${index}`
+      })
+      o.id = index
+      o.precision = hydra.precision
+      hydra.synth['o' + index] = o
+      return o
+    })
+    hydra.output = hydra.o[0]
+
+    // Setup WebGPU
+    await hydra.wgslHydra.setupHydra()
+
+    // Initialize sources
+    initSources(hydra, numSources)
+
+    // Generate transforms
+    hydra.generator = new Generator({
+      defaultOutput: hydra.o[0],
+      defaultUniforms: hydra.o[0].uniforms || {},
+      extendTransforms: hydra.extendTransforms,
+      changeListener: ({ type, method, synth }) => {
+        if (type === 'add') {
+          hydra.synth[method] = synth.generators[method]
+          if (hydra.sandbox) hydra.sandbox.add(method)
+        }
+      }
+    })
+    // Set isWGSL so GlslSource knows to generate WGSL shaders
+    hydra.generator.isWGSL = true
+
+    // Expose setFunction for extensions
+    hydra.synth.setFunction = hydra.generator.setFunction.bind(hydra.generator)
+
+  } else {
+    // WebGL mode
+    hydra.regl = regl({
+      canvas: hydra.canvas,
+      pixelRatio: 1,
+      attributes: { preserveDrawingBuffer }
+    })
+
+    hydra.regl.clear({ color: [0, 0, 0, 1] })
+
+    // Initialize outputs
+    hydra.o = Array(numOutputs).fill().map((_, index) => {
+      const o = new Output({
+        regl: hydra.regl,
+        width: hydra.width,
+        height: hydra.height,
+        precision: hydra.precision,
+        label: `o${index}`
+      })
+      o.id = index
+      hydra.synth['o' + index] = o
+      return o
+    })
+    hydra.output = hydra.o[0]
+
+    // Initialize sources
+    initSources(hydra, numSources)
+
+    // Generate transforms
+    hydra.generator = new Generator({
+      genWGSL: false,
+      defaultOutput: hydra.o[0],
+      defaultUniforms: hydra.o[0].uniforms,
+      extendTransforms: hydra.extendTransforms,
+      changeListener: ({ type, method, synth }) => {
+        if (type === 'add') {
+          hydra.synth[method] = synth.generators[method]
+          if (hydra.sandbox) hydra.sandbox.add(method)
+        }
+      }
+    })
+
+    // Expose setFunction for extensions
+    hydra.synth.setFunction = hydra.generator.setFunction.bind(hydra.generator)
+
+    // Create renderAll for WebGL
+    hydra.renderAll = hydra.regl({
+      frag: `
+        precision ${hydra.precision} float;
+        varying vec2 uv;
+        uniform sampler2D tex0;
+        uniform sampler2D tex1;
+        uniform sampler2D tex2;
+        uniform sampler2D tex3;
+        void main () {
+          vec2 st = vec2(1.0 - uv.x, uv.y);
+          st *= vec2(2);
+          vec2 q = floor(st).xy * vec2(2.0, 1.0);
+          int quad = int(q.x) + int(q.y);
+          st.x += step(1., mod(st.y, 2.0));
+          st.y += step(1., mod(st.x, 2.0));
+          st = fract(st);
+          if (quad == 0) {
+            gl_FragColor = texture2D(tex0, st);
+          } else if (quad == 1) {
+            gl_FragColor = texture2D(tex1, st);
+          } else if (quad == 2) {
+            gl_FragColor = texture2D(tex2, st);
+          } else {
+            gl_FragColor = texture2D(tex3, st);
+          }
+        }
+      `,
+      vert: `
+        precision ${hydra.precision} float;
+        attribute vec2 position;
+        varying vec2 uv;
+        void main () {
+          uv = position;
+          gl_Position = vec4(2.0 * position - 1.0, 0, 1);
+        }
+      `,
+      attributes: {
+        position: [[-2, 0], [0, -2], [2, 2]]
+      },
+      uniforms: {
+        tex0: () => hydra.o[0].getCurrent(),
+        tex1: () => hydra.o[1].getCurrent(),
+        tex2: () => hydra.o[2].getCurrent(),
+        tex3: () => hydra.o[3].getCurrent()
+      },
+      count: 3,
+      depth: { enable: false }
+    })
+
+    // Create renderFbo for single output to canvas
+    hydra.renderFbo = hydra.regl({
+      frag: `
+        precision ${hydra.precision} float;
+        varying vec2 uv;
+        uniform sampler2D tex0;
+        void main () {
+          gl_FragColor = texture2D(tex0, vec2(1.0 - uv.x, uv.y));
+        }
+      `,
+      vert: `
+        precision ${hydra.precision} float;
+        attribute vec2 position;
+        varying vec2 uv;
+        void main () {
+          uv = position;
+          gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
+        }
+      `,
+      attributes: {
+        position: [[-2, 0], [0, -2], [2, 2]]
+      },
+      uniforms: {
+        tex0: hydra.regl.prop('tex0'),
+        resolution: hydra.regl.prop('resolution')
+      },
+      count: 3,
+      depth: { enable: false }
+    })
+  }
+
+  // Create sandbox
+  hydra.sandbox = new Sandbox(hydra.synth, makeGlobal, ['speed', 'update', 'bpm', 'fps'])
+
+  // Add all generator methods to sandbox (Generator was created before sandbox)
+  if (hydra.generator && hydra.generator.synth && hydra.generator.synth.generators) {
+    for (const method of Object.keys(hydra.generator.synth.generators)) {
+      hydra.sandbox.add(method)
+    }
+  }
+
+  // Add eval method (delegates to sandbox)
+  hydra.eval = function(code) {
+    return hydra.sandbox.eval(code)
+  }
+
+  // Audio detection
+  if (detectAudio) {
+    try {
+      hydra.audio = new Audio({ numBins: 4 })
+      hydra.synth.a = hydra.audio
+      // Register audio 'a' with sandbox
+      hydra.sandbox.add('a')
+    } catch (e) {
+      console.warn('[hydra] Audio detection not available')
+    }
+  }
+
+  // Start animation loop
+  if (autoLoop) {
+    hydra.looper = createLoop(hydra.tick).start()
+  }
+
+  // Set default render
+  hydra.synth.render(hydra.o[0])
+
+  return hydra
+}
+
+function initSources(hydra, numSources) {
+  // Sources require regl - skip in WebGPU mode for now
+  // TODO: Create WebGPU-compatible source class
+  if (!hydra.regl) {
+    console.warn('[hydra] Sources (s0, s1, etc.) not available in WebGPU mode')
+    return
+  }
+
+  for (let i = 0; i < numSources; i++) {
+    const s = new Source({
+      regl: hydra.regl,
+      hydraSynth: hydra,
+      pb: hydra.pb,
+      width: hydra.width,
+      height: hydra.height,
+      chanNum: i,
+      label: `s${i}`
+    })
+    hydra.synth['s' + i] = s
+    hydra.s.push(s)
+  }
+}
+
+function createTick(hydra) {
+  return function tick(dt) {
+    hydra.synth.time += dt * 0.001 * hydra.synth.speed
+    hydra.synth.stats.fps = Math.round(1000 / dt)
+
+    if (hydra.synth.update) hydra.synth.update(dt)
+
+    // Update sources
+    hydra.s.forEach(source => source.tick && source.tick(hydra.synth.time))
+
+    // Render
+    if (hydra.useWGSL) {
+      // WebGPU render
+      hydra.wgslHydra.animate(hydra.synth.time, hydra.synth.mouse, hydra.synth.resolution, hydra.isRenderingAll)
+    } else {
+      // WebGL render
+      hydra.o.forEach(o => o.tick && o.tick({
+        time: hydra.synth.time,
+        mouse: hydra.synth.mouse,
+        bpm: hydra.synth.bpm,
+        resolution: [hydra.canvas.width, hydra.canvas.height]
+      }))
+
+      if (hydra.isRenderingAll) {
+        hydra.renderAll({
+          tex0: hydra.o[0].getCurrent(),
+          tex1: hydra.o[1].getCurrent(),
+          tex2: hydra.o[2].getCurrent(),
+          tex3: hydra.o[3].getCurrent(),
+          resolution: [hydra.canvas.width, hydra.canvas.height]
+        })
+      } else {
+        hydra.renderFbo({
+          tex0: hydra.output.getCurrent(),
+          resolution: [hydra.canvas.width, hydra.canvas.height]
+        })
+      }
+    }
+
+    if (hydra.synth.afterUpdate) hydra.synth.afterUpdate(dt)
+  }
+}
+
+export default createHydra

--- a/extensions/vertex/easing-functions.js
+++ b/extensions/vertex/easing-functions.js
@@ -1,0 +1,32 @@
+// from https://gist.github.com/gre/1650294
+
+export default {
+  // no easing, no acceleration
+  linear: function (t) { return t },
+  // accelerating from zero velocity
+  easeInQuad: function (t) { return t*t },
+  // decelerating to zero velocity
+  easeOutQuad: function (t) { return t*(2-t) },
+  // acceleration until halfway, then deceleration
+  easeInOutQuad: function (t) { return t<.5 ? 2*t*t : -1+(4-2*t)*t },
+  // accelerating from zero velocity
+  easeInCubic: function (t) { return t*t*t },
+  // decelerating to zero velocity
+  easeOutCubic: function (t) { return (--t)*t*t+1 },
+  // acceleration until halfway, then deceleration
+  easeInOutCubic: function (t) { return t<.5 ? 4*t*t*t : (t-1)*(2*t-2)*(2*t-2)+1 },
+  // accelerating from zero velocity
+  easeInQuart: function (t) { return t*t*t*t },
+  // decelerating to zero velocity
+  easeOutQuart: function (t) { return 1-(--t)*t*t*t },
+  // acceleration until halfway, then deceleration
+  easeInOutQuart: function (t) { return t<.5 ? 8*t*t*t*t : 1-8*(--t)*t*t*t },
+  // accelerating from zero velocity
+  easeInQuint: function (t) { return t*t*t*t*t },
+  // decelerating to zero velocity
+  easeOutQuint: function (t) { return 1+(--t)*t*t*t*t },
+  // acceleration until halfway, then deceleration
+  easeInOutQuint: function (t) { return t<.5 ? 16*t*t*t*t*t : 1+16*(--t)*t*t*t*t },
+  // sin shape
+  sin: function (t) { return (1 + Math.sin(Math.PI*t-Math.PI/2))/2 }
+}

--- a/extensions/vertex/extension.json
+++ b/extensions/vertex/extension.json
@@ -1,0 +1,12 @@
+{
+  "name": "hydra-vertex",
+  "description": "3D vertex shader extension - adds geometry primitives (cube, sphere, torus), vertex transforms (rotate, scale), lighting (diffuse, specular, fresnel), model loading (GLB/OBJ), and WebGPU support",
+  "documentation": "https://github.com/jamiefaye/hydra-synth/tree/extensions/extensions/vertex",
+  "author": "Jamie Faye Fenton",
+  "thumbnail": "vertex-icon.svg",
+  "load": "await import('https://www.fentonia.com/hydra-extensions/vertex/index.js').then(m => m.install(window.hydraSynth))",
+  "examples": [
+    "https://hydra.ojack.xyz/?code=JTJGJTJGJTIwM0QlMjBzcGhlcmUlMjB3aXRoJTIwbGlnaHRpbmclMEFvc2MoMTAlMkMlMjAwLjElMkMlMjAxKS5kaWZmdXNlKDAlMkMlMjAxJTJDJTIwMCkub3V0KG8wJTJDJTIwc3BoZXJlKCkucGVyc3BlY3RpdmUoNjApLnJvdGF0ZVkoKCklMjAlM0QlM0UlMjB0aW1lKSk=",
+    "https://hydra.ojack.xyz/?code=JTJGJTJGJTIwR3JpZCUyMG9mJTIwY3ViZXMlMEFvc2MoMTApLmRpZmZ1c2UoMCUyQyUyMDElMkMlMjAwKS5vdXQobzAlMkMlMjBjdWJlKDAuMSkuZ3JpZCgzJTJDJTIwMyUyQyUyMDMlMkMlMjAwLjMpLnBlcnNwZWN0aXZlKDYwKS5yb3RhdGVZKCgpJTIwJTNEJTNFJTIwdGltZSkp"
+  ]
+}

--- a/extensions/vertex/format-arguments.js
+++ b/extensions/vertex/format-arguments.js
@@ -1,0 +1,150 @@
+import arrayUtils from './array-utils.js'
+import { isVaryingRef } from './varying-proxy.js'
+
+// [WIP] how to treat different dimensions (?)
+const DEFAULT_CONVERSIONS = {
+  float: {
+    'vec4': { name: 'sum', args: [[1, 1, 1, 1]] },
+    'vec2': { name: 'sum', args: [[1, 1]] }
+  }
+}
+
+function fillArrayWithDefaults(arr, len) {
+  // fill the array with default values if it's too short
+  while (arr.length < len) {
+    if (arr.length === 3) { // push a 1 as the default for .a in vec4
+      arr.push(1.0)
+    } else {
+      arr.push(0.0)
+    }
+  }
+  return arr.slice(0, len)
+}
+
+const ensure_decimal_dot = (val) => {
+  val = val.toString()
+  if (val.indexOf('.') < 0) {
+    val += '.'
+  }
+  return val
+}
+
+
+
+export default function formatArguments(transform, startIndex, synthContext) {
+  const defaultArgs = transform.transform.inputs
+  const userArgs = transform.userArgs
+  const { generators } = transform.synth
+  const { src } = generators // depends on synth having src() function
+  return defaultArgs.map((input, index) => {
+    const typedArg = {
+      value: input.default,
+      type: input.type, //
+      isUniform: false,
+      name: input.name,
+      vecLen: 0
+      //  generateGlsl: null // function for creating glsl
+    }
+
+    if (typedArg.type === 'float') typedArg.value = ensure_decimal_dot(input.default)
+    if (input.type.startsWith('vec')) {
+      try {
+        typedArg.vecLen = Number.parseInt(input.type.substr(3))
+      } catch (e) {
+        console.log(`Error determining length of vector input type ${input.type} (${input.name})`)
+      }
+    }
+
+    // if user has input something for this argument
+    if (userArgs.length > index) {
+      typedArg.value = userArgs[index]
+
+      // Check for VaryingRef first (e.g., v.normal.z) - handle before other type checks
+      if (isVaryingRef(userArgs[index])) {
+        // Varying reference from v proxy
+        // Store the VaryingRef directly - it will be resolved in generate-glsl based on backend
+        typedArg.value = userArgs[index]
+        typedArg.isVaryingRef = true
+        typedArg.isUniform = false
+      } else if (typedArg.type === 'vec4') {
+        if (!(typedArg.value.type === "GlslSource" || typedArg.value.getTexture)) {
+          throw new Error("Arguments must be a texture or GlslSource")
+        }
+      }
+      // do something if a composite or transform
+
+      if (!typedArg.isVaryingRef && typeof userArgs[index] === 'function') {
+        // if (typedArg.vecLen > 0) { // expected input is a vector, not a scalar
+        //    typedArg.value = (context, props, batchId) => (fillArrayWithDefaults(userArgs[index](props), typedArg.vecLen))
+        // } else {
+        typedArg.value = (context, props, batchId) => {
+          try {
+            const val = userArgs[index](props)
+            if (typeof val === 'number') {
+              return val
+            } else {
+              console.warn('function does not return a number', userArgs[index])
+            }
+            return input.default
+          } catch (e) {
+            console.warn('ERROR', e)
+            return input.default
+          }
+        }
+        //  }
+
+        typedArg.isUniform = true
+      } else if (!typedArg.isVaryingRef && userArgs[index].constructor === Array) {
+        //   if (typedArg.vecLen > 0) { // expected input is a vector, not a scalar
+        //     typedArg.isUniform = true
+        //     typedArg.value = fillArrayWithDefaults(typedArg.value, typedArg.vecLen)
+        //  } else {
+        //  console.log("is Array")
+        // filter out values that are not a number
+        // const filteredArray = userArgs[index].filter((val) => typeof val === 'number')
+        // typedArg.value = (context, props, batchId) => arrayUtils.getValue(filteredArray)(props)
+        typedArg.value = (context, props, batchId) => arrayUtils.getValue(userArgs[index])(props)
+        typedArg.isUniform = true
+        // }
+      }
+    }
+
+    if (startIndex < 0) {
+    } else {
+      if (typedArg.value && typedArg.value.transforms) {
+        // Type coercion (vec4 → float) is now handled inline in generate-glsl.js
+        // by extracting .r channel. The old DEFAULT_CONVERSIONS approach using
+        // .sum() didn't work because sum is a 'color' type function that expects
+        // _c0 in a chain context.
+        typedArg.isUniform = false
+      } else if (typedArg.type === 'float' && typeof typedArg.value === 'number') {
+        typedArg.value = ensure_decimal_dot(typedArg.value)
+      } else if (typedArg.type.startsWith('vec') && typeof typedArg.value === 'object' && Array.isArray(typedArg.value)) {
+        typedArg.isUniform = false
+        typedArg.value = `${typedArg.type}(${typedArg.value.map(ensure_decimal_dot).join(', ')})`
+      } else if (input.type === 'sampler2D') {
+        // typedArg.tex = typedArg.value
+        var x = typedArg.value
+        typedArg.value = () => (x.getTexture())
+        typedArg.isUniform = true
+      } else {
+        // if passing in a texture reference, when function asks for vec4, convert to vec4
+        if (typedArg.value.getTexture && input.type === 'vec4') {
+          var x1 = typedArg.value
+          typedArg.value = src(x1)
+          typedArg.isUniform = false
+        }
+      }
+
+      // add to uniform array if is a function that will pass in a different value on each render frame,
+      // or a texture/ external source
+
+      if (typedArg.isUniform) {
+        typedArg.name += startIndex
+        //  shaderParams.uniforms.push(typedArg)
+      }
+    }
+    return typedArg
+  })
+}
+

--- a/extensions/vertex/generate-glsl.js
+++ b/extensions/vertex/generate-glsl.js
@@ -1,0 +1,114 @@
+import formatArguments from './format-arguments.js'
+
+// Add extra functionality to Array.prototype for generating sequences in time
+import arrayUtils from './array-utils.js'
+import { isVaryingRef, getVaryingString } from './varying-proxy.js'
+
+
+
+// converts a tree of javascript functions to a shader
+export default function (transforms, synth) {
+   var shaderParams = {
+      uniforms: [], // list of uniforms used in shader
+      glslFunctions: [], // list of functions used in shader
+      fragColor: ''
+    }
+
+    var gen = generateGlsl(transforms, shaderParams)('st')
+    shaderParams.fragColor = gen
+    // remove uniforms with duplicate names
+    let uniforms = {}
+    shaderParams.uniforms.forEach((uniform) => uniforms[uniform.name] = uniform)
+    shaderParams.uniforms = Object.values(uniforms)
+    return shaderParams
+}
+
+
+// recursive function for generating shader string from object containing functions and user arguments. Order of functions in string depends on type of function
+// to do: improve variable names
+function generateGlsl (transforms, shaderParams) {
+  // transform function that outputs a shader string corresponding to gl_FragColor
+  var fragColor = () => ''
+  transforms.forEach((transform) => {
+    var inputs = formatArguments(transform, shaderParams.uniforms.length)
+    inputs.forEach((input) => {
+      if(input.isUniform) {
+      	shaderParams.uniforms.push(input)
+      }
+    })
+
+    // add new glsl function to running list of functions
+    if(!contains(transform, shaderParams.glslFunctions)) shaderParams.glslFunctions.push(transform)
+
+    // current function for generating frag color shader code
+    var f0 = fragColor
+    if (transform.transform.type === 'src') {
+      fragColor = (uv) => {
+        return `${shaderString(uv, transform.name, inputs, shaderParams)}`
+      }
+    } else if (transform.transform.type === 'coord') {
+      fragColor = (uv) => `${f0(`${shaderString(uv, transform.name, inputs, shaderParams)}`)}`
+    } else if (transform.transform.type === 'color') {
+      fragColor = (uv) =>  `${shaderString(`${f0(uv)}`, transform.name, inputs, shaderParams)}`
+    } else if (transform.transform.type === 'combine') {
+      // combining two generated shader strings (i.e. for blend, mult, add funtions)
+      var f1 = inputs[0].value && inputs[0].value.transforms ?
+      (uv) => `${generateGlsl(inputs[0].value.transforms, shaderParams)(uv)}` :
+      (inputs[0].isUniform ? () => inputs[0].name : () => inputs[0].value)
+      fragColor = (uv) => `${shaderString(`${f0(uv)}, ${f1(uv)}`, transform.name, inputs.slice(1), shaderParams)}`
+    } else if (transform.transform.type === 'combineCoord') {
+      // combining two generated shader strings (i.e. for modulate functions)
+      var f1 = inputs[0].value && inputs[0].value.transforms ?
+      (uv) => `${generateGlsl(inputs[0].value.transforms, shaderParams)(uv)}` :
+      (inputs[0].isUniform ? () => inputs[0].name : () => inputs[0].value)
+      fragColor = (uv) => `${f0(`${shaderString(`${uv}, ${f1(uv)}`, transform.name, inputs.slice(1), shaderParams)}`)}`
+    }
+  })
+  return fragColor
+}
+
+// assembles a shader string containing the arguments and the function name, i.e. 'osc(uv, frequency)'
+function shaderString (uv, method, inputs, shaderParams) {
+  const str = inputs.map((input) => {
+    if (input.isUniform) {
+      return input.name
+    } else if (input.isVaryingRef && isVaryingRef(input.value)) {
+      // Varying reference from v proxy (e.g., v.normal.z)
+      return getVaryingString(input.value, false)
+    } else if (input.value && input.value.transforms) {
+      // this by definition needs to be a generator, hence we start with 'st' as the initial value for generating the glsl fragment
+      const srcCode = `${generateGlsl(input.value.transforms, shaderParams)('st')}`
+      // Auto-coerce vec4 source to float if needed (extract .r channel)
+      if (input.type === 'float') {
+        // Check if chain produces vec4 - any src/color/combine transform means vec4 output
+        // (coord/combineCoord just transform UVs, don't change output type)
+        const hasColorOutput = input.value.transforms.some(t => {
+          const type = t.transform.type
+          return type === 'src' || type === 'color' || type === 'combine'
+        })
+        if (hasColorOutput) {
+          return `(${srcCode}).r`
+        }
+      }
+      return srcCode
+    }
+    return input.value
+  }).reduce((p, c) => `${p}, ${c}`, '')
+
+  return `${method}(${uv}${str})`
+}
+
+// merge two arrays and remove duplicates
+function mergeArrays (a, b) {
+  return a.concat(b.filter(function (item) {
+    return a.indexOf(item) < 0;
+  }))
+}
+
+// check whether array
+function contains(object, arr) {
+  for(var i = 0; i < arr.length; i++){
+    if(object.name == arr[i].name) return true
+  }
+  return false
+}

--- a/extensions/vertex/geometry.js
+++ b/extensions/vertex/geometry.js
@@ -1,0 +1,1533 @@
+// Geometry helper functions - return VertexSource for chainable transforms
+import VertexSource from './vertex-source.js'
+
+// Parse OBJ file text and return VertexSource
+// Supports vertices (v), normals (vn), UVs (vt), faces (f), and materials (usemtl)
+// Triangulates quads automatically, normalizes model to fit in a unit cube
+// Options:
+//   swapYZ: swap Y and Z axes (for Z-up exports like Blender). Default: false (Y-up, WebGL standard)
+export function parseObj(objText, options = {}) {
+  const { swapYZ = false } = options
+  const vertices = []
+  const colors = []  // Vertex colors (OBJ extension: v x y z r g b)
+  const normals = []
+  const uvs = []
+  const faces = []
+
+  // Material tracking for faceIds
+  const materialNames = []
+  const materialToId = new Map()
+  let currentMaterial = null
+
+  const lines = objText.split('\n')
+  for (const line of lines) {
+    const parts = line.trim().split(/\s+/)
+    if (parts[0] === 'v') {
+      const x = parseFloat(parts[1])
+      const y = parseFloat(parts[2])
+      const z = parseFloat(parts[3])
+      // Swap Y and Z if needed (converts Z-up to Y-up)
+      vertices.push(swapYZ ? [x, z, y] : [x, y, z])
+      // OBJ extension: vertex colors as r g b after coordinates
+      if (parts.length >= 7) {
+        colors.push([parseFloat(parts[4]), parseFloat(parts[5]), parseFloat(parts[6])])
+      }
+    } else if (parts[0] === 'vn') {
+      const x = parseFloat(parts[1])
+      const y = parseFloat(parts[2])
+      const z = parseFloat(parts[3])
+      normals.push(swapYZ ? [x, z, y] : [x, y, z])
+    } else if (parts[0] === 'vt') {
+      uvs.push([parseFloat(parts[1]), parseFloat(parts[2])])
+    } else if (parts[0] === 'usemtl') {
+      // Track material for faceId assignment
+      const matName = parts.slice(1).join(' ')
+      if (!materialToId.has(matName)) {
+        materialToId.set(matName, materialNames.length)
+        materialNames.push(matName)
+      }
+      currentMaterial = materialToId.get(matName)
+    } else if (parts[0] === 'f') {
+      // Parse face indices - format can be v, v/vt, v/vt/vn, or v//vn
+      const faceVerts = []
+      const faceUVs = []
+      const faceNormals = []
+      for (let i = 1; i < parts.length; i++) {
+        const indices = parts[i].split('/')
+        faceVerts.push(parseInt(indices[0]) - 1)
+        if (indices[1]) faceUVs.push(parseInt(indices[1]) - 1)
+        if (indices[2]) faceNormals.push(parseInt(indices[2]) - 1)
+      }
+      faces.push({ verts: faceVerts, uvs: faceUVs, normals: faceNormals, material: currentMaterial })
+    }
+  }
+
+  // Calculate bounding box
+  let minX = Infinity, maxX = -Infinity
+  let minY = Infinity, maxY = -Infinity
+  let minZ = Infinity, maxZ = -Infinity
+  for (const v of vertices) {
+    minX = Math.min(minX, v[0]); maxX = Math.max(maxX, v[0])
+    minY = Math.min(minY, v[1]); maxY = Math.max(maxY, v[1])
+    minZ = Math.min(minZ, v[2]); maxZ = Math.max(maxZ, v[2])
+  }
+
+  // Center and normalize to fit in unit cube
+  const centerX = (minX + maxX) / 2
+  const centerY = (minY + maxY) / 2
+  const centerZ = (minZ + maxZ) / 2
+  const rangeX = maxX - minX
+  const rangeY = maxY - minY
+  const rangeZ = maxZ - minZ
+  const maxRange = Math.max(rangeX, rangeY, rangeZ)
+  const scale = 1.0 / maxRange  // Fit largest dimension to 1.0
+
+  // Build triangle list from faces (triangulate quads and n-gons)
+  const verts = []
+  const outNormals = []
+  const outUVs = []
+  const outFaceIds = []
+  const outColors = []
+  const hasNormals = normals.length > 0
+  const hasExplicitUVs = uvs.length > 0
+  const hasMaterials = materialNames.length > 0
+  const hasColors = colors.length === vertices.length  // Must have color per vertex
+
+  // Default per-face UVs for quads (when OBJ doesn't have vt coordinates)
+  // Maps quad corners to (0,0), (1,0), (1,1), (0,1) so texture fills the face
+  const defaultQuadUVs = [[0, 0], [1, 0], [1, 1], [0, 1]]
+  // For triangles: (0,0), (1,0), (0.5,1)
+  const defaultTriUVs = [[0, 0], [1, 0], [0.5, 1]]
+
+  // Helper to add a vertex with its attributes
+  const addVertex = (vertIdx, uv, normalIdx, materialId) => {
+    const v = vertices[vertIdx]
+    verts.push((v[0] - centerX) * scale)
+    verts.push((v[1] - centerY) * scale)
+    verts.push((v[2] - centerZ) * scale)
+    if (hasNormals && normalIdx !== undefined) {
+      const n = normals[normalIdx]
+      outNormals.push(n[0], n[1], n[2])
+    }
+    // Always output UVs (explicit from file or generated per-face)
+    outUVs.push(uv[0], uv[1])
+    if (hasMaterials) {
+      outFaceIds.push(materialId !== null ? materialId : 0)
+    }
+    if (hasColors) {
+      const c = colors[vertIdx]
+      outColors.push(c[0], c[1], c[2], 1.0)  // RGB + alpha=1
+    }
+  }
+
+  for (const face of faces) {
+    const fv = face.verts
+    const fu = face.uvs
+    const fn = face.normals
+    const fm = face.material
+    if (fv.length === 3) {
+      // Triangle
+      for (let i = 0; i < 3; i++) {
+        const uv = hasExplicitUVs && fu[i] !== undefined ? uvs[fu[i]] : defaultTriUVs[i]
+        addVertex(fv[i], uv, fn[i], fm)
+      }
+    } else if (fv.length >= 4) {
+      // Fan triangulation for quads and n-gons
+      for (let i = 1; i < fv.length - 1; i++) {
+        // For quads, use default UVs if no explicit UVs
+        const uv0 = hasExplicitUVs && fu[0] !== undefined ? uvs[fu[0]] : defaultQuadUVs[0]
+        const uv1 = hasExplicitUVs && fu[i] !== undefined ? uvs[fu[i]] : defaultQuadUVs[i]
+        const uv2 = hasExplicitUVs && fu[i + 1] !== undefined ? uvs[fu[i + 1]] : defaultQuadUVs[i + 1]
+        addVertex(fv[0], uv0, fn[0], fm)
+        addVertex(fv[i], uv1, fn[i], fm)
+        addVertex(fv[i + 1], uv2, fn[i + 1], fm)
+      }
+    }
+  }
+
+  const vs = new VertexSource(verts)
+  vs.is3D = true
+  if (outNormals.length > 0) vs.normals = outNormals
+  if (outUVs.length > 0) vs.uvs = outUVs
+  if (outFaceIds.length > 0) {
+    vs.faceIds = outFaceIds
+    vs.materialNames = materialNames  // Expose material names for debugging/tooling
+  }
+  if (outColors.length > 0) vs.colors = outColors
+  return vs
+}
+
+// Load OBJ file from URL and return Promise<VertexSource>
+// Options:
+//   swapYZ: swap Y and Z axes (for Z-up exports like Blender). Default: false (Y-up, WebGL standard)
+export async function loadObj(url, options = {}) {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to load OBJ from ${url}: ${response.status} ${response.statusText}`)
+  }
+  const text = await response.text()
+  return parseObj(text, options)
+}
+
+// ============================================================================
+// GLB/glTF Loader
+// ============================================================================
+
+// Parse GLB binary file and return VertexSource
+// GLB format: 12-byte header + JSON chunk + BIN chunk
+// Options:
+//   meshIndex: which mesh to load (default 0)
+//   primitiveIndex: which primitive to load (default: all primitives combined)
+export function parseGlb(arrayBuffer, options = {}) {
+  const { meshIndex = 0, primitiveIndex } = options  // primitiveIndex undefined = load all
+  const view = new DataView(arrayBuffer)
+
+  // Parse GLB header (12 bytes)
+  const magic = view.getUint32(0, true)
+  if (magic !== 0x46546C67) { // "glTF" in little-endian
+    throw new Error('Invalid GLB file: bad magic number')
+  }
+  const version = view.getUint32(4, true)
+  if (version !== 2) {
+    throw new Error(`Unsupported glTF version: ${version}`)
+  }
+  // const length = view.getUint32(8, true)
+
+  // Parse chunks
+  let jsonChunk = null
+  let binChunk = null
+  let offset = 12
+
+  while (offset < arrayBuffer.byteLength) {
+    const chunkLength = view.getUint32(offset, true)
+    const chunkType = view.getUint32(offset + 4, true)
+    const chunkData = new Uint8Array(arrayBuffer, offset + 8, chunkLength)
+
+    if (chunkType === 0x4E4F534A) { // JSON
+      const decoder = new TextDecoder('utf-8')
+      jsonChunk = JSON.parse(decoder.decode(chunkData))
+    } else if (chunkType === 0x004E4942) { // BIN
+      binChunk = chunkData.buffer.slice(chunkData.byteOffset, chunkData.byteOffset + chunkData.byteLength)
+    }
+
+    offset += 8 + chunkLength
+    // Align to 4-byte boundary
+    if (offset % 4 !== 0) offset += 4 - (offset % 4)
+  }
+
+  if (!jsonChunk) throw new Error('GLB missing JSON chunk')
+
+  return extractMeshFromGltf(jsonChunk, binChunk, meshIndex, primitiveIndex)
+}
+
+// Extract mesh data from glTF JSON and binary buffer
+// Combines all primitives in the mesh into a single VertexSource
+function extractMeshFromGltf(gltf, binBuffer, meshIndex, primitiveIndex) {
+  const mesh = gltf.meshes?.[meshIndex]
+  if (!mesh) throw new Error(`Mesh ${meshIndex} not found`)
+
+  // Helper to read accessor data
+  const readAccessor = (accessorIndex) => {
+    const accessor = gltf.accessors[accessorIndex]
+    const bufferView = gltf.bufferViews[accessor.bufferView]
+    const componentType = accessor.componentType
+    const count = accessor.count
+    const type = accessor.type
+
+    // Component counts for each type
+    const typeComponents = { SCALAR: 1, VEC2: 2, VEC3: 3, VEC4: 4, MAT4: 16 }
+    const components = typeComponents[type] || 1
+
+    // Get the right typed array constructor
+    const TypedArray = {
+      5120: Int8Array,    // BYTE
+      5121: Uint8Array,   // UNSIGNED_BYTE
+      5122: Int16Array,   // SHORT
+      5123: Uint16Array,  // UNSIGNED_SHORT
+      5125: Uint32Array,  // UNSIGNED_INT
+      5126: Float32Array  // FLOAT
+    }[componentType]
+
+    if (!TypedArray) throw new Error(`Unsupported component type: ${componentType}`)
+
+    const byteOffset = (bufferView.byteOffset || 0) + (accessor.byteOffset || 0)
+    const byteStride = bufferView.byteStride || 0
+
+    // If tightly packed, read directly
+    if (byteStride === 0 || byteStride === components * TypedArray.BYTES_PER_ELEMENT) {
+      return new TypedArray(binBuffer, byteOffset, count * components)
+    }
+
+    // Otherwise, handle stride
+    const result = new TypedArray(count * components)
+    const srcView = new DataView(binBuffer)
+    for (let i = 0; i < count; i++) {
+      const srcOffset = byteOffset + i * byteStride
+      for (let j = 0; j < components; j++) {
+        if (TypedArray === Float32Array) {
+          result[i * components + j] = srcView.getFloat32(srcOffset + j * 4, true)
+        } else if (TypedArray === Uint16Array) {
+          result[i * components + j] = srcView.getUint16(srcOffset + j * 2, true)
+        } else if (TypedArray === Uint32Array) {
+          result[i * components + j] = srcView.getUint32(srcOffset + j * 4, true)
+        }
+      }
+    }
+    return result
+  }
+
+  // Determine which primitives to load
+  const primitives = primitiveIndex !== undefined
+    ? [mesh.primitives[primitiveIndex]]
+    : mesh.primitives  // Load all primitives if no specific index given
+
+  if (!primitives || primitives.length === 0) {
+    throw new Error(`No primitives found in mesh ${meshIndex}`)
+  }
+
+  // Accumulate vertices from all primitives
+  const verts = []
+  const outNormals = []
+  const outUVs = []
+  const outTangents = []
+  const outColors = []
+  const outJoints = []
+  const outWeights = []
+  let hasAnyUVs = false
+  let hasAnyNormals = false
+  let hasAnyTangents = false
+  let hasAnyColors = false
+  let hasAnySkinning = false
+
+  for (const primitive of primitives) {
+    const positionAccessor = primitive.attributes.POSITION
+    if (positionAccessor === undefined) continue  // Skip primitives without positions
+
+    const positions = readAccessor(positionAccessor)
+    const normals = primitive.attributes.NORMAL !== undefined
+      ? readAccessor(primitive.attributes.NORMAL) : null
+    const uvs = primitive.attributes.TEXCOORD_0 !== undefined
+      ? readAccessor(primitive.attributes.TEXCOORD_0) : null
+    // TANGENT is vec4: xyz = tangent direction, w = handedness for bitangent
+    const tangents = primitive.attributes.TANGENT !== undefined
+      ? readAccessor(primitive.attributes.TANGENT) : null
+    // COLOR_0 can be vec3 (RGB) or vec4 (RGBA), we'll normalize to vec4
+    const colors = primitive.attributes.COLOR_0 !== undefined
+      ? readAccessor(primitive.attributes.COLOR_0) : null
+    // Determine if colors are vec3 or vec4
+    let colorStride = 0
+    if (colors && primitive.attributes.COLOR_0 !== undefined) {
+      const colorAccessor = gltf.accessors[primitive.attributes.COLOR_0]
+      colorStride = colorAccessor.type === 'VEC4' ? 4 : 3
+    }
+
+    // Skinning data for animation
+    const joints = primitive.attributes.JOINTS_0 !== undefined
+      ? readAccessor(primitive.attributes.JOINTS_0) : null
+    const weights = primitive.attributes.WEIGHTS_0 !== undefined
+      ? readAccessor(primitive.attributes.WEIGHTS_0) : null
+
+    if (normals) hasAnyNormals = true
+    if (uvs) hasAnyUVs = true
+    if (tangents) hasAnyTangents = true
+    if (colors) hasAnyColors = true
+    if (joints && weights) hasAnySkinning = true
+
+    // Read indices if present
+    const indices = primitive.indices !== undefined
+      ? readAccessor(primitive.indices) : null
+
+    const addVertex = (idx) => {
+      verts.push(positions[idx * 3], positions[idx * 3 + 1], positions[idx * 3 + 2])
+      if (normals) {
+        outNormals.push(normals[idx * 3], normals[idx * 3 + 1], normals[idx * 3 + 2])
+      }
+      if (uvs) {
+        outUVs.push(uvs[idx * 2], uvs[idx * 2 + 1])
+      }
+      if (tangents) {
+        // vec4: xyz = tangent, w = handedness
+        outTangents.push(tangents[idx * 4], tangents[idx * 4 + 1], tangents[idx * 4 + 2], tangents[idx * 4 + 3])
+      }
+      if (colors) {
+        // Normalize to vec4 (RGBA), default alpha = 1.0
+        if (colorStride === 4) {
+          outColors.push(colors[idx * 4], colors[idx * 4 + 1], colors[idx * 4 + 2], colors[idx * 4 + 3])
+        } else {
+          outColors.push(colors[idx * 3], colors[idx * 3 + 1], colors[idx * 3 + 2], 1.0)
+        }
+      }
+      if (joints && weights) {
+        // 4 joint indices and 4 weights per vertex
+        outJoints.push(joints[idx * 4], joints[idx * 4 + 1], joints[idx * 4 + 2], joints[idx * 4 + 3])
+        outWeights.push(weights[idx * 4], weights[idx * 4 + 1], weights[idx * 4 + 2], weights[idx * 4 + 3])
+      }
+    }
+
+    if (indices) {
+      for (let i = 0; i < indices.length; i++) {
+        addVertex(indices[i])
+      }
+    } else {
+      const vertexCount = positions.length / 3
+      for (let i = 0; i < vertexCount; i++) {
+        addVertex(i)
+      }
+    }
+  }
+
+  if (verts.length === 0) {
+    throw new Error('No vertex data found in mesh')
+  }
+
+  // Compute bounding box and normalize (but NOT for skinned meshes - skeleton defines scale)
+  let minX = Infinity, maxX = -Infinity
+  let minY = Infinity, maxY = -Infinity
+  let minZ = Infinity, maxZ = -Infinity
+
+  for (let i = 0; i < verts.length; i += 3) {
+    minX = Math.min(minX, verts[i]); maxX = Math.max(maxX, verts[i])
+    minY = Math.min(minY, verts[i + 1]); maxY = Math.max(maxY, verts[i + 1])
+    minZ = Math.min(minZ, verts[i + 2]); maxZ = Math.max(maxZ, verts[i + 2])
+  }
+
+  const centerX = (minX + maxX) / 2
+  const centerY = (minY + maxY) / 2
+  const centerZ = (minZ + maxZ) / 2
+  const rangeX = maxX - minX
+  const rangeY = maxY - minY
+  const rangeZ = maxZ - minZ
+  const maxRange = Math.max(rangeX, rangeY, rangeZ)
+  const scale = maxRange > 0 ? 1.0 / maxRange : 1.0
+
+  // Always normalize vertices
+  for (let i = 0; i < verts.length; i += 3) {
+    verts[i] = (verts[i] - centerX) * scale
+    verts[i + 1] = (verts[i + 1] - centerY) * scale
+    verts[i + 2] = (verts[i + 2] - centerZ) * scale
+  }
+
+  // Generate default UVs if model has none (spherical projection)
+  if (!hasAnyUVs) {
+    for (let i = 0; i < verts.length; i += 3) {
+      const x = verts[i], y = verts[i + 1], z = verts[i + 2]
+      // Spherical UV mapping
+      const u = 0.5 + Math.atan2(z, x) / (2 * Math.PI)
+      const v = 0.5 + Math.asin(Math.max(-1, Math.min(1, y))) / Math.PI
+      outUVs.push(u, v)
+    }
+  }
+
+  // Create VertexSource
+  const vs = new VertexSource(verts)
+  vs.is3D = true
+  if (outNormals.length > 0) vs.normals = outNormals
+  if (outUVs.length > 0) vs.uvs = outUVs
+  if (outTangents.length > 0) vs.tangents = outTangents
+  if (outColors.length > 0) vs.colors = outColors
+  if (hasAnySkinning) {
+    vs.joints = outJoints
+    vs.weights = outWeights
+  }
+
+  // Store reference to gltf data for animation extraction
+  vs._gltf = gltf
+  vs._binBuffer = binBuffer
+
+  // Store normalization params for skinning (need to denormalize before skinning, renormalize after)
+  if (hasAnySkinning) {
+    vs._normCenter = [centerX, centerY, centerZ]
+    vs._normScale = scale
+  }
+
+  return vs
+}
+
+// Load GLB file from URL and return Promise<VertexSource>
+// The returned VertexSource has a .texture property (Image) if the GLB has embedded textures
+// Options:
+//   meshIndex: which mesh to load (default 0)
+//   primitiveIndex: which primitive to load (default: all primitives combined)
+//   extractTextures: extract embedded textures (default: true)
+export async function loadGlb(url, options = {}) {
+  const { extractTextures = true, ...parseOptions } = options
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to load GLB from ${url}: ${response.status} ${response.statusText}`)
+  }
+  const arrayBuffer = await response.arrayBuffer()
+  if (arrayBuffer.byteLength < 12) {
+    throw new Error(`Invalid GLB file from ${url}: file too small (${arrayBuffer.byteLength} bytes)`)
+  }
+  const model = parseGlb(arrayBuffer, parseOptions)
+
+  // Attach embedded texture to model if available
+  if (extractTextures) {
+    const textures = await extractGlbTextures(arrayBuffer)
+    model.texture = textures[0]?.image || null
+    model.textures = textures.map(t => t.image)  // all textures if multiple
+  }
+
+  return model
+}
+
+// Extract embedded images from GLB as Image objects
+// Returns array of { image: HTMLImageElement, index: number }
+export async function extractGlbTextures(arrayBuffer) {
+  const view = new DataView(arrayBuffer)
+
+  // Parse header
+  const magic = view.getUint32(0, true)
+  if (magic !== 0x46546C67) throw new Error('Invalid GLB')
+
+  // Find JSON and BIN chunks
+  let jsonChunk = null
+  let binStart = 0
+  let offset = 12
+
+  while (offset < arrayBuffer.byteLength) {
+    const chunkLength = view.getUint32(offset, true)
+    const chunkType = view.getUint32(offset + 4, true)
+
+    if (chunkType === 0x4E4F534A) { // JSON
+      const chunkData = new Uint8Array(arrayBuffer, offset + 8, chunkLength)
+      jsonChunk = JSON.parse(new TextDecoder().decode(chunkData))
+    } else if (chunkType === 0x004E4942) { // BIN
+      binStart = offset + 8
+    }
+
+    offset += 8 + chunkLength
+    if (offset % 4 !== 0) offset += 4 - (offset % 4)
+  }
+
+  if (!jsonChunk || !jsonChunk.images) return []
+
+  // Extract each image
+  const textures = []
+  for (let i = 0; i < jsonChunk.images.length; i++) {
+    const imgDef = jsonChunk.images[i]
+    if (imgDef.bufferView === undefined) continue
+
+    const bv = jsonChunk.bufferViews[imgDef.bufferView]
+    const imgBytes = new Uint8Array(arrayBuffer, binStart + (bv.byteOffset || 0), bv.byteLength)
+
+    // Detect mime type from magic bytes if not specified
+    let mimeType = imgDef.mimeType
+    if (!mimeType) {
+      if (imgBytes[0] === 0x89 && imgBytes[1] === 0x50) mimeType = 'image/png'
+      else if (imgBytes[0] === 0xFF && imgBytes[1] === 0xD8) mimeType = 'image/jpeg'
+      else mimeType = 'image/png'
+    }
+
+    // Create blob URL and load as Image
+    const blob = new Blob([imgBytes], { type: mimeType })
+    const url = URL.createObjectURL(blob)
+
+    const img = await new Promise((resolve, reject) => {
+      const image = new Image()
+      image.onload = () => resolve(image)
+      image.onerror = reject
+      image.src = url
+    })
+
+    textures.push({ image: img, index: i, blobUrl: url })
+  }
+
+  return textures
+}
+
+// Create a sprite sheet canvas from multiple GLB files
+// Returns { canvas, models, cols, rows }
+export async function createGlbSpriteSheet(urls, options = {}) {
+  const { cellSize = 256 } = options
+
+  // Load all GLBs and extract textures
+  const results = await Promise.all(urls.map(async (url) => {
+    const response = await fetch(url)
+    const arrayBuffer = await response.arrayBuffer()
+    const model = parseGlb(arrayBuffer, options)
+    const textures = await extractGlbTextures(arrayBuffer)
+    return { model, texture: textures[0]?.image || null }
+  }))
+
+  // Calculate grid size
+  const count = results.length
+  const cols = Math.ceil(Math.sqrt(count))
+  const rows = Math.ceil(count / cols)
+
+  // Create canvas
+  const canvas = document.createElement('canvas')
+  canvas.width = cols * cellSize
+  canvas.height = rows * cellSize
+  const ctx = canvas.getContext('2d')
+
+  // Draw textures into grid
+  results.forEach((r, i) => {
+    if (r.texture) {
+      const col = i % cols
+      const row = Math.floor(i / cols)
+      ctx.drawImage(r.texture, col * cellSize, row * cellSize, cellSize, cellSize)
+    }
+  })
+
+  // Assign faceIds to models for sprite picking
+  const models = results.map((r, i) => {
+    r.model.spriteIndex = i
+    return r.model
+  })
+
+  return { canvas, models, cols, rows, cellSize }
+}
+
+// ============================================================================
+// Animation Support
+// ============================================================================
+
+// Extract skeleton data from glTF
+// Returns { joints: [...], inverseBindMatrices: [...] }
+function extractSkeleton(gltf, binBuffer, skinIndex = 0) {
+  if (!gltf.skins || !gltf.skins[skinIndex]) return null
+
+  const skin = gltf.skins[skinIndex]
+  const joints = skin.joints  // Array of node indices
+
+  // Read inverse bind matrices
+  let inverseBindMatrices = null
+  if (skin.inverseBindMatrices !== undefined) {
+    const accessor = gltf.accessors[skin.inverseBindMatrices]
+    const bufferView = gltf.bufferViews[accessor.bufferView]
+    const byteOffset = (bufferView.byteOffset || 0) + (accessor.byteOffset || 0)
+
+    // Create a properly aligned copy of the data
+    const byteLength = accessor.count * 16 * 4  // 16 floats * 4 bytes
+    const slice = binBuffer.slice(byteOffset, byteOffset + byteLength)
+    inverseBindMatrices = new Float32Array(slice)
+  }
+
+  // Build joint info with hierarchy
+  const jointData = joints.map((nodeIndex, i) => {
+    const node = gltf.nodes[nodeIndex]
+    return {
+      index: i,
+      nodeIndex: nodeIndex,
+      name: node.name || `joint_${i}`,
+      children: node.children || [],
+      // Local transform (TRS)
+      translation: node.translation || [0, 0, 0],
+      rotation: node.rotation || [0, 0, 0, 1],  // quaternion
+      scale: node.scale || [1, 1, 1],
+      // Inverse bind matrix (16 floats)
+      inverseBindMatrix: inverseBindMatrices
+        ? Array.from(inverseBindMatrices.slice(i * 16, i * 16 + 16))
+        : identityMatrix()
+    }
+  })
+
+  return {
+    joints: jointData,
+    jointCount: joints.length,
+    jointNodeIndices: joints
+  }
+}
+
+// Extract animation clips from glTF
+// Returns array of { name, duration, channels: [...] }
+function extractAnimations(gltf, binBuffer) {
+  if (!gltf.animations) return []
+
+  const readAccessor = (accessorIndex) => {
+    const accessor = gltf.accessors[accessorIndex]
+    const bufferView = gltf.bufferViews[accessor.bufferView]
+    const byteOffset = (bufferView.byteOffset || 0) + (accessor.byteOffset || 0)
+    return new Float32Array(binBuffer, byteOffset, accessor.count * (
+      accessor.type === 'SCALAR' ? 1 :
+      accessor.type === 'VEC3' ? 3 :
+      accessor.type === 'VEC4' ? 4 : 1
+    ))
+  }
+
+  return gltf.animations.map((anim, animIndex) => {
+    const channels = anim.channels.map(channel => {
+      const sampler = anim.samplers[channel.sampler]
+      const times = readAccessor(sampler.input)
+      const values = readAccessor(sampler.output)
+
+      return {
+        targetNode: channel.target.node,
+        targetPath: channel.target.path,  // 'translation', 'rotation', 'scale'
+        interpolation: sampler.interpolation || 'LINEAR',
+        times: Array.from(times),
+        values: Array.from(values)
+      }
+    })
+
+    // Calculate duration from max time
+    const duration = channels.reduce((max, ch) =>
+      Math.max(max, ch.times[ch.times.length - 1] || 0), 0)
+
+    return {
+      name: anim.name || `animation_${animIndex}`,
+      duration,
+      channels
+    }
+  })
+}
+
+// Matrix math helpers
+function identityMatrix() {
+  return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+}
+
+// Invert a 4x4 matrix (column-major)
+function invertMatrix(m) {
+  const inv = new Array(16)
+  inv[0] = m[5]*m[10]*m[15] - m[5]*m[11]*m[14] - m[9]*m[6]*m[15] + m[9]*m[7]*m[14] + m[13]*m[6]*m[11] - m[13]*m[7]*m[10]
+  inv[4] = -m[4]*m[10]*m[15] + m[4]*m[11]*m[14] + m[8]*m[6]*m[15] - m[8]*m[7]*m[14] - m[12]*m[6]*m[11] + m[12]*m[7]*m[10]
+  inv[8] = m[4]*m[9]*m[15] - m[4]*m[11]*m[13] - m[8]*m[5]*m[15] + m[8]*m[7]*m[13] + m[12]*m[5]*m[11] - m[12]*m[7]*m[9]
+  inv[12] = -m[4]*m[9]*m[14] + m[4]*m[10]*m[13] + m[8]*m[5]*m[14] - m[8]*m[6]*m[13] - m[12]*m[5]*m[10] + m[12]*m[6]*m[9]
+  inv[1] = -m[1]*m[10]*m[15] + m[1]*m[11]*m[14] + m[9]*m[2]*m[15] - m[9]*m[3]*m[14] - m[13]*m[2]*m[11] + m[13]*m[3]*m[10]
+  inv[5] = m[0]*m[10]*m[15] - m[0]*m[11]*m[14] - m[8]*m[2]*m[15] + m[8]*m[3]*m[14] + m[12]*m[2]*m[11] - m[12]*m[3]*m[10]
+  inv[9] = -m[0]*m[9]*m[15] + m[0]*m[11]*m[13] + m[8]*m[1]*m[15] - m[8]*m[3]*m[13] - m[12]*m[1]*m[11] + m[12]*m[3]*m[9]
+  inv[13] = m[0]*m[9]*m[14] - m[0]*m[10]*m[13] - m[8]*m[1]*m[14] + m[8]*m[2]*m[13] + m[12]*m[1]*m[10] - m[12]*m[2]*m[9]
+  inv[2] = m[1]*m[6]*m[15] - m[1]*m[7]*m[14] - m[5]*m[2]*m[15] + m[5]*m[3]*m[14] + m[13]*m[2]*m[7] - m[13]*m[3]*m[6]
+  inv[6] = -m[0]*m[6]*m[15] + m[0]*m[7]*m[14] + m[4]*m[2]*m[15] - m[4]*m[3]*m[14] - m[12]*m[2]*m[7] + m[12]*m[3]*m[6]
+  inv[10] = m[0]*m[5]*m[15] - m[0]*m[7]*m[13] - m[4]*m[1]*m[15] + m[4]*m[3]*m[13] + m[12]*m[1]*m[7] - m[12]*m[3]*m[5]
+  inv[14] = -m[0]*m[5]*m[14] + m[0]*m[6]*m[13] + m[4]*m[1]*m[14] - m[4]*m[2]*m[13] - m[12]*m[1]*m[6] + m[12]*m[2]*m[5]
+  inv[3] = -m[1]*m[6]*m[11] + m[1]*m[7]*m[10] + m[5]*m[2]*m[11] - m[5]*m[3]*m[10] - m[9]*m[2]*m[7] + m[9]*m[3]*m[6]
+  inv[7] = m[0]*m[6]*m[11] - m[0]*m[7]*m[10] - m[4]*m[2]*m[11] + m[4]*m[3]*m[10] + m[8]*m[2]*m[7] - m[8]*m[3]*m[6]
+  inv[11] = -m[0]*m[5]*m[11] + m[0]*m[7]*m[9] + m[4]*m[1]*m[11] - m[4]*m[3]*m[9] - m[8]*m[1]*m[7] + m[8]*m[3]*m[5]
+  inv[15] = m[0]*m[5]*m[10] - m[0]*m[6]*m[9] - m[4]*m[1]*m[10] + m[4]*m[2]*m[9] + m[8]*m[1]*m[6] - m[8]*m[2]*m[5]
+  const det = m[0]*inv[0] + m[1]*inv[4] + m[2]*inv[8] + m[3]*inv[12]
+  if (Math.abs(det) < 1e-10) return identityMatrix()
+  const invDet = 1.0 / det
+  return inv.map(v => v * invDet)
+}
+
+function multiplyMatrices(a, b) {
+  // Column-major matrix multiplication (glTF standard)
+  // C[col][row] = sum of A[k][row] * B[col][k]
+  const result = new Array(16)
+  for (let col = 0; col < 4; col++) {
+    for (let row = 0; row < 4; row++) {
+      result[col * 4 + row] =
+        a[0 * 4 + row] * b[col * 4 + 0] +
+        a[1 * 4 + row] * b[col * 4 + 1] +
+        a[2 * 4 + row] * b[col * 4 + 2] +
+        a[3 * 4 + row] * b[col * 4 + 3]
+    }
+  }
+  return result
+}
+
+function trsToMatrix(t, r, s) {
+  // Convert translation, rotation (quaternion), scale to 4x4 matrix (column-major)
+  const [tx, ty, tz] = t
+  const [qx, qy, qz, qw] = r
+  const [sx, sy, sz] = s
+
+  // Rotation matrix from quaternion - column major layout
+  const xx = qx * qx, yy = qy * qy, zz = qz * qz
+  const xy = qx * qy, xz = qx * qz, yz = qy * qz
+  const wx = qw * qx, wy = qw * qy, wz = qw * qz
+
+  // Column 0
+  const m0 = (1 - 2 * (yy + zz)) * sx
+  const m1 = 2 * (xy + wz) * sx
+  const m2 = 2 * (xz - wy) * sx
+
+  // Column 1
+  const m4 = 2 * (xy - wz) * sy
+  const m5 = (1 - 2 * (xx + zz)) * sy
+  const m6 = 2 * (yz + wx) * sy
+
+  // Column 2
+  const m8 = 2 * (xz + wy) * sz
+  const m9 = 2 * (yz - wx) * sz
+  const m10 = (1 - 2 * (xx + yy)) * sz
+
+  // Return in column-major order: col0, col1, col2, col3
+  return [
+    m0, m1, m2, 0,      // column 0
+    m4, m5, m6, 0,      // column 1
+    m8, m9, m10, 0,     // column 2
+    tx, ty, tz, 1       // column 3 (translation)
+  ]
+}
+
+function transformPoint(m, p) {
+  const x = p[0], y = p[1], z = p[2]
+  return [
+    m[0] * x + m[4] * y + m[8] * z + m[12],
+    m[1] * x + m[5] * y + m[9] * z + m[13],
+    m[2] * x + m[6] * y + m[10] * z + m[14]
+  ]
+}
+
+function transformNormal(m, n) {
+  // Transform normal (ignore translation, use inverse transpose for proper normals)
+  // For uniform scale, we can just use the rotation part
+  const x = n[0], y = n[1], z = n[2]
+  const nx = m[0] * x + m[4] * y + m[8] * z
+  const ny = m[1] * x + m[5] * y + m[9] * z
+  const nz = m[2] * x + m[6] * y + m[10] * z
+  const len = Math.sqrt(nx * nx + ny * ny + nz * nz)
+  return len > 0 ? [nx / len, ny / len, nz / len] : [0, 1, 0]
+}
+
+// Interpolate between keyframes
+function sampleAnimation(channel, time) {
+  const { times, values, targetPath, interpolation } = channel
+  const componentCount = targetPath === 'rotation' ? 4 : 3
+
+  // Clamp time to animation range
+  if (time <= times[0]) {
+    return values.slice(0, componentCount)
+  }
+  if (time >= times[times.length - 1]) {
+    const start = (times.length - 1) * componentCount
+    return values.slice(start, start + componentCount)
+  }
+
+  // Find surrounding keyframes
+  let i = 0
+  while (i < times.length - 1 && times[i + 1] < time) i++
+
+  const t0 = times[i], t1 = times[i + 1]
+  const alpha = (time - t0) / (t1 - t0)
+
+  const v0Start = i * componentCount
+  const v1Start = (i + 1) * componentCount
+
+  if (interpolation === 'STEP') {
+    return values.slice(v0Start, v0Start + componentCount)
+  }
+
+  // LINEAR interpolation
+  if (targetPath === 'rotation') {
+    // Spherical linear interpolation for quaternions
+    return slerpQuat(
+      values.slice(v0Start, v0Start + 4),
+      values.slice(v1Start, v1Start + 4),
+      alpha
+    )
+  } else {
+    // Linear interpolation for translation/scale
+    const result = []
+    for (let j = 0; j < componentCount; j++) {
+      result.push(values[v0Start + j] * (1 - alpha) + values[v1Start + j] * alpha)
+    }
+    return result
+  }
+}
+
+// Quaternion spherical interpolation
+function slerpQuat(q1, q2, t) {
+  let dot = q1[0] * q2[0] + q1[1] * q2[1] + q1[2] * q2[2] + q1[3] * q2[3]
+
+  // Handle negative dot (take shorter path)
+  if (dot < 0) {
+    q2 = [-q2[0], -q2[1], -q2[2], -q2[3]]
+    dot = -dot
+  }
+
+  if (dot > 0.9995) {
+    // Linear interpolation for very close quaternions
+    const result = [
+      q1[0] + t * (q2[0] - q1[0]),
+      q1[1] + t * (q2[1] - q1[1]),
+      q1[2] + t * (q2[2] - q1[2]),
+      q1[3] + t * (q2[3] - q1[3])
+    ]
+    const len = Math.sqrt(result[0] ** 2 + result[1] ** 2 + result[2] ** 2 + result[3] ** 2)
+    return result.map(v => v / len)
+  }
+
+  const theta0 = Math.acos(dot)
+  const theta = theta0 * t
+  const sinTheta = Math.sin(theta)
+  const sinTheta0 = Math.sin(theta0)
+
+  const s0 = Math.cos(theta) - dot * sinTheta / sinTheta0
+  const s1 = sinTheta / sinTheta0
+
+  return [
+    s0 * q1[0] + s1 * q2[0],
+    s0 * q1[1] + s1 * q2[1],
+    s0 * q1[2] + s1 * q2[2],
+    s0 * q1[3] + s1 * q2[3]
+  ]
+}
+
+// Compute skinning matrices for all joints at a given time
+// normCenter/normScale: if provided, pre-transform matrices to work in normalized coordinate space
+function computeSkinningMatrices(skeleton, animations, clipName, time, gltf, normCenter = null, normScale = 1) {
+  if (!skeleton) return null
+
+  const clip = animations.find(a => a.name === clipName) || animations[0]
+  if (!clip) return null
+
+  // Build node-to-joint mapping
+  const nodeToJoint = new Map()
+  skeleton.joints.forEach((joint, i) => {
+    nodeToJoint.set(joint.nodeIndex, i)
+  })
+
+  // For each joint, sample the animation to get current local transform
+  // Animation values REPLACE the node's default TRS (they're absolute, not deltas)
+  const localTransforms = skeleton.joints.map((joint, jointIdx) => {
+    // Start with node's default TRS
+    let t = [...joint.translation]
+    let r = [...joint.rotation]
+    let s = [...joint.scale]
+
+    // Apply animation channels - these REPLACE the base values
+    let animated = false
+    for (const channel of clip.channels) {
+      if (channel.targetNode === joint.nodeIndex) {
+        animated = true
+        const sampled = sampleAnimation(channel, time)
+        if (channel.targetPath === 'translation') t = sampled
+        else if (channel.targetPath === 'rotation') r = sampled
+        else if (channel.targetPath === 'scale') s = sampled
+      }
+    }
+
+    return trsToMatrix(t, r, s)
+  })
+
+  // Compute world transforms by traversing hierarchy
+  const worldTransforms = new Array(skeleton.joints.length)
+
+  // Build parent map from gltf nodes
+  const parentMap = new Map()
+  gltf.nodes.forEach((node, nodeIdx) => {
+    if (node.children) {
+      node.children.forEach(childIdx => parentMap.set(childIdx, nodeIdx))
+    }
+  })
+
+  // Compute world transform for each joint
+  const computeWorld = (jointIndex) => {
+    if (worldTransforms[jointIndex]) return worldTransforms[jointIndex]
+
+    const joint = skeleton.joints[jointIndex]
+    const parentNodeIndex = parentMap.get(joint.nodeIndex)
+
+    if (parentNodeIndex !== undefined && nodeToJoint.has(parentNodeIndex)) {
+      const parentJointIndex = nodeToJoint.get(parentNodeIndex)
+      const parentWorld = computeWorld(parentJointIndex)
+      worldTransforms[jointIndex] = multiplyMatrices(parentWorld, localTransforms[jointIndex])
+    } else {
+      worldTransforms[jointIndex] = localTransforms[jointIndex]
+    }
+
+    return worldTransforms[jointIndex]
+  }
+
+  // Standard glTF skinning: jointMatrix = globalTransform * inverseBindMatrix
+  const rawMatrices = skeleton.joints.map((joint, i) => {
+    const globalTransform = computeWorld(i)
+    return multiplyMatrices(globalTransform, joint.inverseBindMatrix)
+  })
+
+  // If normCenter provided, pre-transform matrices to work in normalized coordinate space
+  // Transform: N * jointMatrix * N^-1  where N = translate(-center) then scale(scale)
+  if (normCenter) {
+    const [cx, cy, cz] = normCenter
+    const s = normScale
+    const invS = 1 / s
+
+    // N = translate(-center) then scale = scale * translate(-center)
+    // N^-1 = translate(center) then scale(1/s) = scale(1/s) * translate(center)
+    // For column-major 4x4: result = N * M * N^-1
+    return rawMatrices.map(M => {
+      // Step 1: M' = M * N^-1 = M * (scale(1/s) * translate(center))
+      // This is: first translate by center, then scale by 1/s, then apply M
+      // Step 2: result = N * M' = (scale(s) * translate(-center)) * M'
+
+      // Compute M * N^-1 directly:
+      // N^-1 translates by center then scales by 1/s
+      // Column-major: N^-1[12..14] = [cx, cy, cz], and scale diagonal by 1/s
+      const MN = [
+        M[0] * invS, M[1] * invS, M[2] * invS, M[3],
+        M[4] * invS, M[5] * invS, M[6] * invS, M[7],
+        M[8] * invS, M[9] * invS, M[10] * invS, M[11],
+        M[0] * cx + M[4] * cy + M[8] * cz + M[12],
+        M[1] * cx + M[5] * cy + M[9] * cz + M[13],
+        M[2] * cx + M[6] * cy + M[10] * cz + M[14],
+        M[3] * cx + M[7] * cy + M[11] * cz + M[15]
+      ]
+
+      // Now compute N * MN where N = scale(s) * translate(-center)
+      // N scales by s then translates by -center
+      // Result[i] = s * MN[i] for position columns, translation adjusts
+      return [
+        s * MN[0], s * MN[1], s * MN[2], MN[3],
+        s * MN[4], s * MN[5], s * MN[6], MN[7],
+        s * MN[8], s * MN[9], s * MN[10], MN[11],
+        s * MN[12] - cx * s, s * MN[13] - cy * s, s * MN[14] - cz * s, MN[15]
+      ]
+    })
+  }
+
+  return rawMatrices
+}
+
+// Export animation helpers for use by VertexSource
+export { extractSkeleton as extractSkeletonFromGltf }
+export { extractAnimations as extractAnimationsFromGltf }
+export { computeSkinningMatrices, applySkinning }
+
+// Apply skinning to vertices
+// Matrices should already be pre-transformed for normalized coords (via computeSkinningMatrices)
+function applySkinning(vertices, normals, joints, weights, skinningMatrices) {
+  const vertexCount = vertices.length / 3
+  const skinnedVerts = new Array(vertices.length)
+  const skinnedNormals = normals ? new Array(normals.length) : null
+
+  for (let v = 0; v < vertexCount; v++) {
+    const vi = v * 3
+    const ji = v * 4
+
+    const pos = [vertices[vi], vertices[vi + 1], vertices[vi + 2]]
+    const norm = normals ? [normals[vi], normals[vi + 1], normals[vi + 2]] : null
+
+    // Blend up to 4 bone influences
+    let skinnedPos = [0, 0, 0]
+    let skinnedNorm = normals ? [0, 0, 0] : null
+
+    for (let i = 0; i < 4; i++) {
+      const jointIndex = joints[ji + i]
+      const weight = weights[ji + i]
+
+      if (weight > 0 && skinningMatrices[jointIndex]) {
+        const mat = skinningMatrices[jointIndex]
+        const transformedPos = transformPoint(mat, pos)
+
+        skinnedPos[0] += transformedPos[0] * weight
+        skinnedPos[1] += transformedPos[1] * weight
+        skinnedPos[2] += transformedPos[2] * weight
+
+        if (normals) {
+          const transformedNorm = transformNormal(mat, norm)
+          skinnedNorm[0] += transformedNorm[0] * weight
+          skinnedNorm[1] += transformedNorm[1] * weight
+          skinnedNorm[2] += transformedNorm[2] * weight
+        }
+      }
+    }
+
+    skinnedVerts[vi] = skinnedPos[0]
+    skinnedVerts[vi + 1] = skinnedPos[1]
+    skinnedVerts[vi + 2] = skinnedPos[2]
+
+    if (normals) {
+      // Normalize the normal vector
+      const len = Math.sqrt(skinnedNorm[0] ** 2 + skinnedNorm[1] ** 2 + skinnedNorm[2] ** 2)
+      skinnedNormals[vi] = len > 0 ? skinnedNorm[0] / len : 0
+      skinnedNormals[vi + 1] = len > 0 ? skinnedNorm[1] / len : 1
+      skinnedNormals[vi + 2] = len > 0 ? skinnedNorm[2] / len : 0
+    }
+  }
+
+  return { vertices: skinnedVerts, normals: skinnedNormals }
+}
+
+// Equilateral triangle centered at (centerX, centerY)
+export function tri(size = 1.0, centerX = 0, centerY = 0) {
+  const h = size * Math.sqrt(3) / 2
+  const verts = [
+    centerX, centerY + h * 2/3,
+    centerX - size/2, centerY - h/3,
+    centerX + size/2, centerY - h/3
+  ]
+  return new VertexSource(verts)
+}
+
+// Rectangle as two triangles
+export function quad(width = 1.0, height = 1.0, centerX = 0, centerY = 0) {
+  const hw = width / 2, hh = height / 2
+  const verts = [
+    // Triangle 1
+    centerX - hw, centerY - hh,
+    centerX + hw, centerY - hh,
+    centerX + hw, centerY + hh,
+    // Triangle 2
+    centerX - hw, centerY - hh,
+    centerX + hw, centerY + hh,
+    centerX - hw, centerY + hh
+  ]
+  return new VertexSource(verts)
+}
+
+// Regular polygon with n sides (triangle fan from center)
+export function poly(sides, radius = 1.0, centerX = 0, centerY = 0) {
+  const verts = []
+  for (let i = 0; i < sides; i++) {
+    const a1 = (i / sides) * Math.PI * 2 - Math.PI / 2
+    const a2 = ((i + 1) / sides) * Math.PI * 2 - Math.PI / 2
+    verts.push(centerX, centerY)
+    verts.push(centerX + Math.cos(a1) * radius, centerY + Math.sin(a1) * radius)
+    verts.push(centerX + Math.cos(a2) * radius, centerY + Math.sin(a2) * radius)
+  }
+  return new VertexSource(verts)
+}
+
+// Circle approximation (polygon with many sides)
+export function circle(radius = 1.0, centerX = 0, centerY = 0, segments = 32) {
+  return poly(segments, radius, centerX, centerY)
+}
+
+// Line as thin quad (for stroke-like rendering)
+export function line(x1, y1, x2, y2, thickness = 0.02) {
+  const dx = x2 - x1
+  const dy = y2 - y1
+  const len = Math.sqrt(dx * dx + dy * dy)
+  const nx = -dy / len * thickness / 2
+  const ny = dx / len * thickness / 2
+  const verts = [
+    x1 + nx, y1 + ny,
+    x1 - nx, y1 - ny,
+    x2 - nx, y2 - ny,
+    x1 + nx, y1 + ny,
+    x2 - nx, y2 - ny,
+    x2 + nx, y2 + ny
+  ]
+  return new VertexSource(verts)
+}
+
+// Ring (annulus) - outer circle minus inner circle
+export function ring(outerRadius = 1.0, innerRadius = 0.5, centerX = 0, centerY = 0, segments = 32) {
+  const verts = []
+  for (let i = 0; i < segments; i++) {
+    const a1 = (i / segments) * Math.PI * 2
+    const a2 = ((i + 1) / segments) * Math.PI * 2
+    const cos1 = Math.cos(a1), sin1 = Math.sin(a1)
+    const cos2 = Math.cos(a2), sin2 = Math.sin(a2)
+    // Two triangles per segment
+    verts.push(centerX + cos1 * innerRadius, centerY + sin1 * innerRadius)
+    verts.push(centerX + cos1 * outerRadius, centerY + sin1 * outerRadius)
+    verts.push(centerX + cos2 * outerRadius, centerY + sin2 * outerRadius)
+    verts.push(centerX + cos1 * innerRadius, centerY + sin1 * innerRadius)
+    verts.push(centerX + cos2 * outerRadius, centerY + sin2 * outerRadius)
+    verts.push(centerX + cos2 * innerRadius, centerY + sin2 * innerRadius)
+  }
+  return new VertexSource(verts)
+}
+
+// 3D Cube - 6 faces, 12 triangles
+// Returns 3D vertices with per-face UVs and faceIds
+// Face order: front, back, top, bottom, right, left (indices 0-5)
+export function cube(size = 0.5) {
+  const s = size
+  // 8 corners of the cube
+  const corners = [
+    [-s, -s,  s],  // 0: front-bottom-left
+    [ s, -s,  s],  // 1: front-bottom-right
+    [ s,  s,  s],  // 2: front-top-right
+    [-s,  s,  s],  // 3: front-top-left
+    [-s, -s, -s],  // 4: back-bottom-left
+    [ s, -s, -s],  // 5: back-bottom-right
+    [ s,  s, -s],  // 6: back-top-right
+    [-s,  s, -s],  // 7: back-top-left
+  ]
+
+  // 6 faces, each as 2 triangles (CCW winding for front-facing)
+  // Each face has vertex indices and corresponding UVs
+  const faces = [
+    { indices: [0, 1, 2, 0, 2, 3], uvs: [[0,0], [1,0], [1,1], [0,0], [1,1], [0,1]] },  // front (0)
+    { indices: [5, 4, 7, 5, 7, 6], uvs: [[0,0], [1,0], [1,1], [0,0], [1,1], [0,1]] },  // back (1)
+    { indices: [3, 2, 6, 3, 6, 7], uvs: [[0,0], [1,0], [1,1], [0,0], [1,1], [0,1]] },  // top (2)
+    { indices: [4, 5, 1, 4, 1, 0], uvs: [[0,0], [1,0], [1,1], [0,0], [1,1], [0,1]] },  // bottom (3)
+    { indices: [1, 5, 6, 1, 6, 2], uvs: [[0,0], [1,0], [1,1], [0,0], [1,1], [0,1]] },  // right (4)
+    { indices: [4, 0, 3, 4, 3, 7], uvs: [[0,0], [1,0], [1,1], [0,0], [1,1], [0,1]] },  // left (5)
+  ]
+
+  const verts = []
+  const uvs = []
+  const faceIds = []
+  for (let faceIdx = 0; faceIdx < faces.length; faceIdx++) {
+    const face = faces[faceIdx]
+    for (let i = 0; i < face.indices.length; i++) {
+      verts.push(...corners[face.indices[i]])
+      uvs.push(...face.uvs[i])
+      faceIds.push(faceIdx)  // Each vertex knows which face it belongs to
+    }
+  }
+
+  const vs = new VertexSource(verts)
+  vs.uvs = uvs  // Store UVs for later use
+  vs.faceIds = faceIds  // Store face IDs for per-face materials
+  vs.is3D = true
+  return vs
+}
+
+// ============================================================================
+// Procedural 3D Geometry
+// ============================================================================
+
+// Generate a UV sphere with normals
+// segments: number of horizontal divisions (longitude)
+// rings: number of vertical divisions (latitude)
+export function sphere(radius = 0.5, segments = 32, rings = 16) {
+  const verts = []
+  const normals = []
+  const uvs = []
+
+  for (let ring = 0; ring <= rings; ring++) {
+    const theta = (ring / rings) * Math.PI  // 0 to PI (top to bottom)
+    const sinTheta = Math.sin(theta)
+    const cosTheta = Math.cos(theta)
+
+    for (let seg = 0; seg <= segments; seg++) {
+      const phi = (seg / segments) * Math.PI * 2  // 0 to 2PI (around)
+      const sinPhi = Math.sin(phi)
+      const cosPhi = Math.cos(phi)
+
+      // Normal is just the unit sphere position
+      const nx = sinTheta * cosPhi
+      const ny = cosTheta
+      const nz = sinTheta * sinPhi
+
+      // Position is normal * radius
+      const x = nx * radius
+      const y = ny * radius
+      const z = nz * radius
+
+      // UV coordinates
+      const u = seg / segments
+      const v = ring / rings
+
+      verts.push(x, y, z)
+      normals.push(nx, ny, nz)
+      uvs.push(u, v)
+    }
+  }
+
+  // Build triangle indices
+  const outVerts = []
+  const outNormals = []
+  const outUVs = []
+
+  const stride = segments + 1
+  for (let ring = 0; ring < rings; ring++) {
+    for (let seg = 0; seg < segments; seg++) {
+      const i0 = ring * stride + seg
+      const i1 = i0 + 1
+      const i2 = i0 + stride
+      const i3 = i2 + 1
+
+      // Two triangles per quad
+      const indices = [i0, i2, i1, i1, i2, i3]
+      for (const idx of indices) {
+        outVerts.push(verts[idx * 3], verts[idx * 3 + 1], verts[idx * 3 + 2])
+        outNormals.push(normals[idx * 3], normals[idx * 3 + 1], normals[idx * 3 + 2])
+        outUVs.push(uvs[idx * 2], uvs[idx * 2 + 1])
+      }
+    }
+  }
+
+  const vs = new VertexSource(outVerts)
+  vs.normals = outNormals
+  vs.uvs = outUVs
+  vs.is3D = true
+  return vs
+}
+
+// Generate a subdivided plane with normals (facing +Y by default)
+// width, height: size of the plane
+// subdivisionsX, subdivisionsY: number of subdivisions
+export function plane(width = 1, height = 1, subdivisionsX = 1, subdivisionsY = 1) {
+  const verts = []
+  const normals = []
+  const uvs = []
+
+  const halfW = width / 2
+  const halfH = height / 2
+
+  for (let y = 0; y <= subdivisionsY; y++) {
+    for (let x = 0; x <= subdivisionsX; x++) {
+      const u = x / subdivisionsX
+      const v = y / subdivisionsY
+      const px = -halfW + u * width
+      const pz = -halfH + v * height
+
+      verts.push(px, 0, pz)
+      normals.push(0, 1, 0)  // Facing up
+      uvs.push(u, v)
+    }
+  }
+
+  // Build triangles
+  const outVerts = []
+  const outNormals = []
+  const outUVs = []
+
+  const stride = subdivisionsX + 1
+  for (let y = 0; y < subdivisionsY; y++) {
+    for (let x = 0; x < subdivisionsX; x++) {
+      const i0 = y * stride + x
+      const i1 = i0 + 1
+      const i2 = i0 + stride
+      const i3 = i2 + 1
+
+      // Two triangles per quad
+      const indices = [i0, i2, i1, i1, i2, i3]
+      for (const idx of indices) {
+        outVerts.push(verts[idx * 3], verts[idx * 3 + 1], verts[idx * 3 + 2])
+        outNormals.push(normals[idx * 3], normals[idx * 3 + 1], normals[idx * 3 + 2])
+        outUVs.push(uvs[idx * 2], uvs[idx * 2 + 1])
+      }
+    }
+  }
+
+  const vs = new VertexSource(outVerts)
+  vs.normals = outNormals
+  vs.uvs = outUVs
+  vs.is3D = true
+  return vs
+}
+
+// Generate a torus (donut) with normals
+// radius: distance from center to tube center
+// tubeRadius: radius of the tube
+// radialSegments: segments around the ring
+// tubularSegments: segments around the tube
+export function torus(radius = 0.4, tubeRadius = 0.15, radialSegments = 32, tubularSegments = 16) {
+  const verts = []
+  const normals = []
+  const uvs = []
+
+  for (let i = 0; i <= radialSegments; i++) {
+    const u = i / radialSegments
+    const theta = u * Math.PI * 2
+
+    for (let j = 0; j <= tubularSegments; j++) {
+      const v = j / tubularSegments
+      const phi = v * Math.PI * 2
+
+      // Position on torus
+      const x = (radius + tubeRadius * Math.cos(phi)) * Math.cos(theta)
+      const y = tubeRadius * Math.sin(phi)
+      const z = (radius + tubeRadius * Math.cos(phi)) * Math.sin(theta)
+
+      // Normal: direction from ring center to surface
+      const cx = radius * Math.cos(theta)  // center of tube ring
+      const cz = radius * Math.sin(theta)
+      const nx = x - cx
+      const ny = y
+      const nz = z - cz
+      const len = Math.sqrt(nx * nx + ny * ny + nz * nz)
+
+      verts.push(x, y, z)
+      normals.push(nx / len, ny / len, nz / len)
+      uvs.push(u, v)
+    }
+  }
+
+  // Build triangles
+  const outVerts = []
+  const outNormals = []
+  const outUVs = []
+
+  const stride = tubularSegments + 1
+  for (let i = 0; i < radialSegments; i++) {
+    for (let j = 0; j < tubularSegments; j++) {
+      const i0 = i * stride + j
+      const i1 = i0 + 1
+      const i2 = i0 + stride
+      const i3 = i2 + 1
+
+      // Two triangles per quad
+      const indices = [i0, i1, i2, i1, i3, i2]
+      for (const idx of indices) {
+        outVerts.push(verts[idx * 3], verts[idx * 3 + 1], verts[idx * 3 + 2])
+        outNormals.push(normals[idx * 3], normals[idx * 3 + 1], normals[idx * 3 + 2])
+        outUVs.push(uvs[idx * 2], uvs[idx * 2 + 1])
+      }
+    }
+  }
+
+  const vs = new VertexSource(outVerts)
+  vs.normals = outNormals
+  vs.uvs = outUVs
+  vs.is3D = true
+  return vs
+}
+
+// Generate a cylinder with normals
+// radius: radius of the cylinder
+// height: height of the cylinder
+// radialSegments: segments around the circumference
+// heightSegments: segments along the height
+// caps: whether to include top and bottom caps (default true)
+export function cylinder(radius = 0.3, height = 1, radialSegments = 32, heightSegments = 1, caps = true) {
+  const verts = []
+  const normals = []
+  const uvs = []
+
+  const halfHeight = height / 2
+
+  // Generate the tube
+  for (let y = 0; y <= heightSegments; y++) {
+    const v = y / heightSegments
+    const py = -halfHeight + v * height
+
+    for (let i = 0; i <= radialSegments; i++) {
+      const u = i / radialSegments
+      const theta = u * Math.PI * 2
+      const cosT = Math.cos(theta)
+      const sinT = Math.sin(theta)
+
+      verts.push(cosT * radius, py, sinT * radius)
+      normals.push(cosT, 0, sinT)  // Outward normal
+      uvs.push(u, v)
+    }
+  }
+
+  // Build tube triangles
+  const outVerts = []
+  const outNormals = []
+  const outUVs = []
+
+  const stride = radialSegments + 1
+  for (let y = 0; y < heightSegments; y++) {
+    for (let i = 0; i < radialSegments; i++) {
+      const i0 = y * stride + i
+      const i1 = i0 + 1
+      const i2 = i0 + stride
+      const i3 = i2 + 1
+
+      const indices = [i0, i2, i1, i1, i2, i3]
+      for (const idx of indices) {
+        outVerts.push(verts[idx * 3], verts[idx * 3 + 1], verts[idx * 3 + 2])
+        outNormals.push(normals[idx * 3], normals[idx * 3 + 1], normals[idx * 3 + 2])
+        outUVs.push(uvs[idx * 2], uvs[idx * 2 + 1])
+      }
+    }
+  }
+
+  // Add caps
+  if (caps) {
+    // Top cap (y = halfHeight)
+    for (let i = 0; i < radialSegments; i++) {
+      const theta1 = (i / radialSegments) * Math.PI * 2
+      const theta2 = ((i + 1) / radialSegments) * Math.PI * 2
+
+      // Center vertex
+      outVerts.push(0, halfHeight, 0)
+      outNormals.push(0, 1, 0)
+      outUVs.push(0.5, 0.5)
+
+      // Edge vertices (CCW from above)
+      outVerts.push(Math.cos(theta2) * radius, halfHeight, Math.sin(theta2) * radius)
+      outNormals.push(0, 1, 0)
+      outUVs.push(0.5 + Math.cos(theta2) * 0.5, 0.5 + Math.sin(theta2) * 0.5)
+
+      outVerts.push(Math.cos(theta1) * radius, halfHeight, Math.sin(theta1) * radius)
+      outNormals.push(0, 1, 0)
+      outUVs.push(0.5 + Math.cos(theta1) * 0.5, 0.5 + Math.sin(theta1) * 0.5)
+    }
+
+    // Bottom cap (y = -halfHeight)
+    for (let i = 0; i < radialSegments; i++) {
+      const theta1 = (i / radialSegments) * Math.PI * 2
+      const theta2 = ((i + 1) / radialSegments) * Math.PI * 2
+
+      // Center vertex
+      outVerts.push(0, -halfHeight, 0)
+      outNormals.push(0, -1, 0)
+      outUVs.push(0.5, 0.5)
+
+      // Edge vertices (CCW from below)
+      outVerts.push(Math.cos(theta1) * radius, -halfHeight, Math.sin(theta1) * radius)
+      outNormals.push(0, -1, 0)
+      outUVs.push(0.5 + Math.cos(theta1) * 0.5, 0.5 + Math.sin(theta1) * 0.5)
+
+      outVerts.push(Math.cos(theta2) * radius, -halfHeight, Math.sin(theta2) * radius)
+      outNormals.push(0, -1, 0)
+      outUVs.push(0.5 + Math.cos(theta2) * 0.5, 0.5 + Math.sin(theta2) * 0.5)
+    }
+  }
+
+  const vs = new VertexSource(outVerts)
+  vs.normals = outNormals
+  vs.uvs = outUVs
+  vs.is3D = true
+  return vs
+}
+
+// Generate a cone with normals
+// radius: radius of the base
+// height: height of the cone
+// radialSegments: segments around the circumference
+// caps: whether to include bottom cap (default true)
+export function cone(radius = 0.3, height = 1, radialSegments = 32, caps = true) {
+  const outVerts = []
+  const outNormals = []
+  const outUVs = []
+
+  const halfHeight = height / 2
+  const apex = halfHeight
+  const base = -halfHeight
+
+  // Calculate the normal slope for cone surface
+  // Normal needs to point outward and up the slope
+  const slopeAngle = Math.atan2(radius, height)
+  const ny = Math.sin(slopeAngle)
+  const nxz = Math.cos(slopeAngle)
+
+  // Generate cone sides
+  for (let i = 0; i < radialSegments; i++) {
+    const theta1 = (i / radialSegments) * Math.PI * 2
+    const theta2 = ((i + 1) / radialSegments) * Math.PI * 2
+    const cosT1 = Math.cos(theta1), sinT1 = Math.sin(theta1)
+    const cosT2 = Math.cos(theta2), sinT2 = Math.sin(theta2)
+
+    // Triangle from apex to base edge
+    // Apex
+    outVerts.push(0, apex, 0)
+    // Normal at apex: average of surrounding normals, pointing up/out
+    const midTheta = (theta1 + theta2) / 2
+    outNormals.push(Math.cos(midTheta) * nxz, ny, Math.sin(midTheta) * nxz)
+    outUVs.push(0.5, 0)
+
+    // Base edge 1
+    outVerts.push(cosT1 * radius, base, sinT1 * radius)
+    outNormals.push(cosT1 * nxz, ny, sinT1 * nxz)
+    outUVs.push(i / radialSegments, 1)
+
+    // Base edge 2
+    outVerts.push(cosT2 * radius, base, sinT2 * radius)
+    outNormals.push(cosT2 * nxz, ny, sinT2 * nxz)
+    outUVs.push((i + 1) / radialSegments, 1)
+  }
+
+  // Add base cap
+  if (caps) {
+    for (let i = 0; i < radialSegments; i++) {
+      const theta1 = (i / radialSegments) * Math.PI * 2
+      const theta2 = ((i + 1) / radialSegments) * Math.PI * 2
+
+      // Center vertex
+      outVerts.push(0, base, 0)
+      outNormals.push(0, -1, 0)
+      outUVs.push(0.5, 0.5)
+
+      // Edge vertices (CCW from below)
+      outVerts.push(Math.cos(theta1) * radius, base, Math.sin(theta1) * radius)
+      outNormals.push(0, -1, 0)
+      outUVs.push(0.5 + Math.cos(theta1) * 0.5, 0.5 + Math.sin(theta1) * 0.5)
+
+      outVerts.push(Math.cos(theta2) * radius, base, Math.sin(theta2) * radius)
+      outNormals.push(0, -1, 0)
+      outUVs.push(0.5 + Math.cos(theta2) * 0.5, 0.5 + Math.sin(theta2) * 0.5)
+    }
+  }
+
+  const vs = new VertexSource(outVerts)
+  vs.normals = outNormals
+  vs.uvs = outUVs
+  vs.is3D = true
+  return vs
+}

--- a/extensions/vertex/glsl-source.js
+++ b/extensions/vertex/glsl-source.js
@@ -30,8 +30,12 @@ function wrapWgslFunction(transform) {
   if (!t) return transform.transform.wgsl || ''
 
   // Get inputs from the original transform definition
+  // Note: processGlsl mutates obj.inputs to include base args (e.g., _c1 for combine types)
+  // We filter those out since they're already in t.args
   const originalInputs = transform.transform.inputs || []
-  const allArgs = [...t.args, ...originalInputs.map(inp => ({
+  const baseArgNames = new Set(t.args.map(a => a.name))
+  const userInputs = originalInputs.filter(inp => !baseArgNames.has(inp.name))
+  const allArgs = [...t.args, ...userInputs.map(inp => ({
     type: toWgslType(inp.type),
     name: inp.name
   }))]

--- a/extensions/vertex/glsl-source.js
+++ b/extensions/vertex/glsl-source.js
@@ -1,0 +1,318 @@
+import generateGlsl from './generate-glsl.js'
+import utilityGlsl from './utility-functions.js'
+// Import WGSL utilities from extension's wgsl folder
+import utilityWgsl from './wgsl/utility-functions-wgsl.js'
+
+// WGSL type mappings
+const wgslTypeLookup = {
+  'src': { returnType: 'vec4<f32>', args: [{ type: 'vec2<f32>', name: '_st' }] },
+  'coord': { returnType: 'vec2<f32>', args: [{ type: 'vec2<f32>', name: '_st' }] },
+  'color': { returnType: 'vec4<f32>', args: [{ type: 'vec4<f32>', name: '_c0' }] },
+  'combine': { returnType: 'vec4<f32>', args: [{ type: 'vec4<f32>', name: '_c0' }, { type: 'vec4<f32>', name: '_c1' }] },
+  'combineCoord': { returnType: 'vec2<f32>', args: [{ type: 'vec2<f32>', name: '_st' }, { type: 'vec4<f32>', name: '_c0' }] }
+}
+
+// Convert GLSL type to WGSL type
+function toWgslType(glslType) {
+  const typeMap = {
+    'float': 'f32',
+    'vec2': 'vec2<f32>',
+    'vec3': 'vec3<f32>',
+    'vec4': 'vec4<f32>',
+    'sampler2D': 'texture_2d<f32>'
+  }
+  return typeMap[glslType] || glslType
+}
+
+// Wrap raw WGSL body in a function definition (like processGlsl does for GLSL)
+function wrapWgslFunction(transform) {
+  const t = wgslTypeLookup[transform.transform.type]
+  if (!t) return transform.transform.wgsl || ''
+
+  // Get inputs from the original transform definition
+  const originalInputs = transform.transform.inputs || []
+  const allArgs = [...t.args, ...originalInputs.map(inp => ({
+    type: toWgslType(inp.type),
+    name: inp.name
+  }))]
+
+  const args = allArgs.map(arg => `${arg.name}: ${arg.type}`).join(', ')
+  const body = transform.transform.wgsl || ''
+
+  return `
+fn ${transform.name}(${args}) -> ${t.returnType} {
+    ${body}
+}
+`
+}
+
+var GlslSource = function (obj) {
+  this.transforms = []
+  this.transforms.push(obj)
+  this.defaultOutput = obj.defaultOutput
+  this.synth = obj.synth
+  this.type = 'GlslSource'
+  this.defaultUniforms = obj.defaultUniforms
+  this.isWGSL = obj.synth.isWGSL  // Track WGSL mode
+  return this
+}
+
+GlslSource.prototype.addTransform = function (obj)  {
+    this.transforms.push(obj)
+}
+
+// Extended out() signature with config object:
+// out(output?, geometry?, config?)
+//
+// New API (config object):
+//   osc(10).out(o0, tri(0.3), { level: 1, blend: 'add', primitive: 'triangles' })
+//   osc(10).out(o0, tri(0.3))           // geometry with defaults
+//   osc(10).out(o0)                      // fullscreen
+//   osc(10).out()                        // fullscreen to default output
+//
+// Config options:
+//   level: Integer for painter's algorithm (0 clears, 1+ composites) - default: 0
+//   blend: 'normal', 'add', 'multiply', 'screen' - default: 'normal'
+//   primitive: 'triangles', 'triangle strip', 'lines', etc. - default: 'triangles'
+//
+// Legacy positional API (still supported):
+//   osc(10).out(o0, vertices, 1, 'add')
+//
+function isGeometry(arg) {
+  if (!arg) return false
+  if (Array.isArray(arg)) return true
+  if (arg.vertices) return true  // VertexSource
+  return false
+}
+
+function isConfig(arg) {
+  if (!arg) return false
+  if (typeof arg !== 'object') return false
+  if (Array.isArray(arg)) return false
+  if (arg.vertices) return false  // VertexSource
+  // Check for config keys
+  return 'level' in arg || 'blend' in arg || 'primitive' in arg || 'sprite' in arg || 'enabled' in arg
+}
+
+function isOutput(arg) {
+  // Check if arg looks like an output object
+  return arg && typeof arg === 'object' && 'registerSprite' in arg
+}
+
+GlslSource.prototype.out = function (arg1, arg2, arg3, arg4) {
+  let output, geometry, config
+
+  // Parse arguments flexibly
+  if (isGeometry(arg1)) {
+    // out(geometry, config?) - no output specified
+    output = this.defaultOutput
+    geometry = arg1
+    config = isConfig(arg2) ? arg2 : {}
+    // Legacy: out(geometry, level, blend)
+    if (typeof arg2 === 'number') {
+      config = { level: arg2, blend: arg3 || 'normal' }
+    }
+  } else if (isOutput(arg1) || arg1 === undefined || arg1 === null) {
+    // out(output?, geometry?, config?)
+    output = arg1 || this.defaultOutput
+
+    if (isGeometry(arg2)) {
+      geometry = arg2
+      config = isConfig(arg3) ? arg3 : {}
+      // Legacy: out(output, geometry, level, blend)
+      if (typeof arg3 === 'number') {
+        config = { level: arg3, blend: arg4 || 'normal' }
+      }
+    } else if (isConfig(arg2)) {
+      // out(output, config) - fullscreen with config
+      geometry = null
+      config = arg2
+    } else if (arg2 === null && isConfig(arg3)) {
+      // out(output, null, config) - explicit null geometry with config
+      geometry = null
+      config = arg3
+    } else {
+      // out(output) or out() - fullscreen
+      geometry = null
+      config = {}
+    }
+  } else {
+    // Fallback: treat arg1 as output
+    output = arg1 || this.defaultOutput
+    geometry = null
+    config = {}
+  }
+
+  // Extract config values with defaults
+  const level = config.level !== undefined ? config.level : 0
+  const blend = config.blend || 'normal'
+  const primitive = config.primitive || 'triangles'
+  const sprite = config.sprite || null
+  const enabled = config.enabled !== undefined ? config.enabled : true
+
+  if(output) try {
+    var glsl = this.glsl(output)
+    this.synth.currentFunctions = []
+
+    // Clean up existing sprite at this level if it exists
+    if (output.sprites && output.sprites.has(level) && output.defaultPositionBuffer) {
+      const oldSprite = output.sprites.get(level)
+      if (oldSprite.positionBuffer && oldSprite.positionBuffer !== output.defaultPositionBuffer) {
+        oldSprite.positionBuffer.destroy()
+      }
+    }
+
+    // Register sprite at the specified level
+    output.registerSprite(level, {
+      passes: glsl,
+      vertexData: geometry,
+      blendMode: blend,
+      primitive: primitive,
+      sprite: sprite,
+      enabled: enabled
+    })
+  } catch (error) {
+    console.warn('shader could not compile', error)
+  }
+}
+
+GlslSource.prototype.glsl = function () {
+  var self = this
+  var passes = []
+  var transforms = []
+
+  this.transforms.forEach((transform) => {
+    if(transform.transform.type === 'renderpass'){
+      console.warn('no support for renderpass')
+    } else {
+      transforms.push(transform)
+    }
+  })
+
+  if (transforms.length > 0) passes.push(this.compile(transforms))
+
+  return passes
+}
+
+GlslSource.prototype.compile = function (transforms) {
+  var shaderInfo = generateGlsl(transforms, this.synth)
+  var uniforms = {}
+  shaderInfo.uniforms.forEach((uniform) => { uniforms[uniform.name] = uniform.value })
+
+  let frag
+
+  // Check both this.isWGSL and this.synth.isWGSL (for patched vanilla instances)
+  const isWGSL = this.isWGSL || (this.synth && this.synth.isWGSL)
+
+  if (isWGSL) {
+    // Generate WGSL fragment shader
+    // Module-scope private variables for varyings (accessible from all functions)
+    frag = `
+var<private> v_position: vec3<f32>;
+var<private> v_normal: vec3<f32>;
+var<private> v_worldNormal: vec3<f32>;
+var<private> v_tangent: vec3<f32>;
+var<private> v_bitangent: vec3<f32>;
+var<private> v_viewDir: vec3<f32>;
+var<private> v_depth: f32;
+var<private> v_color: vec4<f32>;
+
+${Object.values(utilityWgsl).map((transform) => {
+      return `
+            ${transform.wgsl}
+          `
+    }).join('')}
+
+${shaderInfo.glslFunctions.map((transform) => {
+      if (isWGSL && transform.transform.strange) return ''
+      return wrapWgslFunction(transform)
+    }).join('')}
+
+  @fragment
+  fn main(ourIn: VertexOutput) -> @location(0) vec4<f32> {
+    let c: vec4<f32> = vec4<f32>(1.0, 0.0, 0.0, 1.0);
+    let st: vec2<f32> = ourIn.texcoord;
+    // Copy varyings to module-scope private variables
+    v_position = ourIn.v_position;
+    v_normal = ourIn.v_normal;
+    v_worldNormal = ourIn.v_worldNormal;
+    v_tangent = ourIn.v_tangent;
+    v_bitangent = ourIn.v_bitangent;
+    v_viewDir = ourIn.v_viewDir;
+    v_depth = ourIn.v_depth;
+    v_color = ourIn.v_color;
+    return ${shaderInfo.fragColor};
+  }
+`
+  } else {
+    // Generate GLSL fragment shader
+    frag = `
+  precision ${this.defaultOutput.precision} float;
+  ${Object.values(shaderInfo.uniforms).map((uniform) => {
+    let type = uniform.type
+    switch (uniform.type) {
+      case 'texture':
+        type = 'sampler2D'
+        break
+    }
+    return `
+      uniform ${type} ${uniform.name};`
+  }).join('')}
+  uniform float time;
+  uniform vec2 resolution;
+  varying vec2 uv;
+  varying float v_faceId;
+
+  // Vertex data from vertex shader (for 3D geometry)
+  varying vec3 v_position;
+  varying vec3 v_normal;
+  varying vec3 v_worldNormal;
+  varying vec3 v_tangent;
+  varying vec3 v_bitangent;
+  varying vec3 v_viewDir;
+  varying float v_depth;
+  varying vec4 v_color;
+
+  uniform sampler2D prevBuffer;
+  uniform vec4 u_spriteUV;  // x=uMin, y=vMin, z=uMax, w=vMax (fallback when no faceId)
+  uniform vec2 u_spriteGrid;  // cols, rows for faceId-based sprite picking
+
+  ${Object.values(utilityGlsl).map((transform) => {
+    return `
+            ${transform.glsl}
+          `
+  }).join('')}
+
+  ${shaderInfo.glslFunctions.map((transform) => {
+    return `
+            ${transform.transform.glsl}
+          `
+  }).join('')}
+
+  void main () {
+    vec2 st;
+    // If using sprite grid (cols > 1 or rows > 1), use faceId to pick cell
+    if (u_spriteGrid.x > 1.0 || u_spriteGrid.y > 1.0) {
+      // faceId maps to cell in row-major order (left-to-right, top-to-bottom)
+      float cellX = mod(v_faceId, u_spriteGrid.x);
+      float cellY = floor(v_faceId / u_spriteGrid.x);
+      vec2 cellSize = vec2(1.0 / u_spriteGrid.x, 1.0 / u_spriteGrid.y);
+      st = uv * cellSize + vec2(cellX, cellY) * cellSize;
+    } else {
+      // Fallback to u_spriteUV for single sprite picking
+      st = u_spriteUV.xy + uv * (u_spriteUV.zw - u_spriteUV.xy);
+    }
+
+    vec4 c = ${shaderInfo.fragColor};
+    gl_FragColor = c;
+  }
+  `
+  }
+
+  return {
+    frag: frag,
+    uniforms: Object.assign({}, this.defaultUniforms, uniforms)
+  }
+}
+
+export default GlslSource

--- a/extensions/vertex/index-webgpu.js
+++ b/extensions/vertex/index-webgpu.js
@@ -1,0 +1,342 @@
+/**
+ * Hydra Vertex Shader Extension - WebGPU Build
+ *
+ * Adds 3D vertex shader capabilities to hydra-synth with WebGL + WebGPU support.
+ * This extension is self-contained and does not require modifications to vanilla hydra-synth.
+ *
+ * Usage (recommended - uses built-in WebGPU support):
+ *   import { createHydra } from 'hydra-vertex-extension'
+ *
+ *   // WebGPU mode
+ *   const hydra = await createHydra({ useWGSL: true, ... })
+ *
+ *   // WebGL mode
+ *   const hydra = await createHydra({ useWGSL: false, ... })
+ *
+ *   // Now you can use vertex functions:
+ *   // osc(10).out(o0, sphere())
+ *   // loadGlb('model.glb').then(m => osc(10).out(o0, m.rotateY(() => time)))
+ *
+ * Usage (alternative - patch existing hydra instance):
+ *   import Hydra from 'hydra-synth'
+ *   import { install } from 'hydra-vertex-extension'
+ *
+ *   const hydra = new Hydra({ ... })
+ *   install(hydra)  // Adds vertex features to WebGL hydra
+ */
+
+// Import createHydra factory
+import { createHydra as _createHydra } from './createHydra.js'
+
+// Import geometry primitives
+import {
+  tri, quad, poly, circle, line, ring,
+  cube, sphere, plane, torus, cylinder, cone,
+  parseObj, loadObj, parseGlb, loadGlb
+} from './geometry.js'
+
+// Import VertexSource class and generators
+import VertexSource, { generateVertexGlsl, generateVertexWgsl, getPassthroughVertexWgsl } from './vertex-source.js'
+
+// Import varying proxy
+import { v } from './varying-proxy.js'
+
+// Import the modified GlslSource and Output
+import GlslSource from './glsl-source.js'
+import Output from './output.js'
+
+// Import lighting functions
+import lightingFunctions from './lighting-functions.js'
+
+// Import WebGPU utilities
+import { getSharedDevice, hasSharedDevice, releaseSharedDevice } from './wgsl/gpu-device-factory.js'
+
+// Extension version
+export const VERSION = '0.2.0-webgpu'
+
+// Store reference to hydra instance
+let _hydra = null
+
+/**
+ * Install the vertex shader extension with WebGL + WebGPU support
+ */
+export function install(hydra, options = {}) {
+  console.log(`[hydra-vertex-webgpu] Installing vertex shader extension v${VERSION}`)
+
+  _hydra = hydra
+  const synth = hydra.synth
+
+  if (!synth) {
+    console.error('[hydra-vertex-webgpu] Could not find hydra.synth')
+    return false
+  }
+
+  // Register geometry functions as globals
+  registerGeometryFunctions(synth)
+
+  // Register lighting functions
+  registerLightingFunctions(synth)
+
+  // Register varying proxy
+  synth.v = v
+  if (typeof window !== 'undefined') {
+    window.v = v
+  }
+
+  // Replace GlslSource prototype methods with vertex-shader versions
+  patchGlslSource(hydra)
+
+  // Replace Output prototype methods (WebGL)
+  patchOutput(hydra)
+
+  // Patch hush() to clear sprites
+  patchHush(hydra)
+
+  // Add ResizeObserver to handle canvas resize automatically
+  setupResizeObserver(hydra)
+
+  // WebGPU mode: outputWgsl.js already has registerSprite built-in
+  if (hydra.useWGSL && hydra.wgslHydra) {
+    console.log('[hydra-vertex-webgpu] WebGPU mode detected')
+  }
+
+  console.log('[hydra-vertex-webgpu] Extension installed successfully')
+  return true
+}
+
+/**
+ * Setup ResizeObserver to automatically update resolution when canvas resizes
+ */
+function setupResizeObserver(hydra) {
+  const canvas = hydra.canvas
+  if (!canvas || typeof ResizeObserver === 'undefined') return
+
+  const observer = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const width = Math.round(entry.contentRect.width * (window.devicePixelRatio || 1))
+      const height = Math.round(entry.contentRect.height * (window.devicePixelRatio || 1))
+
+      // Skip invalid dimensions (can happen before layout is ready)
+      if (width <= 0 || height <= 0) continue
+
+      if (canvas.width !== width || canvas.height !== height) {
+        console.log(`[hydra-vertex-webgpu] Canvas resized: ${width}x${height}`)
+        hydra.setResolution(width, height)
+      }
+    }
+  })
+
+  observer.observe(canvas)
+  hydra._vertexResizeObserver = observer
+}
+
+/**
+ * Register geometry creation functions as globals
+ */
+function registerGeometryFunctions(synth) {
+  const geometryFunctions = {
+    tri, quad, poly, circle, line, ring,
+    cube, sphere, plane, torus, cylinder, cone,
+    parseObj, loadObj, parseGlb, loadGlb
+  }
+
+  for (const [name, fn] of Object.entries(geometryFunctions)) {
+    synth[name] = fn
+    if (typeof window !== 'undefined') {
+      window[name] = fn
+    }
+  }
+  console.log('[hydra-vertex-webgpu] Registered geometry functions')
+}
+
+/**
+ * Register lighting functions (diffuse, specular, fresnel, etc.)
+ */
+function registerLightingFunctions(synth) {
+  for (const fn of lightingFunctions) {
+    synth.setFunction(fn)
+  }
+  console.log('[hydra-vertex-webgpu] Registered lighting functions')
+}
+
+/**
+ * Patch GlslSource prototype with vertex-shader methods
+ */
+function patchGlslSource(hydra) {
+  const testSource = hydra.synth.osc ? hydra.synth.osc() : null
+  if (!testSource) return
+
+  const GlslSourceProto = Object.getPrototypeOf(testSource)
+
+  // Copy all methods from our GlslSource to the existing prototype
+  GlslSourceProto.out = GlslSource.prototype.out
+  GlslSourceProto.glsl = GlslSource.prototype.glsl
+  GlslSourceProto.compile = GlslSource.prototype.compile
+
+  console.log('[hydra-vertex-webgpu] GlslSource patched')
+}
+
+/**
+ * Patch Output prototype with vertex-shader methods (WebGL)
+ */
+function patchOutput(hydra) {
+  const output = hydra.o[0]
+  if (!output || !output.regl) return  // Skip if WebGPU only
+
+  const OutputProto = Object.getPrototypeOf(output)
+
+  // Copy all methods from our Output to the existing prototype
+  OutputProto.registerSprite = Output.prototype.registerSprite
+  OutputProto.enableDepthBuffer = Output.prototype.enableDepthBuffer
+  OutputProto._renderSprites = Output.prototype._renderSprites
+  OutputProto.clearSprites = Output.prototype.clearSprites
+  OutputProto.removeSprite = Output.prototype.removeSprite
+  OutputProto.enableSprite = Output.prototype.enableSprite
+  OutputProto.disableSprite = Output.prototype.disableSprite
+  OutputProto.tick = Output.prototype.tick
+  OutputProto.render = Output.prototype.render
+
+  // Initialize each output with vertex-shader properties
+  for (const o of hydra.o) {
+    if (!o.regl) continue  // Skip WGSL outputs
+
+    // Default fullscreen triangle using vec3
+    o.defaultPositionBuffer = o.regl.buffer([
+      [-2, 0, 0],
+      [0, -2, 0],
+      [2, 2, 0]
+    ])
+    o.positionBuffer = o.defaultPositionBuffer
+
+    // Sprite registry
+    o.sprites = new Map()
+    o.hasDepthBuffer = false
+
+    // Update the vertex shader to use vec3 positions
+    o.vert = `
+    precision ${o.precision} float;
+    attribute vec3 position;
+    varying vec2 uv;
+    varying float v_faceId;
+
+    varying vec3 v_position;
+    varying vec3 v_normal;
+    varying vec3 v_worldNormal;
+    varying vec3 v_tangent;
+    varying vec3 v_bitangent;
+    varying vec3 v_viewDir;
+    varying float v_depth;
+
+    void main () {
+      uv = position.xy;
+      v_faceId = 0.0;
+
+      v_position = vec3(position.xy * 2.0 - 1.0, 0.0);
+      v_normal = vec3(0.0, 0.0, 1.0);
+      v_worldNormal = vec3(0.0, 0.0, 1.0);
+      v_tangent = vec3(1.0, 0.0, 0.0);
+      v_bitangent = vec3(0.0, 1.0, 0.0);
+      v_viewDir = vec3(0.0, 0.0, 1.0);
+      v_depth = 1.0;
+
+      gl_Position = vec4(2.0 * position.xy - 1.0, 0, 1);
+    }`
+
+    // Create copy command for persistence/trails
+    o.copyCommand = o.regl({
+      frag: `
+        precision ${o.precision} float;
+        uniform sampler2D source;
+        varying vec2 uv;
+        void main () {
+          gl_FragColor = texture2D(source, uv);
+        }
+      `,
+      vert: o.vert,
+      attributes: {
+        position: o.defaultPositionBuffer
+      },
+      uniforms: {
+        source: o.regl.prop('source')
+      },
+      count: 3,
+      depth: { enable: false }
+    })
+  }
+
+  console.log('[hydra-vertex-webgpu] Output patched (WebGL)')
+}
+
+/**
+ * Patch hush() to clear all sprites before resetting
+ */
+function patchHush(hydra) {
+  hydra.hush = function() {
+    // Clear sources
+    hydra.s.forEach((source) => {
+      source.clear()
+    })
+    // Clear all sprite levels and reset to blank
+    hydra.o.forEach((output) => {
+      if (output.clearSprites) {
+        output.clearSprites()
+      }
+      // Clear the framebuffers directly
+      if (output.fbos && output.regl) {
+        output.fbos.forEach(fbo => {
+          output.regl.clear({
+            color: [0, 0, 0, 1],
+            depth: 1,
+            framebuffer: fbo
+          })
+        })
+      }
+    })
+    hydra.synth.render(hydra.o[0])
+    if (hydra.sandbox) {
+      hydra.sandbox.set('update', (dt) => {})
+      hydra.sandbox.set('afterUpdate', (dt) => {})
+    }
+  }
+
+  if (hydra.sandbox) {
+    hydra.sandbox.set('hush', hydra.hush)
+  }
+
+  console.log('[hydra-vertex-webgpu] hush() patched')
+}
+
+/**
+ * Cleanup extension resources
+ */
+export function cleanup(hydra) {
+  hydra = hydra || _hydra
+  if (!hydra) return
+
+  for (const output of hydra.o) {
+    if (output && output.sprites) {
+      output.clearSprites()
+    }
+  }
+}
+
+/**
+ * Create a Hydra instance with vertex extension auto-installed
+ * Supports both WebGL and WebGPU modes
+ */
+export async function createHydra(options = {}) {
+  const hydra = await _createHydra(options)
+  install(hydra)
+  return hydra
+}
+
+// Re-export everything for direct import
+export {
+  tri, quad, poly, circle, line, ring,
+  cube, sphere, plane, torus, cylinder, cone,
+  parseObj, loadObj, parseGlb, loadGlb,
+  VertexSource, v,
+  generateVertexGlsl, generateVertexWgsl, getPassthroughVertexWgsl,
+  // WebGPU utilities
+  getSharedDevice, hasSharedDevice, releaseSharedDevice
+}

--- a/extensions/vertex/index.js
+++ b/extensions/vertex/index.js
@@ -1,0 +1,356 @@
+/**
+ * Hydra Vertex Shader Extension
+ *
+ * Adds 3D vertex shader capabilities to hydra-synth.
+ *
+ * Usage:
+ *   import Hydra from 'hydra-synth'
+ *   import { install } from 'hydra-synth/extensions/vertex'
+ *
+ *   const hydra = new Hydra({ ... })
+ *   install(hydra)
+ *
+ *   // Now you can use vertex functions:
+ *   // osc(10).out(o0, sphere())   // osc shader on sphere geometry
+ *   // solid(1,0,0).out(o0, cube())  // red cube
+ */
+
+// Import geometry primitives
+import {
+  tri, quad, poly, circle, line, ring,
+  cube, sphere, plane, torus, cylinder, cone,
+  parseObj, loadObj, parseGlb, loadGlb
+} from './geometry.js'
+
+// Import VertexSource class
+import VertexSource from './vertex-source.js'
+
+// Import varying proxy
+import { v } from './varying-proxy.js'
+
+// Import the modified GlslSource and Output from vertex-shaders branch
+import GlslSource from './glsl-source.js'
+import Output from './output.js'
+
+// Import lighting functions
+import lightingFunctions from './lighting-functions.js'
+
+// Import WebGPU utilities
+import { getSharedDevice, hasSharedDevice, releaseSharedDevice } from './wgsl/gpu-device-factory.js'
+
+// Extension version
+export const VERSION = '0.1.0'
+
+// Store reference to hydra instance
+let _hydra = null
+
+/**
+ * Fixed RAF loop implementation
+ * Replaces vanilla hydra's loop which has timing issues
+ */
+function createLoop(fn) {
+  let running = false
+  let lastTime = performance.now()
+  let rafId = null
+
+  function tick() {
+    if (!running) return
+    const now = performance.now()
+    const dt = now - lastTime
+    lastTime = now
+    fn(dt)
+    rafId = requestAnimationFrame(tick)
+  }
+
+  return {
+    start() {
+      if (running) return this
+      running = true
+      lastTime = performance.now()
+      rafId = requestAnimationFrame(tick)
+      return this
+    },
+    stop() {
+      running = false
+      if (rafId) cancelAnimationFrame(rafId)
+      return this
+    }
+  }
+}
+
+/**
+ * Install the vertex shader extension into a Hydra instance
+ */
+export function install(hydra, options = {}) {
+  console.log(`[hydra-vertex] Installing vertex shader extension v${VERSION}`)
+
+  _hydra = hydra
+  const synth = hydra.synth
+
+  if (!synth) {
+    console.error('[hydra-vertex] Could not find hydra.synth')
+    return false
+  }
+
+  // Fix vanilla hydra's raf loop timing issues
+  if (hydra.looper) {
+    hydra.looper.stop()
+    hydra.looper = createLoop(hydra.tick.bind(hydra)).start()
+    console.log('[hydra-vertex] Replaced animation loop with fixed version')
+  }
+
+  // Register geometry functions as globals
+  registerGeometryFunctions(synth)
+
+  // Register lighting functions
+  registerLightingFunctions(synth)
+
+  // Register varying proxy
+  synth.v = v
+  if (typeof window !== 'undefined') {
+    window.v = v
+  }
+
+  // Replace GlslSource prototype methods with vertex-shader branch versions
+  patchGlslSource(hydra)
+
+  // Replace Output prototype methods with vertex-shader branch versions
+  patchOutput(hydra)
+
+  // Patch hush() to clear sprites
+  patchHush(hydra)
+
+  // Add ResizeObserver to handle canvas resize automatically
+  setupResizeObserver(hydra)
+
+  console.log('[hydra-vertex] Extension installed successfully')
+  return true
+}
+
+/**
+ * Setup ResizeObserver to automatically update resolution when canvas resizes
+ */
+function setupResizeObserver(hydra) {
+  const canvas = hydra.canvas
+  if (!canvas || typeof ResizeObserver === 'undefined') return
+
+  const observer = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      // Get the new display size
+      const width = Math.round(entry.contentRect.width * (window.devicePixelRatio || 1))
+      const height = Math.round(entry.contentRect.height * (window.devicePixelRatio || 1))
+
+      // Only update if size actually changed
+      if (canvas.width !== width || canvas.height !== height) {
+        console.log(`[hydra-vertex] Canvas resized: ${width}x${height}`)
+        hydra.setResolution(width, height)
+      }
+    }
+  })
+
+  observer.observe(canvas)
+
+  // Store observer for potential cleanup
+  hydra._vertexResizeObserver = observer
+}
+
+/**
+ * Register geometry creation functions as globals
+ */
+function registerGeometryFunctions(synth) {
+  const geometryFunctions = {
+    tri, quad, poly, circle, line, ring,
+    cube, sphere, plane, torus, cylinder, cone,
+    parseObj, loadObj, parseGlb, loadGlb
+  }
+
+  for (const [name, fn] of Object.entries(geometryFunctions)) {
+    synth[name] = fn
+    if (typeof window !== 'undefined') {
+      window[name] = fn
+    }
+  }
+  console.log('[hydra-vertex] Registered geometry functions')
+}
+
+/**
+ * Register lighting functions (diffuse, specular, fresnel, etc.)
+ */
+function registerLightingFunctions(synth) {
+  for (const fn of lightingFunctions) {
+    synth.setFunction(fn)
+  }
+  console.log('[hydra-vertex] Registered lighting functions')
+}
+
+/**
+ * Patch GlslSource prototype with methods from vertex-shaders branch
+ */
+function patchGlslSource(hydra) {
+  const testSource = hydra.synth.osc ? hydra.synth.osc() : null
+  if (!testSource) return
+
+  const GlslSourceProto = Object.getPrototypeOf(testSource)
+
+  // Copy all methods from our GlslSource to the existing prototype
+  GlslSourceProto.out = GlslSource.prototype.out
+  GlslSourceProto.glsl = GlslSource.prototype.glsl
+  GlslSourceProto.compile = GlslSource.prototype.compile
+
+  console.log('[hydra-vertex] GlslSource patched')
+}
+
+/**
+ * Patch Output prototype with methods from vertex-shaders branch
+ */
+function patchOutput(hydra) {
+  const output = hydra.o[0]
+  if (!output) return
+
+  const OutputProto = Object.getPrototypeOf(output)
+
+  // Copy all methods from our Output to the existing prototype
+  OutputProto.registerSprite = Output.prototype.registerSprite
+  OutputProto.enableDepthBuffer = Output.prototype.enableDepthBuffer
+  OutputProto._renderSprites = Output.prototype._renderSprites
+  OutputProto.clearSprites = Output.prototype.clearSprites
+  OutputProto.removeSprite = Output.prototype.removeSprite
+  OutputProto.enableSprite = Output.prototype.enableSprite
+  OutputProto.disableSprite = Output.prototype.disableSprite
+  OutputProto.tick = Output.prototype.tick
+  OutputProto.render = Output.prototype.render
+
+  // Initialize each output with vertex-shader branch properties
+  for (const o of hydra.o) {
+    // Default fullscreen triangle using vec3
+    o.defaultPositionBuffer = o.regl.buffer([
+      [-2, 0, 0],
+      [0, -2, 0],
+      [2, 2, 0]
+    ])
+    o.positionBuffer = o.defaultPositionBuffer
+
+    // Sprite registry
+    o.sprites = new Map()
+    o.hasDepthBuffer = false
+
+    // Update the vertex shader to use vec3 positions
+    o.vert = `
+    precision ${o.precision} float;
+    attribute vec3 position;
+    varying vec2 uv;
+    varying float v_faceId;
+
+    // Vertex data for fragment shader (default values for fullscreen quad)
+    varying vec3 v_position;
+    varying vec3 v_normal;
+    varying vec3 v_worldNormal;
+    varying vec3 v_tangent;
+    varying vec3 v_bitangent;
+    varying vec3 v_viewDir;
+    varying float v_depth;
+
+    void main () {
+      uv = position.xy;
+      v_faceId = 0.0;
+
+      // Default vertex data for fullscreen quad
+      v_position = vec3(position.xy * 2.0 - 1.0, 0.0);
+      v_normal = vec3(0.0, 0.0, 1.0);
+      v_worldNormal = vec3(0.0, 0.0, 1.0);
+      v_tangent = vec3(1.0, 0.0, 0.0);
+      v_bitangent = vec3(0.0, 1.0, 0.0);
+      v_viewDir = vec3(0.0, 0.0, 1.0);
+      v_depth = 1.0;
+
+      gl_Position = vec4(2.0 * position.xy - 1.0, 0, 1);
+    }`
+
+    // Create copy command for persistence/trails
+    o.copyCommand = o.regl({
+      frag: `
+        precision ${o.precision} float;
+        uniform sampler2D source;
+        varying vec2 uv;
+        void main () {
+          gl_FragColor = texture2D(source, uv);
+        }
+      `,
+      vert: o.vert,
+      attributes: {
+        position: o.defaultPositionBuffer
+      },
+      uniforms: {
+        source: o.regl.prop('source')
+      },
+      count: 3,
+      depth: { enable: false }
+    })
+  }
+
+  console.log('[hydra-vertex] Output patched')
+}
+
+/**
+ * Patch hush() to clear all sprites before resetting
+ */
+function patchHush(hydra) {
+  hydra.hush = function() {
+    // Clear sources
+    hydra.s.forEach((source) => {
+      source.clear()
+    })
+    // Clear all sprite levels and reset to blank
+    hydra.o.forEach((output) => {
+      if (output.clearSprites) {
+        output.clearSprites()
+      }
+      // Clear the framebuffers directly instead of registering a sprite
+      if (output.fbos) {
+        output.fbos.forEach(fbo => {
+          output.regl.clear({
+            color: [0, 0, 0, 1],
+            depth: 1,
+            framebuffer: fbo
+          })
+        })
+      }
+    })
+    hydra.synth.render(hydra.o[0])
+    if (hydra.sandbox) {
+      hydra.sandbox.set('update', (dt) => {})
+      hydra.sandbox.set('afterUpdate', (dt) => {})
+    }
+  }
+
+  // Also update the sandbox reference
+  if (hydra.sandbox) {
+    hydra.sandbox.set('hush', hydra.hush)
+  }
+
+  console.log('[hydra-vertex] hush() patched')
+}
+
+/**
+ * Cleanup extension resources
+ */
+export function cleanup(hydra) {
+  hydra = hydra || _hydra
+  if (!hydra) return
+
+  for (const output of hydra.o) {
+    if (output && output.sprites) {
+      output.clearSprites()
+    }
+  }
+}
+
+// Re-export for direct import
+export {
+  tri, quad, poly, circle, line, ring,
+  cube, sphere, plane, torus, cylinder, cone,
+  parseObj, loadObj, parseGlb, loadGlb,
+  VertexSource, v,
+  // WebGPU utilities
+  getSharedDevice, hasSharedDevice, releaseSharedDevice
+}

--- a/extensions/vertex/lighting-functions.js
+++ b/extensions/vertex/lighting-functions.js
@@ -1,0 +1,89 @@
+// Lighting functions for vertex shader extension
+// These use vertex data (normals, view direction) for shading effects
+
+export default [
+  {
+    name: 'diffuse',
+    type: 'color',
+    inputs: [
+      { type: 'float', name: 'lx', default: 0 },
+      { type: 'float', name: 'ly', default: 1 },
+      { type: 'float', name: 'lz', default: 0 },
+      { type: 'float', name: 'ambient', default: 0.2 }
+    ],
+    glsl: `
+      vec3 lightDir = normalize(vec3(lx, ly, lz));
+      vec3 normal = normalize(v_worldNormal);
+      float diff = max(0.0, dot(normal, lightDir));
+      float lighting = ambient + (1.0 - ambient) * diff;
+      return vec4(_c0.rgb * lighting, _c0.a);`,
+    wgsl: `
+      let lightDir = normalize(vec3<f32>(lx, ly, lz));
+      let normal = normalize(v_worldNormal);
+      let diff = max(0.0, dot(normal, lightDir));
+      let lighting = ambient + (1.0 - ambient) * diff;
+      return vec4<f32>(_c0.rgb * lighting, _c0.a);`
+  },
+  {
+    name: 'specular',
+    type: 'color',
+    inputs: [
+      { type: 'float', name: 'lx', default: 0 },
+      { type: 'float', name: 'ly', default: 1 },
+      { type: 'float', name: 'lz', default: 0 },
+      { type: 'float', name: 'shininess', default: 32 },
+      { type: 'float', name: 'intensity', default: 1 }
+    ],
+    glsl: `
+      vec3 lightDir = normalize(vec3(lx, ly, lz));
+      vec3 normal = normalize(v_worldNormal);
+      vec3 viewDir = normalize(v_viewDir);
+      vec3 halfDir = normalize(lightDir + viewDir);
+      float spec = pow(max(0.0, dot(normal, halfDir)), shininess) * intensity;
+      return vec4(_c0.rgb + spec, _c0.a);`,
+    wgsl: `
+      let lightDir = normalize(vec3<f32>(lx, ly, lz));
+      let normal = normalize(v_worldNormal);
+      let viewDir = normalize(v_viewDir);
+      let halfDir = normalize(lightDir + viewDir);
+      let spec = pow(max(0.0, dot(normal, halfDir)), shininess) * intensity;
+      return vec4<f32>(_c0.rgb + spec, _c0.a);`
+  },
+  {
+    name: 'fresnel',
+    type: 'color',
+    inputs: [
+      { type: 'float', name: 'power', default: 2 },
+      { type: 'float', name: 'intensity', default: 1 }
+    ],
+    glsl: `
+      vec3 normal = normalize(v_worldNormal);
+      vec3 viewDir = normalize(v_viewDir);
+      float f = pow(1.0 - abs(dot(normal, viewDir)), power) * intensity;
+      return vec4(_c0.rgb + f, _c0.a);`,
+    wgsl: `
+      let normal = normalize(v_worldNormal);
+      let viewDir = normalize(v_viewDir);
+      let f = pow(1.0 - abs(dot(normal, viewDir)), power) * intensity;
+      return vec4<f32>(_c0.rgb + f, _c0.a);`
+  },
+  {
+    name: 'halfLambert',
+    type: 'color',
+    inputs: [
+      { type: 'float', name: 'lx', default: 0 },
+      { type: 'float', name: 'ly', default: 1 },
+      { type: 'float', name: 'lz', default: 0 }
+    ],
+    glsl: `
+      vec3 lightDir = normalize(vec3(lx, ly, lz));
+      vec3 normal = normalize(v_worldNormal);
+      float diff = dot(normal, lightDir) * 0.5 + 0.5;
+      return vec4(_c0.rgb * diff, _c0.a);`,
+    wgsl: `
+      let lightDir = normalize(vec3<f32>(lx, ly, lz));
+      let normal = normalize(v_worldNormal);
+      let diff = dot(normal, lightDir) * 0.5 + 0.5;
+      return vec4<f32>(_c0.rgb * diff, _c0.a);`
+  }
+]

--- a/extensions/vertex/output.js
+++ b/extensions/vertex/output.js
@@ -1,0 +1,759 @@
+import VertexSource, { generateVertexGlsl } from './vertex-source.js'
+import { computeSkinningMatrices, applySkinning } from './geometry.js'
+
+// Blend mode configurations for regl
+const BLEND_MODES = {
+  normal: {
+    enable: true,
+    func: {
+      srcRGB: 'src alpha',
+      srcAlpha: 1,
+      dstRGB: 'one minus src alpha',
+      dstAlpha: 'one minus src alpha'
+    }
+  },
+  add: {
+    enable: true,
+    func: {
+      srcRGB: 'src alpha',
+      srcAlpha: 1,
+      dstRGB: 'one',
+      dstAlpha: 'one'
+    }
+  },
+  multiply: {
+    enable: true,
+    func: {
+      srcRGB: 'dst color',
+      srcAlpha: 1,
+      dstRGB: 'zero',
+      dstAlpha: 'one'
+    }
+  },
+  screen: {
+    enable: true,
+    func: {
+      srcRGB: 'one',
+      srcAlpha: 1,
+      dstRGB: 'one minus src color',
+      dstAlpha: 'one'
+    }
+  }
+}
+
+var Output = function ({ regl, precision, label = "", chanNum, hydraSynth, width, height}) {
+  this.regl = regl
+  this.precision = precision
+  this.label = label
+  this.chanNum = chanNum
+  this.hydraSynth = hydraSynth
+
+  // Default fullscreen triangle (covers clip space with overdraw)
+  // Using vec3 for forward compatibility with 3D (z=0 for 2D)
+  this.defaultPositionBuffer = this.regl.buffer([
+    [-2, 0, 0],
+    [0, -2, 0],
+    [2, 2, 0]
+  ])
+  // Keep for backwards compatibility
+  this.positionBuffer = this.defaultPositionBuffer
+
+  // Sprite registry: Map<spriteLevel, SpriteConfig>
+  this.sprites = new Map()
+
+  this.draw = () => {}
+  this.init()
+  this.pingPongIndex = 0
+
+  // for each output, create two fbos for pingponging
+  // Depth buffer added lazily when 3D geometry is first used
+  this.hasDepthBuffer = false
+  this.fbos = (Array(2)).fill().map(() => this.regl.framebuffer({
+    color: this.regl.texture({
+      mag: 'nearest',
+      width: width,
+      height: height,
+      format: 'rgba'
+    }),
+    depthStencil: false
+  }))
+
+  // array containing render passes
+//  this.passes = []
+}
+
+Output.prototype.resize = function(width, height) {
+  // Guard against invalid dimensions
+  if (!width || !height || width <= 0 || height <= 0) {
+    console.warn(`[Output] resize called with invalid dimensions: ${width}x${height}`)
+    return
+  }
+  this.fbos.forEach((fbo) => {
+    fbo.resize(width, height)
+  })
+//  console.log(this)
+}
+
+// Lazily enable depth buffer for 3D rendering
+// Called automatically when 3D geometry is first registered
+Output.prototype.enableDepthBuffer = function() {
+  if (this.hasDepthBuffer) return  // Already enabled
+
+  // Get current dimensions from existing fbo
+  const width = this.fbos[0].width
+  const height = this.fbos[0].height
+
+  // Destroy old framebuffers
+  this.fbos.forEach(fbo => fbo.destroy())
+
+  // Create new framebuffers with depth
+  this.fbos = (Array(2)).fill().map(() => this.regl.framebuffer({
+    color: this.regl.texture({
+      mag: 'nearest',
+      width: width,
+      height: height,
+      format: 'rgba'
+    }),
+    depth: true
+  }))
+
+  this.hasDepthBuffer = true
+}
+
+Output.prototype.getCurrent = function () {
+  return this.fbos[this.pingPongIndex]
+}
+
+Output.prototype.getTexture = function () {
+   var index = this.pingPongIndex ? 0 : 1
+  return this.fbos[index]
+}
+
+Output.prototype.init = function () {
+//  console.log('clearing')
+  this.transformIndex = 0
+  this.fragHeader = `
+  precision ${this.precision} float;
+
+  uniform float time;
+  varying vec2 uv;
+  `
+
+  this.fragBody = ``
+
+  // Vertex shader uses vec3 for forward compatibility with 3D
+  this.vert = `
+  precision ${this.precision} float;
+  attribute vec3 position;
+  varying vec2 uv;
+  varying float v_faceId;
+
+  // Vertex data for fragment shader (default values for fullscreen quad)
+  varying vec3 v_position;
+  varying vec3 v_normal;
+  varying vec3 v_worldNormal;
+  varying vec3 v_tangent;
+  varying vec3 v_bitangent;
+  varying vec3 v_viewDir;
+  varying float v_depth;
+
+  void main () {
+    uv = position.xy;
+    v_faceId = 0.0;
+
+    // Default vertex data for fullscreen quad
+    v_position = vec3(position.xy * 2.0 - 1.0, 0.0);
+    v_normal = vec3(0.0, 0.0, 1.0);
+    v_worldNormal = vec3(0.0, 0.0, 1.0);
+    v_tangent = vec3(1.0, 0.0, 0.0);
+    v_bitangent = vec3(0.0, 1.0, 0.0);
+    v_viewDir = vec3(0.0, 0.0, 1.0);
+    v_depth = 1.0;
+
+    gl_Position = vec4(2.0 * position.xy - 1.0, 0, 1);
+  }`
+
+  this.attributes = {
+    position: this.positionBuffer
+  }
+  this.uniforms = {
+    time: this.regl.prop('time'),
+    resolution: this.regl.prop('resolution')
+  }
+
+  this.frag = `
+       ${this.fragHeader}
+
+      void main () {
+        vec4 c = vec4(0, 0, 0, 0);
+        vec2 st = uv;
+        ${this.fragBody}
+        gl_FragColor = c;
+      }
+  `
+
+  // Create copy command for persistence (no level 0 = keep previous frame)
+  this.copyCommand = this.regl({
+    frag: `
+      precision ${this.precision} float;
+      uniform sampler2D source;
+      varying vec2 uv;
+      void main () {
+        gl_FragColor = texture2D(source, uv);
+      }
+    `,
+    vert: this.vert,
+    attributes: {
+      position: this.defaultPositionBuffer
+    },
+    uniforms: {
+      source: this.regl.prop('source')
+    },
+    count: 3,
+    depth: { enable: false }
+  })
+
+  return this
+}
+
+
+// Reshape vertex data to vec3 format for forward compatibility with 3D
+// Input: flat array of 2D coords [x,y, x,y, ...] or 3D coords [x,y,z, x,y,z, ...]
+// Output: array of [x,y,z] triples
+// is3D: explicit flag indicating 3D data (required for ambiguous lengths like 108 which is divisible by both 2 and 3)
+function reshapeToVec3(flatArray, is3D = false) {
+  const len = flatArray.length
+  const stride = is3D ? 3 : 2
+
+  const verts = []
+  for (let i = 0; i < len; i += stride) {
+    if (is3D) {
+      verts.push([flatArray[i], flatArray[i + 1], flatArray[i + 2]])
+    } else {
+      // 2D input: add z=0
+      verts.push([flatArray[i], flatArray[i + 1], 0.0])
+    }
+  }
+  return verts
+}
+
+// Helper to normalize vertex option values (handles scalars, arrays, and lambdas)
+function normalizeVertexOption(value, defaultValue) {
+  if (value === undefined || value === null) return defaultValue
+  return value
+}
+
+// Register a sprite at a given level
+// spriteLevel 0 clears the buffer before drawing
+// spriteLevel 1+ composites over previous content
+Output.prototype.registerSprite = function (spriteLevel, config) {
+  const { passes, vertexData, blendMode = 'normal', vertexOptions = null, primitive = 'triangles', sprite = null, enabled = true } = config
+  const pass = passes[0]
+  const self = this
+
+  // Extract raw vertices and check for VertexSource
+  let rawVerts = null
+  let vertexSource = null
+  let has3D = false
+
+  if (vertexData instanceof VertexSource) {
+    vertexSource = vertexData
+    rawVerts = vertexData.vertices
+    has3D = vertexData.is3D || false
+  } else if (vertexData && Array.isArray(vertexData)) {
+    rawVerts = vertexData
+  }
+
+  // Enable depth buffer lazily for 3D geometry
+  if (has3D) {
+    this.enableDepthBuffer()
+  }
+
+  // Create vertex buffer for this sprite
+  let positionBuffer, uvBuffer, faceIdBuffer, normalBuffer, tangentBuffer, colorBuffer, vertexCount
+  let bounds = { minX: -1, maxX: 1, minY: -1, maxY: 1 }  // default fullscreen bounds
+  let hasExplicitUVs = false
+  let hasFaceIds = false
+  let hasNormals = false
+  let hasTangents = false
+  let hasColors = false
+
+  if (rawVerts && rawVerts.length >= 6) {
+    // Custom geometry: reshape to vec3 for 3D forward-compatibility
+    const verts = reshapeToVec3(rawVerts, has3D)
+    positionBuffer = this.regl.buffer(verts)
+    vertexCount = verts.length
+
+    // Check for explicit UVs from VertexSource (e.g., cube)
+    if (vertexSource && vertexSource.uvs && vertexSource.uvs.length > 0) {
+      hasExplicitUVs = true
+      // Reshape UVs to vec2 array
+      const uvData = []
+      for (let i = 0; i < vertexSource.uvs.length; i += 2) {
+        uvData.push([vertexSource.uvs[i], vertexSource.uvs[i + 1]])
+      }
+      uvBuffer = this.regl.buffer(uvData)
+    } else {
+      // Compute bounds for UV normalization
+      bounds = { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity }
+      for (const v of verts) {
+        bounds.minX = Math.min(bounds.minX, v[0])
+        bounds.maxX = Math.max(bounds.maxX, v[0])
+        bounds.minY = Math.min(bounds.minY, v[1])
+        bounds.maxY = Math.max(bounds.maxY, v[1])
+      }
+    }
+
+    // Check for face IDs from VertexSource (e.g., cube for per-face materials)
+    if (vertexSource && vertexSource.faceIds && vertexSource.faceIds.length > 0) {
+      hasFaceIds = true
+      // Wrap each faceId in array for explicit per-vertex scalar format
+      // This matches how position [[x,y,z],...] and texcoord [[u,v],...] are structured
+      faceIdBuffer = this.regl.buffer(vertexSource.faceIds.map(id => [id]))
+    }
+
+    // Check for normals from VertexSource (e.g., from GLB/OBJ models)
+    if (vertexSource && vertexSource.normals && vertexSource.normals.length > 0) {
+      hasNormals = true
+      // Reshape normals to vec3 array
+      const normalData = []
+      for (let i = 0; i < vertexSource.normals.length; i += 3) {
+        normalData.push([vertexSource.normals[i], vertexSource.normals[i + 1], vertexSource.normals[i + 2]])
+      }
+      normalBuffer = this.regl.buffer(normalData)
+    }
+
+    // Check for tangents from VertexSource (vec4: xyz = tangent, w = handedness)
+    if (vertexSource && vertexSource.tangents && vertexSource.tangents.length > 0) {
+      hasTangents = true
+      // Reshape tangents to vec4 array
+      const tangentData = []
+      for (let i = 0; i < vertexSource.tangents.length; i += 4) {
+        tangentData.push([vertexSource.tangents[i], vertexSource.tangents[i + 1], vertexSource.tangents[i + 2], vertexSource.tangents[i + 3]])
+      }
+      tangentBuffer = this.regl.buffer(tangentData)
+    }
+
+    // Check for vertex colors from VertexSource (vec4: RGBA)
+    if (vertexSource && vertexSource.colors && vertexSource.colors.length > 0) {
+      hasColors = true
+      // Reshape colors to vec4 array
+      const colorData = []
+      for (let i = 0; i < vertexSource.colors.length; i += 4) {
+        colorData.push([vertexSource.colors[i], vertexSource.colors[i + 1], vertexSource.colors[i + 2], vertexSource.colors[i + 3]])
+      }
+      colorBuffer = this.regl.buffer(colorData)
+    }
+  } else {
+    // Default fullscreen triangle
+    positionBuffer = this.defaultPositionBuffer
+    vertexCount = 3
+  }
+
+  // Check if we need vertex transforms (from vertexOptions OR VertexSource chain)
+  const hasChainedTransforms = vertexSource && vertexSource.hasTransforms
+  const hasVertexOptions = rawVerts && vertexOptions && (
+    vertexOptions.scale !== undefined ||
+    vertexOptions.offset !== undefined ||
+    vertexOptions.rotation !== undefined
+  )
+  const hasVertexTransforms = hasChainedTransforms || hasVertexOptions
+
+  // Build uniforms with prevBuffer and resolution (for aspect ratio correction)
+  const uniforms = Object.assign({}, pass.uniforms, {
+    prevBuffer: () => self.fbos[self.pingPongIndex],
+    resolution: this.regl.prop('resolution')
+  })
+
+  // Add sprite UV uniform (default = full texture)
+  if (sprite && sprite.getUVBounds) {
+    // Dynamic sprite picker - call getUVBounds each frame
+    uniforms.u_spriteUV = () => {
+      const bounds = sprite.getUVBounds()
+      return [bounds.uMin, bounds.vMin, bounds.uMax, bounds.vMax]
+    }
+  } else {
+    // No sprite picking - use full texture
+    uniforms.u_spriteUV = [0, 0, 1, 1]
+  }
+
+  // Add sprite grid uniform for faceId-based picking
+  // If sprite has grid info, use it; otherwise default to [1, 1] (single cell)
+  if (sprite && sprite.cols && sprite.rows) {
+    uniforms.u_spriteGrid = [sprite.cols, sprite.rows]
+  } else {
+    uniforms.u_spriteGrid = [1, 1]
+  }
+
+  // Add bounds uniforms for UV normalization (custom geometry only)
+  if (rawVerts) {
+    uniforms.u_boundsMin = [bounds.minX, bounds.minY]
+    uniforms.u_boundsMax = [bounds.maxX, bounds.maxY]
+  }
+
+  // Add vertex transform uniforms if needed (Phase 3 style only)
+  // Phase 5 chained transforms get uniforms from generateVertexGlsl
+  if (hasVertexOptions) {
+    // Scale: can be number, [x,y] array, or lambda
+    const scaleOpt = normalizeVertexOption(vertexOptions.scale, [1, 1])
+    uniforms.u_scale = (context, props) => {
+      const val = typeof scaleOpt === 'function' ? scaleOpt() : scaleOpt
+      if (typeof val === 'number') return [val, val]
+      return val
+    }
+
+    // Offset: can be [x,y] array or lambda
+    const offsetOpt = normalizeVertexOption(vertexOptions.offset, [0, 0])
+    uniforms.u_offset = (context, props) => {
+      const val = typeof offsetOpt === 'function' ? offsetOpt() : offsetOpt
+      return val
+    }
+
+    // Rotation: can be number (radians) or lambda
+    const rotationOpt = normalizeVertexOption(vertexOptions.rotation, 0)
+    uniforms.u_rotation = (context, props) => {
+      const val = typeof rotationOpt === 'function' ? rotationOpt() : rotationOpt
+      return val
+    }
+  }
+
+  // Create vertex shader based on whether we have custom geometry
+  let vert
+  let vertexUniforms = {}
+
+  if (rawVerts) {
+    if (hasChainedTransforms) {
+      // Use generateVertexGlsl for chained transforms (Phase 5)
+      const generated = generateVertexGlsl(vertexSource, this.precision, { useExplicitUVs: hasExplicitUVs, useFaceIds: hasFaceIds, useNormals: hasNormals, useTangents: hasTangents, useColors: hasColors })
+      vert = generated.glsl
+      vertexUniforms = generated.uniforms
+    } else if (hasVertexOptions) {
+      // Custom geometry with vertexOptions (Phase 3 style)
+      const uvAttrDecl = hasExplicitUVs ? 'attribute vec2 texcoord;' : ''
+      const faceIdAttrDecl = hasFaceIds ? 'attribute float faceId;' : ''
+      const uvCode = hasExplicitUVs
+        ? 'uv = texcoord;'
+        : 'uv = (position.xy - u_boundsMin) / (u_boundsMax - u_boundsMin);'
+      const faceIdCode = hasFaceIds ? 'v_faceId = faceId;' : 'v_faceId = 0.0;'
+      vert = `
+      precision ${this.precision} float;
+      attribute vec3 position;
+      ${uvAttrDecl}
+      ${faceIdAttrDecl}
+      varying vec2 uv;
+      varying float v_faceId;
+
+      // Vertex data for fragment shader
+      varying vec3 v_position;
+      varying vec3 v_normal;
+      varying vec3 v_viewDir;
+      varying float v_depth;
+
+      uniform vec2 u_scale;
+      uniform vec2 u_offset;
+      uniform float u_rotation;
+      uniform vec2 u_boundsMin;
+      uniform vec2 u_boundsMax;
+
+      void main () {
+        // UV ${hasExplicitUVs ? 'from explicit attribute' : 'normalized to shape bounds'}
+        ${uvCode}
+        ${faceIdCode}
+
+        // Apply transforms
+        vec2 pos = position.xy * u_scale;
+
+        // Rotation around origin
+        float c = cos(u_rotation);
+        float s = sin(u_rotation);
+        pos = vec2(pos.x * c - pos.y * s, pos.x * s + pos.y * c);
+
+        // Offset
+        pos += u_offset;
+
+        // Default vertex data for 2D geometry
+        v_position = vec3(pos, 0.0);
+        v_normal = vec3(0.0, 0.0, 1.0);
+        v_viewDir = vec3(0.0, 0.0, 1.0);
+        v_depth = 1.0;
+
+        gl_Position = vec4(pos, 0.0, 1.0);
+        gl_PointSize = 2.0;
+      }`
+    } else {
+      // Custom geometry without transforms: simple passthrough
+      const uvAttrDecl = hasExplicitUVs ? 'attribute vec2 texcoord;' : ''
+      const faceIdAttrDecl = hasFaceIds ? 'attribute float faceId;' : ''
+      const normalAttrDecl = hasNormals ? 'attribute vec3 normal;' : ''
+      const uvCode = hasExplicitUVs
+        ? 'uv = texcoord;'
+        : 'uv = (position.xy - u_boundsMin) / (u_boundsMax - u_boundsMin);'
+      const faceIdCode = hasFaceIds ? 'v_faceId = faceId;' : 'v_faceId = 0.0;'
+      const normalCode = hasNormals ? 'v_normal = normalize(normal);' : 'v_normal = vec3(0.0, 0.0, 1.0);'
+      const positionCode = has3D ? 'v_position = position;' : 'v_position = vec3(position.xy, 0.0);'
+      const glPositionCode = has3D
+        ? `float aspect = resolution.x / resolution.y;
+        gl_Position = vec4(position.x / aspect, position.y, position.z * 0.1, 1.0);`
+        : 'gl_Position = vec4(position.xy, 0.0, 1.0);'
+      vert = `
+      precision ${this.precision} float;
+      attribute vec3 position;
+      ${uvAttrDecl}
+      ${faceIdAttrDecl}
+      ${normalAttrDecl}
+      varying vec2 uv;
+      varying float v_faceId;
+
+      // Vertex data for fragment shader
+      varying vec3 v_position;
+      varying vec3 v_normal;
+      varying vec3 v_worldNormal;
+      varying vec3 v_viewDir;
+      varying float v_depth;
+
+      uniform vec2 u_boundsMin;
+      uniform vec2 u_boundsMax;
+      uniform vec2 resolution;
+
+      void main () {
+        // UV ${hasExplicitUVs ? 'from explicit attribute' : 'normalized to shape bounds'}
+        ${uvCode}
+        ${faceIdCode}
+
+        // Vertex data
+        ${positionCode}
+        ${normalCode}
+        v_worldNormal = v_normal;
+        v_viewDir = vec3(0.0, 0.0, 1.0);
+        v_depth = 1.0;
+
+        ${glPositionCode}
+        gl_PointSize = 2.0;
+      }`
+    }
+  } else {
+    // Fullscreen: use original vertex shader
+    vert = this.vert
+  }
+
+  // Merge vertex uniforms with fragment uniforms
+  Object.assign(uniforms, vertexUniforms)
+
+  // Build attributes object
+  const attributes = {
+    position: positionBuffer
+  }
+  if (hasExplicitUVs && uvBuffer) {
+    attributes.texcoord = uvBuffer
+  }
+  if (hasFaceIds && faceIdBuffer) {
+    attributes.faceId = faceIdBuffer
+  }
+  if (hasNormals && normalBuffer) {
+    attributes.normal = normalBuffer
+  }
+  if (hasTangents && tangentBuffer) {
+    attributes.tangent = tangentBuffer
+  }
+  if (hasColors && colorBuffer) {
+    attributes.color = colorBuffer
+  }
+
+  // Create the draw command
+  const drawCommand = this.regl({
+    frag: pass.frag,
+    vert: vert,
+    attributes: attributes,
+    uniforms: uniforms,
+    count: vertexCount,
+    primitive: primitive,
+    blend: BLEND_MODES[blendMode] || BLEND_MODES.normal,
+    depth: { enable: has3D, func: 'less' }
+  })
+
+  // Store sprite config
+  const spriteConfig = {
+    drawCommand,
+    positionBuffer,
+    normalBuffer,
+    blendMode,
+    has3D,
+    enabled
+  }
+
+  // Store animation data if present
+  if (vertexSource && vertexSource._animTimeFunc) {
+    spriteConfig.animation = {
+      skeleton: vertexSource._skeleton,
+      animations: vertexSource._animations,
+      clipName: vertexSource._animClip,
+      timeFunc: vertexSource._animTimeFunc,
+      originalVerts: vertexSource._originalVerts || vertexSource.vertices,
+      originalNormals: vertexSource._originalNormals || vertexSource.normals,
+      joints: vertexSource.joints,
+      weights: vertexSource.weights,
+      gltf: vertexSource._gltf,
+      normCenter: vertexSource._normCenter,  // For denormalize/renormalize during skinning
+      normScale: vertexSource._normScale,
+      is3D: has3D
+    }
+  }
+
+  this.sprites.set(spriteLevel, spriteConfig)
+}
+
+// Clear all sprites (called by hush)
+Output.prototype.clearSprites = function () {
+  // Clean up any custom position buffers
+  for (const [level, sprite] of this.sprites) {
+    if (sprite.positionBuffer !== this.defaultPositionBuffer) {
+      sprite.positionBuffer.destroy()
+    }
+  }
+  this.sprites.clear()
+}
+
+// Remove a specific sprite level
+Output.prototype.removeSprite = function (level) {
+  if (this.sprites.has(level)) {
+    const sprite = this.sprites.get(level)
+    if (sprite.positionBuffer !== this.defaultPositionBuffer) {
+      sprite.positionBuffer.destroy()
+    }
+    this.sprites.delete(level)
+  }
+}
+
+// Enable/disable a sprite level (keeps it registered but skips rendering)
+Output.prototype.enableSprite = function (level, enabled = true) {
+  if (this.sprites.has(level)) {
+    this.sprites.get(level).enabled = enabled
+  }
+}
+
+Output.prototype.disableSprite = function (level) {
+  this.enableSprite(level, false)
+}
+
+// Legacy render method - registers at sprite level 0
+Output.prototype.render = function (passes) {
+  // Clear existing sprite at level 0 and register new one
+  if (this.sprites.has(0)) {
+    const oldSprite = this.sprites.get(0)
+    if (oldSprite.positionBuffer !== this.defaultPositionBuffer) {
+      oldSprite.positionBuffer.destroy()
+    }
+  }
+  this.registerSprite(0, { passes, vertexData: null, blendMode: 'normal' })
+
+  // For backwards compatibility, also set this.draw
+  const self = this
+  this.draw = function(props) {
+    self._renderSprites(props)
+  }
+}
+
+// Internal method to render all sprites in order
+Output.prototype._renderSprites = function (props) {
+  if (this.sprites.size === 0) return
+
+  // Sort sprite levels ascending
+  const levels = Array.from(this.sprites.keys()).sort((a, b) => a - b)
+
+  // Swap ping-pong index once at start of frame
+  this.pingPongIndex = this.pingPongIndex ? 0 : 1
+  const targetFbo = this.fbos[this.pingPongIndex]
+  const prevFbo = this.fbos[this.pingPongIndex ? 0 : 1]
+
+  // Check if we have an enabled level 0 (which clears)
+  const level0Sprite = this.sprites.get(0)
+  const hasLevel0 = levels.includes(0) && level0Sprite && level0Sprite.enabled !== false
+
+  // Check if any sprite uses 3D (needs depth clearing)
+  const needs3D = Array.from(this.sprites.values()).some(s => s.has3D)
+
+  // If no level 0, copy previous frame for persistence/trails
+  // If level 0 exists, clear to start fresh
+  if (!hasLevel0) {
+    this.regl.clear({
+      color: [0, 0, 0, 0],
+      depth: needs3D ? 1 : undefined,
+      framebuffer: targetFbo
+    })
+    if (this.copyCommand) {
+      targetFbo.use(() => {
+        this.copyCommand({ source: prevFbo })
+      })
+    }
+  } else {
+    // Level 0 clears the framebuffer
+    this.regl.clear({
+      color: [0, 0, 0, 1],
+      depth: needs3D ? 1 : undefined,
+      framebuffer: targetFbo
+    })
+  }
+
+  // Render each sprite level
+  for (let i = 0; i < levels.length; i++) {
+    const level = levels[i]
+    const sprite = this.sprites.get(level)
+
+    // Skip disabled sprites
+    if (sprite.enabled === false) continue
+
+    // Update animation buffers if this sprite is animated
+    if (sprite.animation) {
+      const anim = sprite.animation
+      const time = typeof anim.timeFunc === 'function' ? anim.timeFunc() : 0
+
+      // Support dynamic clip name (function or string)
+      const clipName = typeof anim.clipName === 'function' ? anim.clipName() : anim.clipName
+
+      // Find clip and compute looped time (don't loop here - let timeFunc handle it for dynamic clips)
+      const clip = anim.animations.find(a => a.name === clipName) || anim.animations[0]
+      const loopedTime = clip ? (time % clip.duration) : time
+
+      // Compute skinning matrices (pre-transformed for normalized coordinate space)
+      const skinningMatrices = computeSkinningMatrices(
+        anim.skeleton, anim.animations, clipName, loopedTime, anim.gltf,
+        anim.normCenter, anim.normScale
+      )
+
+      if (skinningMatrices) {
+        // Apply skinning to vertices
+        const skinned = applySkinning(
+          anim.originalVerts, anim.originalNormals,
+          anim.joints, anim.weights, skinningMatrices
+        )
+
+        // Update position buffer with skinned vertices
+        const skinnedVec3 = []
+        for (let j = 0; j < skinned.vertices.length; j += 3) {
+          skinnedVec3.push([skinned.vertices[j], skinned.vertices[j + 1], skinned.vertices[j + 2]])
+        }
+        sprite.positionBuffer(skinnedVec3)
+
+        // Update normal buffer if present
+        if (sprite.normalBuffer && skinned.normals) {
+          const skinnedNormals = []
+          for (let j = 0; j < skinned.normals.length; j += 3) {
+            skinnedNormals.push([skinned.normals[j], skinned.normals[j + 1], skinned.normals[j + 2]])
+          }
+          sprite.normalBuffer(skinnedNormals)
+        }
+      }
+    }
+
+    // Draw to framebuffer
+    targetFbo.use(() => {
+      sprite.drawCommand(props)
+    })
+  }
+}
+
+Output.prototype.tick = function (props) {
+  this._renderSprites(props)
+}
+
+export default Output

--- a/extensions/vertex/utility-functions.js
+++ b/extensions/vertex/utility-functions.js
@@ -1,0 +1,111 @@
+// functions that are only used within other functions
+
+export default {
+  _luminance: {
+    type: 'util',
+    glsl: `float _luminance(vec3 rgb){
+      const vec3 W = vec3(0.2125, 0.7154, 0.0721);
+      return dot(rgb, W);
+    }`
+  },
+  _noise: {
+    type: 'util',
+    glsl: `
+    //	Simplex 3D Noise
+    //	by Ian McEwan, Ashima Arts
+    vec4 permute(vec4 x){return mod(((x*34.0)+1.0)*x, 289.0);}
+  vec4 taylorInvSqrt(vec4 r){return 1.79284291400159 - 0.85373472095314 * r;}
+
+  float _noise(vec3 v){
+    const vec2  C = vec2(1.0/6.0, 1.0/3.0) ;
+    const vec4  D = vec4(0.0, 0.5, 1.0, 2.0);
+
+  // First corner
+    vec3 i  = floor(v + dot(v, C.yyy) );
+    vec3 x0 =   v - i + dot(i, C.xxx) ;
+
+  // Other corners
+    vec3 g = step(x0.yzx, x0.xyz);
+    vec3 l = 1.0 - g;
+    vec3 i1 = min( g.xyz, l.zxy );
+    vec3 i2 = max( g.xyz, l.zxy );
+
+    //  x0 = x0 - 0. + 0.0 * C
+    vec3 x1 = x0 - i1 + 1.0 * C.xxx;
+    vec3 x2 = x0 - i2 + 2.0 * C.xxx;
+    vec3 x3 = x0 - 1. + 3.0 * C.xxx;
+
+  // Permutations
+    i = mod(i, 289.0 );
+    vec4 p = permute( permute( permute(
+               i.z + vec4(0.0, i1.z, i2.z, 1.0 ))
+             + i.y + vec4(0.0, i1.y, i2.y, 1.0 ))
+             + i.x + vec4(0.0, i1.x, i2.x, 1.0 ));
+
+  // Gradients
+  // ( N*N points uniformly over a square, mapped onto an octahedron.)
+    float n_ = 1.0/7.0; // N=7
+    vec3  ns = n_ * D.wyz - D.xzx;
+
+    vec4 j = p - 49.0 * floor(p * ns.z *ns.z);  //  mod(p,N*N)
+
+    vec4 x_ = floor(j * ns.z);
+    vec4 y_ = floor(j - 7.0 * x_ );    // mod(j,N)
+
+    vec4 x = x_ *ns.x + ns.yyyy;
+    vec4 y = y_ *ns.x + ns.yyyy;
+    vec4 h = 1.0 - abs(x) - abs(y);
+
+    vec4 b0 = vec4( x.xy, y.xy );
+    vec4 b1 = vec4( x.zw, y.zw );
+
+    vec4 s0 = floor(b0)*2.0 + 1.0;
+    vec4 s1 = floor(b1)*2.0 + 1.0;
+    vec4 sh = -step(h, vec4(0.0));
+
+    vec4 a0 = b0.xzyw + s0.xzyw*sh.xxyy ;
+    vec4 a1 = b1.xzyw + s1.xzyw*sh.zzww ;
+
+    vec3 p0 = vec3(a0.xy,h.x);
+    vec3 p1 = vec3(a0.zw,h.y);
+    vec3 p2 = vec3(a1.xy,h.z);
+    vec3 p3 = vec3(a1.zw,h.w);
+
+  //Normalise gradients
+    vec4 norm = taylorInvSqrt(vec4(dot(p0,p0), dot(p1,p1), dot(p2, p2), dot(p3,p3)));
+    p0 *= norm.x;
+    p1 *= norm.y;
+    p2 *= norm.z;
+    p3 *= norm.w;
+
+  // Mix final noise value
+    vec4 m = max(0.6 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.0);
+    m = m * m;
+    return 42.0 * dot( m*m, vec4( dot(p0,x0), dot(p1,x1),
+                                  dot(p2,x2), dot(p3,x3) ) );
+  }
+    `
+  },
+
+
+  _rgbToHsv: {
+    type: 'util',
+    glsl: `vec3 _rgbToHsv(vec3 c){
+            vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+            vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+            vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+
+            float d = q.x - min(q.w, q.y);
+            float e = 1.0e-10;
+            return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+        }`
+  },
+  _hsvToRgb: {
+    type: 'util',
+    glsl: `vec3 _hsvToRgb(vec3 c){
+        vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+        vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+        return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+    }`
+  }
+}

--- a/extensions/vertex/varying-proxy.js
+++ b/extensions/vertex/varying-proxy.js
@@ -1,0 +1,93 @@
+// Varying Proxy - provides access to vertex shader data in fragment shaders
+// Usage: v.normal.z, v.position.xy, v.depth, etc.
+
+// Special class to mark varying references that need backend-specific handling
+class VaryingRef {
+  constructor(glslName, wgslName) {
+    this.glslName = glslName
+    this.wgslName = wgslName
+    this._isVaryingRef = true  // Marker for detection
+  }
+
+  // Default toString returns GLSL name
+  toString() {
+    return this.glslName
+  }
+}
+
+// Creates a nested proxy that allows property access like v.normal.z
+function createComponentProxy(baseName) {
+  return new Proxy({}, {
+    get(target, prop) {
+      // Handle vec3 swizzles (x, y, z, xyz, xy, etc.)
+      // and vec4 swizzles (x, y, z, w, xyzw, rgb, rgba, etc.)
+      const validSwizzles = ['x', 'y', 'z', 'w', 'r', 'g', 'b', 'a',
+        'xy', 'xz', 'yz', 'xyz', 'xyzw',
+        'rg', 'rb', 'gb', 'rgb', 'rgba']
+
+      if (typeof prop === 'string') {
+        // Return VaryingRef for the full path
+        // WGSL uses module-scope vars (copied from ourIn at start of main)
+        const glslPath = `${baseName}.${prop}`
+        const wgslPath = `${baseName}.${prop}`
+        return new VaryingRef(glslPath, wgslPath)
+      }
+      return undefined
+    }
+  })
+}
+
+// Main v proxy object
+// Provides access to vertex data: v.position, v.normal, v.worldNormal, v.tangent, v.bitangent, v.viewDir, v.depth
+const v = new Proxy({}, {
+  get(target, prop) {
+    switch (prop) {
+      case 'position':
+        return createComponentProxy('v_position')
+      case 'normal':
+        // Model space normal (raw from vertex buffer)
+        return createComponentProxy('v_normal')
+      case 'worldNormal':
+        // World space normal (after rotation transforms)
+        return createComponentProxy('v_worldNormal')
+      case 'tangent':
+        // Tangent vector (for normal mapping, in world space)
+        return createComponentProxy('v_tangent')
+      case 'bitangent':
+        // Bitangent vector (for normal mapping, in world space)
+        return createComponentProxy('v_bitangent')
+      case 'color':
+        // Vertex color (RGBA)
+        return createComponentProxy('v_color')
+      case 'viewDir':
+        return createComponentProxy('v_viewDir')
+      case 'depth':
+        // depth is a float, return VaryingRef directly
+        // WGSL uses module-scope var (copied from ourIn at start of main)
+        return new VaryingRef('v_depth', 'v_depth')
+      case 'uv':
+        // uv is available as existing varying
+        return createComponentProxy('uv')
+      case 'faceId':
+        // faceId for sprite sheet indexing (note: this one stays ourIn since it's not copied)
+        return new VaryingRef('v_faceId', 'v_faceId')
+      default:
+        console.warn(`Unknown varying property: v.${prop}`)
+        return undefined
+    }
+  }
+})
+
+// Helper to check if a value is a VaryingRef
+function isVaryingRef(value) {
+  return value && value._isVaryingRef === true
+}
+
+// Get the appropriate string for the current backend
+function getVaryingString(varyingRef, isWGSL) {
+  if (!isVaryingRef(varyingRef)) return varyingRef
+  return isWGSL ? varyingRef.wgslName : varyingRef.glslName
+}
+
+export { v, VaryingRef, isVaryingRef, getVaryingString }
+export default v

--- a/extensions/vertex/vertex-icon.svg
+++ b/extensions/vertex/vertex-icon.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" viewBox="0 0 60 60">
+  <!-- Background -->
+  <rect width="60" height="60" fill="#1a1a2e"/>
+
+  <!-- 3D Cube - back faces -->
+  <polygon points="30,8 48,18 48,38 30,48 12,38 12,18" fill="none" stroke="#4a4a6a" stroke-width="1"/>
+
+  <!-- Cube left face -->
+  <polygon points="12,18 30,28 30,48 12,38" fill="#ff6b9d" opacity="0.8"/>
+
+  <!-- Cube right face -->
+  <polygon points="48,18 30,28 30,48 48,38" fill="#c44569" opacity="0.9"/>
+
+  <!-- Cube top face -->
+  <polygon points="12,18 30,8 48,18 30,28" fill="#ff8a5c" opacity="0.9"/>
+
+  <!-- Vertex points -->
+  <circle cx="30" cy="8" r="2.5" fill="#00fff5"/>
+  <circle cx="12" cy="18" r="2.5" fill="#00fff5"/>
+  <circle cx="48" cy="18" r="2.5" fill="#00fff5"/>
+  <circle cx="30" cy="28" r="2" fill="#00fff5"/>
+  <circle cx="12" cy="38" r="2.5" fill="#00fff5"/>
+  <circle cx="48" cy="38" r="2.5" fill="#00fff5"/>
+  <circle cx="30" cy="48" r="2.5" fill="#00fff5"/>
+
+  <!-- Edge highlights -->
+  <line x1="30" y1="8" x2="12" y2="18" stroke="#00fff5" stroke-width="1" opacity="0.6"/>
+  <line x1="30" y1="8" x2="48" y2="18" stroke="#00fff5" stroke-width="1" opacity="0.6"/>
+  <line x1="30" y1="28" x2="30" y2="48" stroke="#00fff5" stroke-width="1" opacity="0.4"/>
+</svg>

--- a/extensions/vertex/vertex-source.js
+++ b/extensions/vertex/vertex-source.js
@@ -1,0 +1,1238 @@
+// VertexSource: Chainable vertex transforms
+// Usage: tri(0.3).rotate(() => time).scale(0.5)
+// Then pass to out(): osc(10).out(o0, tri(0.3).rotate(0.5), 1)
+
+import { extractSkeletonFromGltf, extractAnimationsFromGltf, computeSkinningMatrices, applySkinning } from './geometry.js'
+
+class VertexSource {
+  constructor(vertices) {
+    // Raw vertex array (flat [x,y, x,y, ...] or [x,y,z, ...])
+    this.vertices = vertices
+    // Accumulated transforms
+    this.transforms = []
+  }
+
+  // Get raw vertices (for backward compat or direct access)
+  get verts() {
+    return this.vertices
+  }
+
+  // Check if this has any transforms
+  get hasTransforms() {
+    return this.transforms.length > 0
+  }
+
+  // Add a transform to the chain
+  _addTransform(type, args) {
+    this.transforms.push({ type, args })
+    return this
+  }
+
+  // Chainable transforms
+
+  rotate(angle = 0) {
+    return this._addTransform('rotate', { angle })
+  }
+
+  // 3D rotations
+  rotateX(angle = 0) {
+    return this._addTransform('rotateX', { angle })
+  }
+
+  rotateY(angle = 0) {
+    return this._addTransform('rotateY', { angle })
+  }
+
+  rotateZ(angle = 0) {
+    return this._addTransform('rotateZ', { angle })
+  }
+
+  scale(x = 1, y, z) {
+    // If only one arg, use for all axes (uniform scaling)
+    if (y === undefined) y = x
+    if (z === undefined) z = x
+    return this._addTransform('scale', { x, y, z })
+  }
+
+  offset(x = 0, y = 0, z = 0) {
+    return this._addTransform('offset', { x, y, z })
+  }
+
+  // Alias for offset
+  translate(x = 0, y = 0, z = 0) {
+    return this.offset(x, y, z)
+  }
+
+  // Set perspective projection
+  perspective(fov = 45, near = 0.1, far = 100) {
+    return this._addTransform('perspective', { fov, near, far })
+  }
+
+  // ========== Immediate transforms (CPU, modify vertex array) ==========
+
+  // Mirror geometry across an axis
+  // axis: 'x', 'y', or 'xy' (both)
+  mirror(axis = 'x') {
+    const orig = this.vertices
+    const mirrored = []
+    const stride = 2  // 2D vertices
+
+    for (let i = 0; i < orig.length; i += stride) {
+      const x = orig[i]
+      const y = orig[i + 1]
+      if (axis === 'x' || axis === 'xy') {
+        mirrored.push(-x, y)
+      }
+      if (axis === 'y') {
+        mirrored.push(x, -y)
+      }
+      if (axis === 'xy' && axis !== 'x') {
+        // xy already pushed x-mirror, now push y-mirror of original
+      }
+    }
+
+    // For 'xy', also add y-mirrored and xy-mirrored
+    if (axis === 'xy') {
+      for (let i = 0; i < orig.length; i += stride) {
+        mirrored.push(orig[i], -orig[i + 1])  // y-mirror
+      }
+      for (let i = 0; i < orig.length; i += stride) {
+        mirrored.push(-orig[i], -orig[i + 1])  // xy-mirror
+      }
+    }
+
+    this.vertices = [...orig, ...mirrored]
+    return this
+  }
+
+  // Repeat geometry in a grid pattern
+  // nx, ny: number of copies in x and y directions
+  // spacing: distance between copies (in NDC)
+  repeat(nx = 2, ny = 1, spacing = 0.5) {
+    const orig = this.vertices
+    const repeated = []
+    const stride = 2
+
+    // Calculate offset to center the grid
+    const offsetX = -((nx - 1) * spacing) / 2
+    const offsetY = -((ny - 1) * spacing) / 2
+
+    for (let iy = 0; iy < ny; iy++) {
+      for (let ix = 0; ix < nx; ix++) {
+        const dx = offsetX + ix * spacing
+        const dy = offsetY + iy * spacing
+
+        for (let i = 0; i < orig.length; i += stride) {
+          repeated.push(orig[i] + dx, orig[i + 1] + dy)
+        }
+      }
+    }
+
+    this.vertices = repeated
+    return this
+  }
+
+  // 3D grid instancing with faceId support
+  // Creates a grid of copies, each with unique faceId for variation
+  // nx, ny, nz: number of copies in each direction
+  // spacing: distance between copies (or {x, y, z} object)
+  grid(nx = 2, ny = 2, nz = 1, spacing = 1.0) {
+    const sx = typeof spacing === 'object' ? spacing.x || 1 : spacing
+    const sy = typeof spacing === 'object' ? spacing.y || 1 : spacing
+    const sz = typeof spacing === 'object' ? spacing.z || 1 : spacing
+
+    const orig = this.vertices
+    const stride = this.is3D ? 3 : 2
+    const vertexCount = orig.length / stride
+
+    // Safety check: limit total vertices to prevent browser crash
+    const maxVertices = 5000000  // 5 million vertex limit
+    const totalInstances = nx * ny * nz
+    const totalVertices = vertexCount * totalInstances
+    if (totalVertices > maxVertices) {
+      const maxInstances = Math.floor(maxVertices / vertexCount)
+      const scale = Math.cbrt(maxInstances / totalInstances)
+      const newNx = Math.max(1, Math.floor(nx * scale))
+      const newNy = Math.max(1, Math.floor(ny * scale))
+      const newNz = Math.max(1, Math.floor(nz * scale))
+      console.warn(`grid(${nx}, ${ny}, ${nz}) would create ${totalVertices.toLocaleString()} vertices. ` +
+        `Limiting to grid(${newNx}, ${newNy}, ${newNz}) to prevent crash. ` +
+        `Use lower-poly geometry (e.g., sphere(0.1, 8, 4)) for large grids.`)
+      nx = newNx
+      ny = newNy
+      nz = newNz
+    }
+
+    const newVerts = []
+    const newNormals = this.normals ? [] : null
+    const newUVs = this.uvs ? [] : null
+    const newColors = this.colors ? [] : null
+    const newFaceIds = []
+
+    // Center the grid
+    const offsetX = -((nx - 1) * sx) / 2
+    const offsetY = -((ny - 1) * sy) / 2
+    const offsetZ = -((nz - 1) * sz) / 2
+
+    let instanceId = 0
+    for (let iz = 0; iz < nz; iz++) {
+      for (let iy = 0; iy < ny; iy++) {
+        for (let ix = 0; ix < nx; ix++) {
+          const dx = offsetX + ix * sx
+          const dy = offsetY + iy * sy
+          const dz = offsetZ + iz * sz
+
+          // Copy all vertices with offset
+          for (let v = 0; v < vertexCount; v++) {
+            const vi = v * stride
+            newVerts.push(orig[vi] + dx, orig[vi + 1] + dy)
+            if (stride === 3) newVerts.push(orig[vi + 2] + dz)
+
+            // Copy normals (unchanged by translation)
+            if (this.normals) {
+              const ni = v * 3
+              newNormals.push(this.normals[ni], this.normals[ni + 1], this.normals[ni + 2])
+            }
+
+            // Copy UVs (unchanged)
+            if (this.uvs) {
+              const ui = v * 2
+              newUVs.push(this.uvs[ui], this.uvs[ui + 1])
+            }
+
+            // Copy colors (unchanged)
+            if (this.colors) {
+              const ci = v * 4
+              newColors.push(this.colors[ci], this.colors[ci + 1], this.colors[ci + 2], this.colors[ci + 3])
+            }
+
+            // FaceId = instance index (for per-instance variation)
+            newFaceIds.push(instanceId)
+          }
+          instanceId++
+        }
+      }
+    }
+
+    this.vertices = newVerts
+    if (newNormals) this.normals = newNormals
+    if (newUVs) this.uvs = newUVs
+    if (newColors) this.colors = newColors
+    this.faceIds = newFaceIds
+    this.instanceCount = nx * ny * nz
+
+    return this
+  }
+
+  // Scatter instances randomly
+  // count: number of instances
+  // range: {x, y, z} spread range (centered at origin)
+  // seed: optional random seed for reproducibility
+  scatter(count = 10, range = { x: 2, y: 2, z: 0 }, seed = 0) {
+    // Simple seeded random
+    const random = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff
+      return seed / 0x7fffffff
+    }
+
+    const orig = this.vertices
+    const stride = this.is3D ? 3 : 2
+    const vertexCount = orig.length / stride
+
+    // Safety check: limit total vertices to prevent browser crash
+    const maxVertices = 5000000  // 5 million vertex limit
+    const totalVertices = vertexCount * count
+    if (totalVertices > maxVertices) {
+      const newCount = Math.floor(maxVertices / vertexCount)
+      console.warn(`scatter(${count}) would create ${totalVertices.toLocaleString()} vertices. ` +
+        `Limiting to scatter(${newCount}) to prevent crash. ` +
+        `Use lower-poly geometry for large scatter counts.`)
+      count = newCount
+    }
+
+    const newVerts = []
+    const newNormals = this.normals ? [] : null
+    const newUVs = this.uvs ? [] : null
+    const newColors = this.colors ? [] : null
+    const newFaceIds = []
+
+    for (let i = 0; i < count; i++) {
+      const dx = (random() - 0.5) * range.x
+      const dy = (random() - 0.5) * range.y
+      const dz = (random() - 0.5) * (range.z || 0)
+
+      for (let v = 0; v < vertexCount; v++) {
+        const vi = v * stride
+        newVerts.push(orig[vi] + dx, orig[vi + 1] + dy)
+        if (stride === 3) newVerts.push(orig[vi + 2] + dz)
+
+        if (this.normals) {
+          const ni = v * 3
+          newNormals.push(this.normals[ni], this.normals[ni + 1], this.normals[ni + 2])
+        }
+
+        if (this.uvs) {
+          const ui = v * 2
+          newUVs.push(this.uvs[ui], this.uvs[ui + 1])
+        }
+
+        if (this.colors) {
+          const ci = v * 4
+          newColors.push(this.colors[ci], this.colors[ci + 1], this.colors[ci + 2], this.colors[ci + 3])
+        }
+
+        newFaceIds.push(i)
+      }
+    }
+
+    this.vertices = newVerts
+    if (newNormals) this.normals = newNormals
+    if (newUVs) this.uvs = newUVs
+    if (newColors) this.colors = newColors
+    this.faceIds = newFaceIds
+    this.instanceCount = count
+
+    return this
+  }
+
+  // ========== Animation ==========
+
+  // Animate a skinned model using embedded animation clips
+  // clipName: name of animation clip (or uses first clip if not found)
+  // timeFunc: function returning current time, e.g., () => time
+  // Returns new VertexSource with animated vertices (called each frame)
+  animate(clipName = null, timeFunc = () => 0) {
+    // Check if we have skinning data
+    if (!this.joints || !this.weights || !this._gltf) {
+      console.warn('animate() called on model without skinning data')
+      return this
+    }
+
+    // Lazy-extract skeleton and animations on first call
+    if (!this._skeleton) {
+      this._skeleton = extractSkeletonFromGltf(this._gltf, this._binBuffer)
+      this._animations = extractAnimationsFromGltf(this._gltf, this._binBuffer)
+
+      if (this._animations.length > 0) {
+        console.log(`Loaded ${this._animations.length} animation(s):`,
+          this._animations.map(a => `${a.name} (${a.duration.toFixed(2)}s)`).join(', '))
+      }
+    }
+
+    if (!this._skeleton || this._animations.length === 0) {
+      console.warn('Model has no skeleton or animations')
+      return this
+    }
+
+    // Create animated copy
+    const animated = new VertexSource([...this.vertices])
+    animated.is3D = this.is3D
+    animated.normals = this.normals ? [...this.normals] : null
+    animated.uvs = this.uvs ? [...this.uvs] : null
+    animated.tangents = this.tangents ? [...this.tangents] : null
+    animated.colors = this.colors ? [...this.colors] : null
+    animated.faceIds = this.faceIds ? [...this.faceIds] : null
+    animated.transforms = [...this.transforms]
+
+    // Store animation state for the renderer to apply
+    animated._animClip = clipName
+    animated._animTimeFunc = timeFunc
+    animated._skeleton = this._skeleton
+    animated._animations = this._animations
+    animated._gltf = this._gltf
+    animated._originalVerts = this.vertices
+    animated._originalNormals = this.normals
+    animated.joints = this.joints
+    animated.weights = this.weights
+    animated._normCenter = this._normCenter  // For denormalize/renormalize during skinning
+    animated._normScale = this._normScale
+
+    return animated
+  }
+
+  // Get list of available animation clip names
+  getAnimations() {
+    if (!this._gltf) return []
+    if (!this._animations) {
+      this._animations = extractAnimationsFromGltf(this._gltf, this._binBuffer)
+    }
+    return this._animations.map(a => ({ name: a.name, duration: a.duration }))
+  }
+}
+
+// Generate vertex shader GLSL from transforms
+// Returns { glsl: string, uniforms: object }
+// Options: { useExplicitUVs: boolean, useFaceIds: boolean, useNormals: boolean, useTangents: boolean, useColors: boolean }
+export function generateVertexGlsl(vertexSource, precision, options = {}) {
+  const { useExplicitUVs = false, useFaceIds = false, useNormals = false, useTangents = false, useColors = false } = options
+
+  // UV source code - either from attribute or computed from bounds
+  const uvAttributeDecl = useExplicitUVs ? 'attribute vec2 texcoord;' : ''
+  const uvComputation = useExplicitUVs
+    ? 'uv = texcoord;'
+    : 'uv = (position.xy - u_boundsMin) / (u_boundsMax - u_boundsMin);'
+
+  // FaceId for per-face materials (used with sprite sheets)
+  // Always declare varying, but only declare attribute if faceIds are provided
+  const faceIdAttributeDecl = useFaceIds ? 'attribute float faceId;' : ''
+  const faceIdVaryingDecl = 'varying float v_faceId;'  // Always declare for fragment shader compatibility
+  const faceIdPassthrough = useFaceIds ? 'v_faceId = faceId;' : 'v_faceId = 0.0;'
+
+  // Normal attribute - only if model has normals
+  const normalAttributeDecl = useNormals ? 'attribute vec3 normal;' : ''
+
+  // Tangent attribute - vec4: xyz = tangent direction, w = handedness for bitangent
+  const tangentAttributeDecl = useTangents ? 'attribute vec4 tangent;' : ''
+
+  // Color attribute - vec4 RGBA
+  const colorAttributeDecl = useColors ? 'attribute vec4 color;' : ''
+  const colorPassthrough = useColors ? 'v_color = color;' : 'v_color = vec4(1.0, 1.0, 1.0, 1.0);'
+
+  if (!vertexSource.hasTransforms) {
+    // No transforms - use simple passthrough with bounds
+    return {
+      glsl: `
+        precision ${precision} float;
+        attribute vec3 position;
+        ${uvAttributeDecl}
+        ${faceIdAttributeDecl}
+        ${colorAttributeDecl}
+        varying vec2 uv;
+        ${faceIdVaryingDecl}
+
+        // Vertex data for fragment shader (default values for 2D)
+        varying vec3 v_position;
+        varying vec3 v_normal;
+        varying vec3 v_worldNormal;
+        varying vec3 v_tangent;
+        varying vec3 v_bitangent;
+        varying vec3 v_viewDir;
+        varying float v_depth;
+        varying vec4 v_color;
+
+        uniform vec2 u_boundsMin;
+        uniform vec2 u_boundsMax;
+
+        void main () {
+          // UV ${useExplicitUVs ? 'from explicit attribute' : 'normalized to shape bounds'}
+          ${uvComputation}
+          ${faceIdPassthrough}
+          ${colorPassthrough}
+
+          // Set default vertex data for 2D geometry
+          v_position = vec3(position.xy, 0.0);
+          v_normal = vec3(0.0, 0.0, 1.0);
+          v_worldNormal = vec3(0.0, 0.0, 1.0);
+          v_tangent = vec3(1.0, 0.0, 0.0);
+          v_bitangent = vec3(0.0, 1.0, 0.0);
+          v_viewDir = vec3(0.0, 0.0, 1.0);
+          v_depth = 1.0;
+
+          gl_Position = vec4(position.xy, 0.0, 1.0);
+          gl_PointSize = 2.0;
+        }
+      `,
+      uniforms: {}
+    }
+  }
+
+  // Collect uniforms and build transform code
+  const uniforms = {}
+  const uniformDecls = []
+  const transformCode = []
+  const normalTransformCode = []  // Rotation transforms for normals (no scale/offset)
+  const tangentTransformCode = []  // Rotation transforms for tangents (same as normals)
+
+  // Check if any 3D transforms are used
+  const has3D = vertexSource.transforms.some(t =>
+    ['rotateX', 'rotateY', 'rotateZ', 'perspective'].includes(t.type) ||
+    (t.type === 'offset' && t.args.z !== 0)
+  )
+
+  let hasPerspective = false
+  let perspectiveUniform = null
+
+  vertexSource.transforms.forEach((transform, i) => {
+    const suffix = i // Unique suffix for each transform's uniforms
+
+    switch (transform.type) {
+      case 'rotate': {
+        const uniformName = `u_rotate_${suffix}`
+        uniformDecls.push(`uniform float ${uniformName};`)
+        uniforms[uniformName] = makeUniformAccessor(transform.args.angle)
+        if (has3D) {
+          // 2D rotate = rotate around Z axis
+          const rotateCode = `
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            pos = vec3(pos.x * c - pos.y * s, pos.x * s + pos.y * c, pos.z);
+          }`
+          transformCode.push(rotateCode)
+          // Apply same rotation to normal (using nrm variable)
+          normalTransformCode.push(`
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            nrm = vec3(nrm.x * c - nrm.y * s, nrm.x * s + nrm.y * c, nrm.z);
+          }`)
+          // Apply same rotation to tangent
+          tangentTransformCode.push(`
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            tang = vec3(tang.x * c - tang.y * s, tang.x * s + tang.y * c, tang.z);
+          }`)
+        } else {
+          transformCode.push(`
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            pos = vec2(pos.x * c - pos.y * s, pos.x * s + pos.y * c);
+          }`)
+        }
+        break
+      }
+
+      case 'rotateX': {
+        const uniformName = `u_rotateX_${suffix}`
+        uniformDecls.push(`uniform float ${uniformName};`)
+        uniforms[uniformName] = makeUniformAccessor(transform.args.angle)
+        transformCode.push(`
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            pos = vec3(pos.x, pos.y * c - pos.z * s, pos.y * s + pos.z * c);
+          }`)
+        // Apply same rotation to normal
+        normalTransformCode.push(`
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            nrm = vec3(nrm.x, nrm.y * c - nrm.z * s, nrm.y * s + nrm.z * c);
+          }`)
+        // Apply same rotation to tangent
+        tangentTransformCode.push(`
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            tang = vec3(tang.x, tang.y * c - tang.z * s, tang.y * s + tang.z * c);
+          }`)
+        break
+      }
+
+      case 'rotateY': {
+        const uniformName = `u_rotateY_${suffix}`
+        uniformDecls.push(`uniform float ${uniformName};`)
+        uniforms[uniformName] = makeUniformAccessor(transform.args.angle)
+        transformCode.push(`
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            pos = vec3(pos.x * c + pos.z * s, pos.y, -pos.x * s + pos.z * c);
+          }`)
+        // Apply same rotation to normal
+        normalTransformCode.push(`
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            nrm = vec3(nrm.x * c + nrm.z * s, nrm.y, -nrm.x * s + nrm.z * c);
+          }`)
+        // Apply same rotation to tangent
+        tangentTransformCode.push(`
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            tang = vec3(tang.x * c + tang.z * s, tang.y, -tang.x * s + tang.z * c);
+          }`)
+        break
+      }
+
+      case 'rotateZ': {
+        const uniformName = `u_rotateZ_${suffix}`
+        uniformDecls.push(`uniform float ${uniformName};`)
+        uniforms[uniformName] = makeUniformAccessor(transform.args.angle)
+        transformCode.push(`
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            pos = vec3(pos.x * c - pos.y * s, pos.x * s + pos.y * c, pos.z);
+          }`)
+        // Apply same rotation to normal
+        normalTransformCode.push(`
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            nrm = vec3(nrm.x * c - nrm.y * s, nrm.x * s + nrm.y * c, nrm.z);
+          }`)
+        // Apply same rotation to tangent
+        tangentTransformCode.push(`
+          {
+            float c = cos(${uniformName});
+            float s = sin(${uniformName});
+            tang = vec3(tang.x * c - tang.y * s, tang.x * s + tang.y * c, tang.z);
+          }`)
+        break
+      }
+
+      case 'scale': {
+        const uniformName = `u_scale_${suffix}`
+        if (has3D) {
+          uniformDecls.push(`uniform vec3 ${uniformName};`)
+          uniforms[uniformName] = makeUniformAccessor([transform.args.x, transform.args.y, transform.args.z || 1])
+          transformCode.push(`
+          pos *= ${uniformName};`)
+        } else {
+          uniformDecls.push(`uniform vec2 ${uniformName};`)
+          uniforms[uniformName] = makeUniformAccessor([transform.args.x, transform.args.y])
+          transformCode.push(`
+          pos *= ${uniformName};`)
+        }
+        break
+      }
+
+      case 'offset': {
+        const uniformName = `u_offset_${suffix}`
+        if (has3D) {
+          uniformDecls.push(`uniform vec3 ${uniformName};`)
+          uniforms[uniformName] = makeUniformAccessor([transform.args.x, transform.args.y, transform.args.z || 0])
+          transformCode.push(`
+          pos += ${uniformName};`)
+        } else {
+          uniformDecls.push(`uniform vec2 ${uniformName};`)
+          uniforms[uniformName] = makeUniformAccessor([transform.args.x, transform.args.y])
+          transformCode.push(`
+          pos += ${uniformName};`)
+        }
+        break
+      }
+
+      case 'perspective': {
+        hasPerspective = true
+        perspectiveUniform = `u_perspective_${suffix}`
+        uniformDecls.push(`uniform vec3 ${perspectiveUniform};`) // fov, near, far
+        uniforms[perspectiveUniform] = makeUniformAccessor([
+          transform.args.fov, transform.args.near, transform.args.far
+        ])
+        break
+      }
+    }
+  })
+
+  let glsl
+  if (has3D) {
+    const projectionCode = hasPerspective ? `
+      // Perspective projection with aspect ratio correction
+      float fov = ${perspectiveUniform}.x;
+      float near = ${perspectiveUniform}.y;
+      float far = ${perspectiveUniform}.z;
+      float f = 1.0 / tan(radians(fov) / 2.0);
+      float aspect = resolution.x / resolution.y;
+      float rangeInv = 1.0 / (near - far);
+
+      // Move camera back
+      pos.z -= 2.0;
+
+      // Apply perspective
+      float w = -pos.z;
+      gl_Position = vec4(
+        pos.x * f / aspect,
+        pos.y * f,
+        (pos.z * (near + far) + 2.0 * near * far) * rangeInv,
+        w
+      );
+      gl_PointSize = 2.0;` : `
+      // Simple projection - just use z for depth, no perspective divide
+      float aspect = resolution.x / resolution.y;
+      gl_Position = vec4(pos.x / aspect, pos.y, pos.z * 0.1, 1.0);
+      gl_PointSize = 2.0;`
+
+    // Model space normal (raw from vertex buffer)
+    const normalInit = useNormals ? `vec3 nrm = normalize(normal);` : `vec3 nrm = vec3(0.0, 0.0, 1.0);`
+
+    // Tangent initialization (vec4: xyz = tangent, w = handedness)
+    // Note: use 'tang' not 'tan' to avoid collision with GLSL built-in tan() function
+    const tangentInit = useTangents
+      ? `vec3 tang = normalize(tangent.xyz);
+      float tanW = tangent.w;`
+      : `vec3 tang = vec3(1.0, 0.0, 0.0);
+      float tanW = 1.0;`
+
+    // World space normal computation (apply rotation transforms)
+    const worldNormalCode = normalTransformCode.length > 0
+      ? `// Apply rotation transforms to normal for world space
+      ${normalTransformCode.join('\n      ')}
+      v_worldNormal = normalize(nrm);`
+      : `v_worldNormal = nrm;`
+
+    // World space tangent computation (apply rotation transforms)
+    const worldTangentCode = tangentTransformCode.length > 0
+      ? `// Apply rotation transforms to tangent for world space
+      ${tangentTransformCode.join('\n      ')}
+      v_tangent = normalize(tang);`
+      : `v_tangent = tang;`
+
+    glsl = `
+    precision ${precision} float;
+    attribute vec3 position;
+    ${uvAttributeDecl}
+    ${faceIdAttributeDecl}
+    ${normalAttributeDecl}
+    ${tangentAttributeDecl}
+    ${colorAttributeDecl}
+    varying vec2 uv;
+    ${faceIdVaryingDecl}
+
+    // Vertex data for fragment shader
+    varying vec3 v_position;
+    varying vec3 v_normal;
+    varying vec3 v_worldNormal;
+    varying vec3 v_tangent;
+    varying vec3 v_bitangent;
+    varying vec3 v_viewDir;
+    varying float v_depth;
+    varying vec4 v_color;
+
+    uniform vec2 resolution;
+    uniform vec2 u_boundsMin;
+    uniform vec2 u_boundsMax;
+    ${uniformDecls.join('\n    ')}
+
+    void main () {
+      // UV ${useExplicitUVs ? 'from explicit attribute' : 'normalized to shape bounds'}
+      ${uvComputation}
+      ${faceIdPassthrough}
+      ${colorPassthrough}
+
+      // Apply transforms (3D)
+      vec3 pos = position;
+      ${transformCode.join('\n      ')}
+
+      // Compute vertex data for fragment shader
+      v_position = pos;
+
+      // Model space normal (raw from vertex buffer)
+      ${normalInit}
+      v_normal = nrm;
+
+      // World space normal (after rotation transforms)
+      ${worldNormalCode}
+
+      // Tangent and bitangent for normal mapping
+      ${tangentInit}
+      ${worldTangentCode}
+      // Bitangent = cross(normal, tangent) * handedness
+      v_bitangent = cross(v_worldNormal, v_tangent) * tanW;
+
+      // Camera is at z = 2.0 (matching perspective projection)
+      vec3 cameraPos = vec3(0.0, 0.0, 2.0);
+      v_viewDir = normalize(cameraPos - pos);
+
+      // Normalized depth: 0 = at camera, 1 = at far plane (approx 4 units away)
+      float dist = length(cameraPos - pos);
+      v_depth = clamp(dist / 4.0, 0.0, 1.0);
+
+      ${projectionCode}
+    }
+  `
+  } else {
+    glsl = `
+    precision ${precision} float;
+    attribute vec3 position;
+    ${uvAttributeDecl}
+    ${faceIdAttributeDecl}
+    ${colorAttributeDecl}
+    varying vec2 uv;
+    ${faceIdVaryingDecl}
+
+    // Vertex data for fragment shader (default values for 2D)
+    varying vec3 v_position;
+    varying vec3 v_normal;
+    varying vec3 v_worldNormal;
+    varying vec3 v_tangent;
+    varying vec3 v_bitangent;
+    varying vec3 v_viewDir;
+    varying float v_depth;
+    varying vec4 v_color;
+
+    uniform vec2 u_boundsMin;
+    uniform vec2 u_boundsMax;
+    ${uniformDecls.join('\n    ')}
+
+    void main () {
+      // UV ${useExplicitUVs ? 'from explicit attribute' : 'normalized to shape bounds'}
+      ${uvComputation}
+      ${faceIdPassthrough}
+      ${colorPassthrough}
+
+      // Apply transforms (2D)
+      vec2 pos = position.xy;
+      ${transformCode.join('\n      ')}
+
+      // Set default vertex data for 2D geometry
+      v_position = vec3(pos, 0.0);
+      v_normal = vec3(0.0, 0.0, 1.0);  // Facing camera
+      v_worldNormal = vec3(0.0, 0.0, 1.0);  // Same as normal for 2D
+      v_tangent = vec3(1.0, 0.0, 0.0);
+      v_bitangent = vec3(0.0, 1.0, 0.0);
+      v_viewDir = vec3(0.0, 0.0, 1.0);  // Looking at camera
+      v_depth = 1.0;
+
+      gl_Position = vec4(pos, 0.0, 1.0);
+      gl_PointSize = 2.0;
+    }
+  `
+  }
+
+  return { glsl, uniforms }
+}
+
+// Create a uniform accessor function that handles static values and lambdas
+function makeUniformAccessor(value) {
+  return (context, props) => {
+    // Handle array of values (may contain lambdas)
+    if (Array.isArray(value)) {
+      return value.map(v => typeof v === 'function' ? v() : v)
+    }
+    // Handle single lambda
+    if (typeof value === 'function') {
+      return value()
+    }
+    // Static value
+    return value
+  }
+}
+
+// Generate WGSL vertex shader from transforms
+// Returns { wgsl: string, uniforms: array of {name, type, value} }
+// Options: { useExplicitUVs: boolean, useFaceIds: boolean, useNormals: boolean, useTangents: boolean, useColors: boolean }
+export function generateVertexWgsl(vertexSource, options = {}) {
+  const { useExplicitUVs = false, useFaceIds = false, useNormals = false, useTangents = false, useColors = false } = options
+
+  // Collect uniforms and build transform code
+  const uniforms = []
+  const transformCode = []
+  const normalTransformCode = []  // Rotation transforms for normals (no scale/offset)
+  const tangentTransformCode = []  // Rotation transforms for tangents (same as normals)
+
+  // Check if any 3D transforms are used
+  const has3D = vertexSource.hasTransforms && vertexSource.transforms.some(t =>
+    ['rotateX', 'rotateY', 'rotateZ', 'perspective'].includes(t.type) ||
+    (t.type === 'offset' && t.args.z !== 0)
+  )
+
+  let hasPerspective = false
+  let perspectiveUniform = null
+
+  if (vertexSource.hasTransforms) {
+    vertexSource.transforms.forEach((transform, i) => {
+      const suffix = i
+
+      switch (transform.type) {
+        case 'rotate': {
+          const uniformName = `u_rotate_${suffix}`
+          uniforms.push({ name: uniformName, type: 'f32', value: transform.args.angle })
+          if (has3D) {
+            transformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        pos = vec3f(pos.x * c - pos.y * s, pos.x * s + pos.y * c, pos.z);
+      }`)
+            // Apply same rotation to normal
+            normalTransformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        nrm = vec3f(nrm.x * c - nrm.y * s, nrm.x * s + nrm.y * c, nrm.z);
+      }`)
+            // Apply same rotation to tangent
+            tangentTransformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        tang = vec3f(tang.x * c - tang.y * s, tang.x * s + tang.y * c, tang.z);
+      }`)
+          } else {
+            transformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        pos = vec2f(pos.x * c - pos.y * s, pos.x * s + pos.y * c);
+      }`)
+          }
+          break
+        }
+
+        case 'rotateX': {
+          const uniformName = `u_rotateX_${suffix}`
+          uniforms.push({ name: uniformName, type: 'f32', value: transform.args.angle })
+          transformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        pos = vec3f(pos.x, pos.y * c - pos.z * s, pos.y * s + pos.z * c);
+      }`)
+          // Apply same rotation to normal
+          normalTransformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        nrm = vec3f(nrm.x, nrm.y * c - nrm.z * s, nrm.y * s + nrm.z * c);
+      }`)
+          // Apply same rotation to tangent
+          tangentTransformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        tang = vec3f(tang.x, tang.y * c - tang.z * s, tang.y * s + tang.z * c);
+      }`)
+          break
+        }
+
+        case 'rotateY': {
+          const uniformName = `u_rotateY_${suffix}`
+          uniforms.push({ name: uniformName, type: 'f32', value: transform.args.angle })
+          transformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        pos = vec3f(pos.x * c + pos.z * s, pos.y, -pos.x * s + pos.z * c);
+      }`)
+          // Apply same rotation to normal
+          normalTransformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        nrm = vec3f(nrm.x * c + nrm.z * s, nrm.y, -nrm.x * s + nrm.z * c);
+      }`)
+          // Apply same rotation to tangent
+          tangentTransformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        tang = vec3f(tang.x * c + tang.z * s, tang.y, -tang.x * s + tang.z * c);
+      }`)
+          break
+        }
+
+        case 'rotateZ': {
+          const uniformName = `u_rotateZ_${suffix}`
+          uniforms.push({ name: uniformName, type: 'f32', value: transform.args.angle })
+          transformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        pos = vec3f(pos.x * c - pos.y * s, pos.x * s + pos.y * c, pos.z);
+      }`)
+          // Apply same rotation to normal
+          normalTransformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        nrm = vec3f(nrm.x * c - nrm.y * s, nrm.x * s + nrm.y * c, nrm.z);
+      }`)
+          // Apply same rotation to tangent
+          tangentTransformCode.push(`
+      {
+        let c = cos(vtx.${uniformName});
+        let s = sin(vtx.${uniformName});
+        tang = vec3f(tang.x * c - tang.y * s, tang.x * s + tang.y * c, tang.z);
+      }`)
+          break
+        }
+
+        case 'scale': {
+          const uniformName = `u_scale_${suffix}`
+          if (has3D) {
+            uniforms.push({ name: uniformName, type: 'vec3f', value: [transform.args.x, transform.args.y, transform.args.z || 1] })
+          } else {
+            uniforms.push({ name: uniformName, type: 'vec2f', value: [transform.args.x, transform.args.y] })
+          }
+          transformCode.push(`
+      pos *= vtx.${uniformName};`)
+          break
+        }
+
+        case 'offset': {
+          const uniformName = `u_offset_${suffix}`
+          if (has3D) {
+            uniforms.push({ name: uniformName, type: 'vec3f', value: [transform.args.x, transform.args.y, transform.args.z || 0] })
+          } else {
+            uniforms.push({ name: uniformName, type: 'vec2f', value: [transform.args.x, transform.args.y] })
+          }
+          transformCode.push(`
+      pos += vtx.${uniformName};`)
+          break
+        }
+
+        case 'perspective': {
+          hasPerspective = true
+          perspectiveUniform = `u_perspective_${suffix}`
+          uniforms.push({ name: perspectiveUniform, type: 'vec3f', value: [transform.args.fov, transform.args.near, transform.args.far] })
+          break
+        }
+      }
+    })
+  }
+
+  // Build the uniform struct - always include bounds, plus any transform uniforms
+  const allUniformFields = [
+    '  u_boundsMin: vec2f,',
+    '  u_boundsMax: vec2f,',
+    ...uniforms.map(u => `  ${u.name}: ${u.type},`)
+  ]
+  const uniformStruct = `struct VertexUniforms {
+${allUniformFields.join('\n')}
+};
+@group(2) @binding(0) var<uniform> vtx: VertexUniforms;
+`
+
+  // Build vertex input struct - only include attributes that have buffers
+  const inputFields = ['  @location(0) position: vec3f,']
+  if (useExplicitUVs) {
+    inputFields.push('  @location(1) texcoord: vec2f,')
+  }
+  if (useFaceIds) {
+    inputFields.push('  @location(2) faceId: f32,')
+  }
+  if (useNormals) {
+    inputFields.push('  @location(3) normal: vec3f,')
+  }
+  if (useTangents) {
+    inputFields.push('  @location(4) tangent: vec4f,')  // xyz = tangent direction, w = handedness
+  }
+  if (useColors) {
+    inputFields.push('  @location(5) color: vec4f,')  // RGBA vertex color
+  }
+
+  // Build vertex output struct
+  const outputFields = [
+    '  @builtin(position) position: vec4f,',
+    '  @location(0) texcoord: vec2f,',
+    '  @location(1) faceId: f32,',  // Always include for fragment shader compatibility
+    '  // Vertex data for fragment shader',
+    '  @location(2) v_position: vec3f,',
+    '  @location(3) v_normal: vec3f,',
+    '  @location(4) v_worldNormal: vec3f,',
+    '  @location(5) v_tangent: vec3f,',
+    '  @location(6) v_bitangent: vec3f,',
+    '  @location(7) v_viewDir: vec3f,',
+    '  @location(8) v_depth: f32,',
+    '  @location(9) v_color: vec4f,'
+  ]
+
+  // UV computation
+  const uvCode = useExplicitUVs
+    ? 'output.texcoord = input.texcoord;'
+    : 'output.texcoord = (input.position.xy - vtx.u_boundsMin) / (vtx.u_boundsMax - vtx.u_boundsMin);'
+
+  // FaceId passthrough
+  const faceIdCode = useFaceIds
+    ? 'output.faceId = input.faceId;'
+    : 'output.faceId = 0.0;'
+
+  // Color passthrough
+  const colorCode = useColors
+    ? 'output.v_color = input.color;'
+    : 'output.v_color = vec4f(1.0, 1.0, 1.0, 1.0);'
+
+  // Build the vertex shader
+  let wgsl
+  if (has3D) {
+    const projectionCode = hasPerspective ? `
+      // Perspective projection with aspect ratio correction
+      let fov = vtx.${perspectiveUniform}.x;
+      let near = vtx.${perspectiveUniform}.y;
+      let far = vtx.${perspectiveUniform}.z;
+      let f = 1.0 / tan(radians(fov) / 2.0);
+      let aspect = resolution.x / resolution.y;
+      let rangeInv = 1.0 / (near - far);
+
+      // Move camera back
+      pos.z -= 2.0;
+
+      // Apply perspective
+      let w = -pos.z;
+      output.position = vec4f(
+        pos.x * f / aspect,
+        pos.y * f,
+        (pos.z * (near + far) + 2.0 * near * far) * rangeInv,
+        w
+      );` : `
+      // Simple projection - just use z for depth, no perspective divide
+      let aspect = resolution.x / resolution.y;
+      output.position = vec4f(pos.x / aspect, pos.y, pos.z * 0.1, 1.0);`
+
+    // Model space normal initialization
+    const normalInit = useNormals ? 'var nrm = normalize(input.normal);' : 'var nrm = vec3f(0.0, 0.0, 1.0);'
+
+    // Tangent initialization (vec4: xyz = tangent, w = handedness)
+    // Note: use 'tang' not 'tan' to avoid collision with WGSL built-in tan() function
+    const tangentInit = useTangents
+      ? `var tang = normalize(input.tangent.xyz);
+  let tanW = input.tangent.w;`
+      : `var tang = vec3f(1.0, 0.0, 0.0);
+  let tanW = 1.0;`
+
+    // World space normal computation (apply rotation transforms)
+    const worldNormalCode = normalTransformCode.length > 0
+      ? `// Apply rotation transforms to normal for world space
+${normalTransformCode.join('\n')}
+  output.v_worldNormal = normalize(nrm);`
+      : `output.v_worldNormal = nrm;`
+
+    // World space tangent computation (apply rotation transforms)
+    const worldTangentCode = tangentTransformCode.length > 0
+      ? `// Apply rotation transforms to tangent for world space
+${tangentTransformCode.join('\n')}
+  output.v_tangent = normalize(tang);`
+      : `output.v_tangent = tang;`
+
+    wgsl = `struct VertexInput {
+${inputFields.join('\n')}
+};
+
+struct VertexOutput {
+${outputFields.join('\n')}
+};
+
+@group(0) @binding(1) var<uniform> resolution: vec2f;
+${uniformStruct}
+@vertex
+fn main(input: VertexInput) -> VertexOutput {
+  var output: VertexOutput;
+
+  // UV
+  ${uvCode}
+  // FaceId
+  ${faceIdCode}
+  // Color
+  ${colorCode}
+
+  // Apply transforms (3D)
+  var pos = input.position;
+${transformCode.join('\n')}
+
+  // Compute vertex data for fragment shader
+  output.v_position = pos;
+
+  // Model space normal (raw from vertex buffer)
+  ${normalInit}
+  output.v_normal = nrm;
+
+  // World space normal (after rotation transforms)
+  ${worldNormalCode}
+
+  // Tangent and bitangent for normal mapping
+  ${tangentInit}
+  ${worldTangentCode}
+  // Bitangent = cross(normal, tangent) * handedness
+  output.v_bitangent = cross(output.v_worldNormal, output.v_tangent) * tanW;
+
+  let cameraPos = vec3f(0.0, 0.0, 2.0);
+  output.v_viewDir = normalize(cameraPos - pos);
+
+  // Normalized depth: 0 = at camera, 1 = at far plane (approx 4 units away)
+  let dist = length(cameraPos - pos);
+  output.v_depth = clamp(dist / 4.0, 0.0, 1.0);
+
+  ${projectionCode}
+  return output;
+}
+`
+  } else {
+    wgsl = `struct VertexInput {
+${inputFields.join('\n')}
+};
+
+struct VertexOutput {
+${outputFields.join('\n')}
+};
+
+${uniformStruct}
+@vertex
+fn main(input: VertexInput) -> VertexOutput {
+  var output: VertexOutput;
+
+  // UV
+  ${uvCode}
+  // FaceId
+  ${faceIdCode}
+  // Color
+  ${colorCode}
+
+  // Apply transforms (2D)
+  var pos = input.position.xy;
+${transformCode.join('\n')}
+
+  // Set default vertex data for 2D geometry
+  output.v_position = vec3f(pos, 0.0);
+  output.v_normal = vec3f(0.0, 0.0, 1.0);  // Facing camera
+  output.v_worldNormal = vec3f(0.0, 0.0, 1.0);  // Same as normal for 2D
+  output.v_tangent = vec3f(1.0, 0.0, 0.0);
+  output.v_bitangent = vec3f(0.0, 1.0, 0.0);
+  output.v_viewDir = vec3f(0.0, 0.0, 1.0);  // Looking at camera
+  output.v_depth = 1.0;
+
+  output.position = vec4f(pos, 0.0, 1.0);
+  return output;
+}
+`
+  }
+
+  return { wgsl, uniforms }
+}
+
+// Generate passthrough WGSL vertex shader (no transforms)
+// Note: bounds uniforms are added by outputWgsl.js
+export function getPassthroughVertexWgsl() {
+  return `struct VertexInput {
+  @location(0) position: vec3f,
+};
+
+struct VertexOutput {
+  @builtin(position) position: vec4f,
+  @location(0) texcoord: vec2f,
+  @location(1) faceId: f32,
+  // Vertex data for fragment shader
+  @location(2) v_position: vec3f,
+  @location(3) v_normal: vec3f,
+  @location(4) v_worldNormal: vec3f,
+  @location(5) v_tangent: vec3f,
+  @location(6) v_bitangent: vec3f,
+  @location(7) v_viewDir: vec3f,
+  @location(8) v_depth: f32,
+  @location(9) v_color: vec4f,
+};
+
+struct VertexUniforms {
+  u_boundsMin: vec2f,
+  u_boundsMax: vec2f,
+};
+@group(2) @binding(0) var<uniform> vtx: VertexUniforms;
+
+@vertex
+fn main(input: VertexInput) -> VertexOutput {
+  var output: VertexOutput;
+  // UV normalized to shape bounds (texture fills the shape)
+  output.texcoord = (input.position.xy - vtx.u_boundsMin) / (vtx.u_boundsMax - vtx.u_boundsMin);
+  output.faceId = 0.0;
+
+  // Set default vertex data for 2D geometry
+  output.v_position = vec3f(input.position.xy, 0.0);
+  output.v_normal = vec3f(0.0, 0.0, 1.0);
+  output.v_worldNormal = vec3f(0.0, 0.0, 1.0);
+  output.v_tangent = vec3f(1.0, 0.0, 0.0);
+  output.v_bitangent = vec3f(0.0, 1.0, 0.0);
+  output.v_viewDir = vec3f(0.0, 0.0, 1.0);
+  output.v_depth = 1.0;
+  output.v_color = vec4f(1.0, 1.0, 1.0, 1.0);
+
+  output.position = vec4f(input.position.xy, 0.0, 1.0);
+  return output;
+}
+`
+}
+
+export default VertexSource

--- a/extensions/vertex/wgsl/FBO4toCanvas.js
+++ b/extensions/vertex/wgsl/FBO4toCanvas.js
@@ -1,0 +1,278 @@
+
+// Class to manage the drawing of a frame buffer object to a browser canvas.
+class FBO4ToCanvas {
+	
+	constructor (canvas, device) {
+		this.canvas = canvas;
+		this.device = device;
+	  this.context = this.canvas.getContext("webgpu");
+	  this.aspect = this.canvas.width / this.canvas.height;
+	}
+
+
+  async setupFromScratch() {
+
+	  // Step 1: Check for WebGPU support
+      if (!navigator.gpu) {
+        console.error("WebGPU is not supported on this browser.");
+        return;
+      }
+
+      // Step 2: Request GPU adapter and device
+      const adapter = await navigator.gpu.requestAdapter();
+      if (!adapter) {
+        console.error("Failed to get GPU adapter.");
+        return;
+      }
+
+      this.device = await adapter.requestDevice();
+
+			
+  }
+
+
+	async initializeFBOdrawing() {
+  	if (!this.device) await this.setupFromScratch();
+
+     // Step 3: Setup canvas and configure context
+     //const format = "bgra8unorm"; // normal for MacOS according to 
+     const format = navigator.gpu.getPreferredCanvasFormat();
+     this.context.configure({
+        device: this.device,
+        format,
+        alphaMode: "opaque",
+      });
+
+   const codePrefix = `
+	 struct VertexOutput {
+  	@builtin(position) position : vec4f,
+  	@location(0) texcoord : vec2f,
+	 };
+   @group(0) @binding(0) var ourSamp0: sampler;
+	 @group(0) @binding(1) var ourTex0:  texture_2d<f32>;
+   @group(0) @binding(2) var ourSamp1: sampler;
+	 @group(0) @binding(3) var ourTex1:  texture_2d<f32>;
+   @group(0) @binding(4) var ourSamp2: sampler;
+	 @group(0) @binding(5) var ourTex2:  texture_2d<f32>;
+	 @group(0) @binding(6) var ourSamp3: sampler;
+	 @group(0) @binding(7) var ourTex3:  texture_2d<f32>;
+`;
+      // Step 4: Define shaders
+    const vertexShaderCode = codePrefix + `
+        @vertex
+        fn main(@builtin(vertex_index) vertexIndex : u32) -> VertexOutput {
+          var positions = array<vec2<f32>, 6>(
+            vec2<f32>(-1.0, -1.0),
+            vec2<f32>(-1.0, 1.0),
+            vec2<f32>(1.0, -1.0 ),
+
+            vec2<f32>(1.0, -1.0),
+            vec2<f32>(-1.0, 1.0),
+            vec2<f32>(1.0, 1.0)
+          );
+         var output : VertexOutput;
+         output.position = vec4<f32>( positions[vertexIndex], 0.0, 1);
+         output.texcoord = positions[vertexIndex] / 2 + 0.5; // positions are -1.0 to 1.0, texcoords are 0.0 to 1.0.
+         return output;
+        }
+      `;
+
+    const fragmentShaderCode = codePrefix + `
+        @fragment
+        fn main(ourIn: VertexOutput) -> @location(0) vec4<f32> {
+         var uv :vec2<f32>;
+         uv = ourIn.texcoord; //* ourStruct.scale + ourStruct.offset;
+
+        var st = vec2<f32>(uv.x, uv.y);
+        st = st * vec2<f32>(2.0);
+        let q = floor(st).xy*(vec2<f32>(2.0, 1.0));
+        let quad : i32 = i32(q.x) + i32(q.y);
+        st.x =  st.x + step(1., st.y % 2.0);
+        st.y = st.y + step(1., st.x %2.0);
+        st = fract(st);
+
+        let val0 = textureSample(ourTex0, ourSamp0, st);
+        let val1 = textureSample(ourTex1, ourSamp1, st);
+        let val2 = textureSample(ourTex2, ourSamp2, st);
+        let val3 = textureSample(ourTex3, ourSamp3, st);
+   
+        if(quad == 0){ // LLHC
+					return val1;
+        } else if (quad == 1) { // ULHC
+					return val0;
+        } else if (quad == 2){ // LRHC
+					return val3;
+        } else {
+  				return val2; // URHC
+        }
+      }
+`;
+
+      // Step 5: Create shader modules
+      const vertexShaderModule = this.device.createShaderModule({ label: "vertFBO", code: vertexShaderCode });
+      const fragmentShaderModule = this.device.createShaderModule({ label: "fragFBO", code: fragmentShaderCode });
+
+		// We need to create BindGroupLayouts for our each of our BindGroups
+		// Each bind group with contain entries for each element within.
+		// Bind group for time
+		this.textureBindGroupLayout = this.device.createBindGroupLayout({
+			label: "FBOtextureBindGroupLayout",
+  		entries: [
+//  0
+     	{
+      	binding: 0, // Binding index for sampler.
+     	  visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+     	  sampler: {
+          type: "filtering",
+        },
+    	},
+    	
+     	{
+      	binding: 1, // Binding index for texture 0 
+     	  visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+      	texture: {
+          sampleType: "float",
+          viewDimension: "2d",
+          multisampled: false,
+        },
+    	},
+    	
+ // 1
+      	{
+      	binding: 2, // Binding index for sampler.
+     	  visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+     	  sampler: {
+          type: "filtering",
+        },
+    	},
+    	
+     	{
+      	binding: 3, // Binding index for texture 1
+     	  visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+      	texture: {
+          sampleType: "float",
+          viewDimension: "2d",
+          multisampled: false,
+        },
+    	},
+    	
+ // 2
+      {
+      	binding: 4, // Binding index for sampler.
+     	  visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+     	  sampler: {
+          type: "filtering",
+        },
+    	},
+
+     	{
+      	binding: 5, // Binding index for texture 2
+     	  visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+      	texture: {
+          sampleType: "float",
+          viewDimension: "2d",
+          multisampled: false,
+        },
+    	},
+    	
+  // 3   	
+      	{
+      	binding: 6, // Binding index for sampler.
+     	  visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+     	  sampler: {
+          type: "filtering",
+        },
+    	},
+  
+     	{
+      	binding: 7, // Binding index for texture 3
+     	  visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+      	texture: {
+          sampleType: "float",
+          viewDimension: "2d",
+          multisampled: false,
+        },
+    	},
+ 
+ 
+  		],
+		});
+
+		// We then use those BindGroupLayouts to concoct a Pipeline Layout we can give the Pipeline proper.
+   	this.pipelineLayout = this.device.createPipelineLayout({
+          bindGroupLayouts: [this.textureBindGroupLayout],
+      });
+
+      // Step 6: Set up the render pipeline
+      this.pipeline = this.device.createRenderPipeline({
+       	label: 'FBOrenderpipeline',
+        vertex: {
+          module: vertexShaderModule,
+          entryPoint: "main",
+        },
+        fragment: {
+          module: fragmentShaderModule,
+          entryPoint: "main",
+          targets: [{ format }],
+        },
+        primitive: {
+          topology: "triangle-list",
+        },
+        layout: this.pipelineLayout
+      });
+
+ 		this.sampler0 = this.device.createSampler();
+ 		this.sampler1 = this.device.createSampler();
+ 		this.sampler2 = this.device.createSampler();
+ 		this.sampler3 = this.device.createSampler();
+ 		 		 		 		
+	 	//this.refreshCanvas(this.sourceTexture);
+ }
+
+	refreshCanvases(tex0, tex1, tex2, tex3) {
+		// Create binding for our source texture, which may well have changed.
+		if (!tex0 || !tex1 || !tex2 || !tex3) return;
+
+		this.textureBindGroup = this.device.createBindGroup({
+			 label: "texture bind group",
+  	   layout: this.textureBindGroupLayout,
+  		 entries: [
+      	 {binding: 0, resource: this.sampler0},
+    		 {binding: 1, resource: tex0.createView()},
+      	 {binding: 2, resource: this.sampler1},
+    		 {binding: 3, resource: tex1.createView()},
+     	   {binding: 4, resource: this.sampler2},
+    		 {binding: 5, resource: tex2.createView()},
+      	 {binding: 6, resource: this.sampler3},
+    		 {binding: 7, resource: tex3.createView()}	 
+     	 ],
+		});	
+
+			// Step 7: Create the render pass descriptor (for the output texture).
+			const canvasTextureView = this.context.getCurrentTexture().createView();
+
+      this.renderPassDescriptor = {
+      	label: "FBOrenderPassDescriptor",
+        colorAttachments: [{
+          label: "FBO canvas textureView attachment",
+          view: canvasTextureView,
+          clearValue: { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
+          loadOp: "clear",
+          storeOp: "store",
+        }],
+      };
+
+		// Step 8: create the command encoder, issue commands, and do the actual pass
+			// and then do the pass.
+			// We may be able to move some of this out of the anim loop?
+     const commandEncoder = this.device.createCommandEncoder();
+     const passEncoder = commandEncoder.beginRenderPass(this.renderPassDescriptor);
+     passEncoder.setPipeline(this.pipeline);
+		 passEncoder.setBindGroup(0, this.textureBindGroup);
+     passEncoder.draw(6);  // call our vertex shader 6 times to draw the quad
+     passEncoder.end();
+     this.device.queue.submit([commandEncoder.finish()]);
+		}
+};
+
+export {FBO4ToCanvas}

--- a/extensions/vertex/wgsl/FBOToCanvas.js
+++ b/extensions/vertex/wgsl/FBOToCanvas.js
@@ -1,0 +1,189 @@
+//import { createTextureFromImage } from 'webgpu-utils';
+
+
+// Class to manage the drawing of a frame buffer object to a browser canvas.
+class FBOToCanvas {
+	
+	constructor (canvas, device) {
+		this.canvas = canvas;
+		this.device = device;
+	  this.context = this.canvas.getContext("webgpu");
+	  this.aspect = this.canvas.width / this.canvas.height;
+	}
+
+
+  async setupFromScratch() {
+
+	  // Step 1: Check for WebGPU support
+      if (!navigator.gpu) {
+        console.error("WebGPU is not supported on this browser.");
+        return;
+      }
+
+      // Step 2: Request GPU adapter and device
+      const adapter = await navigator.gpu.requestAdapter();
+      if (!adapter) {
+        console.error("Failed to get GPU adapter.");
+        return;
+      }
+
+      this.device = await adapter.requestDevice();
+			let fru =  './fritzpix.jpg';
+			let fritzPic = await createTextureFromImage(this.device, fru, {
+ 		 		flipY: true,
+			});
+			this.sourceTexture = fritzPic;
+			
+  }
+
+
+	async initializeFBOdrawing() {
+  	if (!this.device) await this.setupFromScratch();
+
+     // Step 3: Setup canvas and configure context
+     //const format = "bgra8unorm"; // normal for MacOS according to 
+     const format = navigator.gpu.getPreferredCanvasFormat();
+     this.context.configure({
+        device: this.device,
+        format,
+        alphaMode: "opaque",
+      });
+
+   const codePrefix = `
+	 struct VertexOutput {
+  	@builtin(position) position : vec4f,
+  	@location(0) texcoord : vec2f,
+	 };
+   @group(0) @binding(0) var ourSamp: sampler;
+	 @group(0) @binding(1) var ourTex:  texture_2d<f32>;
+`;
+
+      // Step 4: Define shaders
+      const vertexShaderCode = codePrefix + `
+        @vertex
+        fn main(@builtin(vertex_index) vertexIndex : u32) -> VertexOutput {
+          var positions = array<vec2<f32>, 6>(
+            vec2<f32>(-1.0, -1.0),
+            vec2<f32>(-1.0, 1.0),
+            vec2<f32>(1.0, -1.0 ),
+
+            vec2<f32>(1.0, -1.0),
+            vec2<f32>(-1.0, 1.0),
+            vec2<f32>(1.0, 1.0)
+          );
+         var output : VertexOutput;
+         output.position = vec4<f32>( positions[vertexIndex], 0.0, 1);
+         output.texcoord = positions[vertexIndex] / 2 + 0.5; // positions are -1.0 to 1.0, texcoords are 0.0 to 1.0.
+         return output;
+        }
+      `;
+
+      const fragmentShaderCode = codePrefix + `
+        @fragment
+        fn main(ourIn: VertexOutput) -> @location(0) vec4<f32> {
+          var uv :vec2<f32>;
+          uv = ourIn.texcoord; //* ourStruct.scale + ourStruct.offset;
+          return textureSample(ourTex, ourSamp, uv);
+        }
+      `;
+
+      // Step 5: Create shader modules
+      const vertexShaderModule = this.device.createShaderModule({ label: "vertFBO", code: vertexShaderCode });
+      const fragmentShaderModule = this.device.createShaderModule({ label: "fragFBO", code: fragmentShaderCode });
+
+		// We need to create BindGroupLayouts for our each of our BindGroups
+		// Each bind group with contain entries for each element within.
+		// Bind group for time
+		this.textureBindGroupLayout = this.device.createBindGroupLayout({
+			label: "FBOtextureBindGroupLayout",
+  		entries: [
+     	{
+      	binding: 0, // Binding index for sampler.
+     	  visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+     	  sampler: {
+          type: "filtering",
+        },
+    	},
+    	
+     	{
+      	binding: 1, // Binding index for texture.
+     	  visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+      	texture: {
+          sampleType: "float",
+          viewDimension: "2d",
+          multisampled: false,
+        },
+    	},
+  		],
+		});
+
+		// We then use those BindGroupLayouts to concoct a Pipeline Layout we can give the Pipeline proper.
+   	this.pipelineLayout = this.device.createPipelineLayout({
+          bindGroupLayouts: [this.textureBindGroupLayout],
+      });
+
+      // Step 6: Set up the render pipeline
+      this.pipeline = this.device.createRenderPipeline({
+       	label: 'FBOrenderpipeline',
+        vertex: {
+          module: vertexShaderModule,
+          entryPoint: "main",
+        },
+        fragment: {
+          module: fragmentShaderModule,
+          entryPoint: "main",
+          targets: [{ format }],
+        },
+        primitive: {
+          topology: "triangle-list",
+        },
+        layout: this.pipelineLayout
+      });
+
+ 		this.sampler = this.device.createSampler();
+	 	//this.refreshCanvas(this.sourceTexture);
+ }
+
+	refreshCanvas(tex) {
+		// Create binding for our source texture, which may well have changed.
+		if (tex) this.sourceTexture = tex;
+
+		if (!this.sourceTexture) return;
+
+		this.textureBindGroup = this.device.createBindGroup({
+			 label: "texture bind group",
+  	   layout: this.textureBindGroupLayout,
+  		 entries: [
+      	 {binding: 0, resource: this.sampler},
+    		 {binding: 1, resource: this.sourceTexture.createView()}
+     	 ],
+		});	
+
+			// Step 7: Create the render pass descriptor (for the output texture).
+			const canvasTextureView = this.context.getCurrentTexture().createView();
+
+      this.renderPassDescriptor = {
+      	label: "FBOrenderPassDescriptor",
+        colorAttachments: [{
+          label: "FBO canvas textureView attachment",
+          view: canvasTextureView,
+          clearValue: { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
+          loadOp: "clear",
+          storeOp: "store",
+        }],
+      };
+
+		// Step 8: create the command encoder, issue commands, and do the actual pass
+			// and then do the pass.
+			// We may be able to move some of this out of the anim loop?
+     const commandEncoder = this.device.createCommandEncoder();
+     const passEncoder = commandEncoder.beginRenderPass(this.renderPassDescriptor);
+     passEncoder.setPipeline(this.pipeline);
+		 passEncoder.setBindGroup(0, this.textureBindGroup);
+     passEncoder.draw(6);  // call our vertex shader 6 times to draw the quad
+     passEncoder.end();
+     this.device.queue.submit([commandEncoder.finish()]);
+		}
+};
+
+export {FBOToCanvas}

--- a/extensions/vertex/wgsl/gpu-device-factory.js
+++ b/extensions/vertex/wgsl/gpu-device-factory.js
@@ -1,0 +1,75 @@
+// Singleton factory for shared WebGPU device
+// Allows multiple Hydra instances to share textures without copying
+
+let sharedDevice = null;
+let sharedAdapter = null;
+let initPromise = null;
+
+async function initSharedDevice() {
+  if (!navigator.gpu) {
+    throw new Error("WebGPU is not supported on this browser.");
+  }
+
+  sharedAdapter = await navigator.gpu.requestAdapter();
+  if (!sharedAdapter) {
+    throw new Error("Failed to get GPU adapter.");
+  }
+
+  const hasBGRA8unormStorage = sharedAdapter.features.has('bgra8unorm-storage');
+  sharedDevice = await sharedAdapter.requestDevice({
+    requiredFeatures: hasBGRA8unormStorage ? ['bgra8unorm-storage'] : [],
+  });
+
+  // Handle device loss
+  sharedDevice.lost.then((info) => {
+    console.error(`WebGPU device was lost: ${info.message}`);
+    sharedDevice = null;
+    sharedAdapter = null;
+    initPromise = null;
+  });
+
+  return sharedDevice;
+}
+
+/**
+ * Get the shared GPUDevice, creating it if necessary.
+ * Multiple Hydra instances using this device can share textures directly.
+ */
+export async function getSharedDevice() {
+  if (sharedDevice) {
+    return sharedDevice;
+  }
+
+  // Avoid race conditions - only one init at a time
+  if (!initPromise) {
+    initPromise = initSharedDevice();
+  }
+
+  return initPromise;
+}
+
+/**
+ * Check if a shared device already exists (without creating one)
+ */
+export function hasSharedDevice() {
+  return sharedDevice !== null;
+}
+
+/**
+ * Get the shared adapter (for feature queries)
+ */
+export function getSharedAdapter() {
+  return sharedAdapter;
+}
+
+/**
+ * Force release the shared device (for cleanup/testing)
+ */
+export function releaseSharedDevice() {
+  if (sharedDevice) {
+    sharedDevice.destroy();
+    sharedDevice = null;
+    sharedAdapter = null;
+    initPromise = null;
+  }
+}

--- a/extensions/vertex/wgsl/outputWgsl.js
+++ b/extensions/vertex/wgsl/outputWgsl.js
@@ -1,0 +1,252 @@
+import VertexSource, { generateVertexWgsl, getPassthroughVertexWgsl } from '../vertex-source.js'
+
+// Blend mode configurations for WebGPU
+const BLEND_MODES = {
+  normal: {
+    color: {
+      srcFactor: 'src-alpha',
+      dstFactor: 'one-minus-src-alpha',
+      operation: 'add'
+    },
+    alpha: {
+      srcFactor: 'one',
+      dstFactor: 'one-minus-src-alpha',
+      operation: 'add'
+    }
+  },
+  add: {
+    color: {
+      srcFactor: 'src-alpha',
+      dstFactor: 'one',
+      operation: 'add'
+    },
+    alpha: {
+      srcFactor: 'one',
+      dstFactor: 'one',
+      operation: 'add'
+    }
+  },
+  multiply: {
+    color: {
+      srcFactor: 'dst',
+      dstFactor: 'zero',
+      operation: 'add'
+    },
+    alpha: {
+      srcFactor: 'one',
+      dstFactor: 'one',
+      operation: 'add'
+    }
+  },
+  screen: {
+    color: {
+      srcFactor: 'one',
+      dstFactor: 'one-minus-src',
+      operation: 'add'
+    },
+    alpha: {
+      srcFactor: 'one',
+      dstFactor: 'one',
+      operation: 'add'
+    }
+  }
+}
+
+class OutputWgsl {
+  constructor ({wgslHydra, hydraSynth, chanNum, label = "", width, height}) {
+    this.wgslHydra = wgslHydra
+    this.hydraSynth = hydraSynth
+    this.chanNum = chanNum
+    this.label = label
+    this.precision = 'mediump' // For compatibility with glsl-source.js
+    this.draw = () => {}
+
+    // Sprite registry: Map<spriteLevel, SpriteConfig>
+    this.sprites = new Map()
+
+    this.init()
+  }
+
+  resize(width, height) {
+    // Handled by wgslHydra.resizeOutputsTo
+  }
+
+  getCurrent() {
+    let tex = this.getCurrentTextureView()
+    return tex
+  }
+
+  getTexture() {
+    let tex = this.getOppositeTextureView()
+    return tex
+  }
+
+  init() {
+    this.pingPongs = 0
+    return this
+  }
+
+  // Register a sprite at a given level (parallel to WebGL Output.registerSprite)
+  async registerSprite(spriteLevel, config) {
+    const { passes, vertexData, blendMode = 'normal', primitive = 'triangles', sprite = null } = config
+    const pass = passes[0]
+
+    // Extract raw vertices and check for VertexSource
+    let rawVerts = null
+    let vertexSource = null
+    let has3D = false
+
+    if (vertexData instanceof VertexSource) {
+      vertexSource = vertexData
+      rawVerts = vertexData.vertices
+      has3D = vertexData.is3D || false
+    } else if (vertexData && Array.isArray(vertexData)) {
+      rawVerts = vertexData
+    }
+
+    // Check for explicit UVs, faceIds, normals, tangents, and colors
+    let hasExplicitUVs = false
+    let hasFaceIds = false
+    let hasNormals = false
+    let hasTangents = false
+    let hasColors = false
+    if (vertexSource) {
+      hasExplicitUVs = vertexSource.uvs && vertexSource.uvs.length > 0
+      hasFaceIds = vertexSource.faceIds && vertexSource.faceIds.length > 0
+      hasNormals = vertexSource.normals && vertexSource.normals.length > 0
+      hasTangents = vertexSource.tangents && vertexSource.tangents.length > 0
+      hasColors = vertexSource.colors && vertexSource.colors.length > 0
+    }
+
+    // Compute bounds for UV normalization
+    let bounds = { minX: -1, maxX: 1, minY: -1, maxY: 1 }
+    if (rawVerts && rawVerts.length >= 6 && !hasExplicitUVs) {
+      bounds = { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity }
+      // rawVerts is flat array [x,y, x,y, ...] or [x,y,z, ...]
+      const stride = has3D ? 3 : 2
+      for (let i = 0; i < rawVerts.length; i += stride) {
+        bounds.minX = Math.min(bounds.minX, rawVerts[i])
+        bounds.maxX = Math.max(bounds.maxX, rawVerts[i])
+        bounds.minY = Math.min(bounds.minY, rawVerts[i + 1])
+        bounds.maxY = Math.max(bounds.maxY, rawVerts[i + 1])
+      }
+    }
+
+    // Determine vertex shader and uniforms
+    let vertexWgsl = null
+    let vertexUniforms = []
+    const hasChainedTransforms = vertexSource && vertexSource.hasTransforms
+
+    if (rawVerts) {
+      // Add bounds uniforms for UV normalization
+      const boundsUniforms = [
+        { name: 'u_boundsMin', type: 'vec2f', value: [bounds.minX, bounds.minY] },
+        { name: 'u_boundsMax', type: 'vec2f', value: [bounds.maxX, bounds.maxY] }
+      ]
+
+      if (hasChainedTransforms) {
+        const generated = generateVertexWgsl(vertexSource, { useExplicitUVs: hasExplicitUVs, useFaceIds: hasFaceIds, useNormals: hasNormals, useTangents: hasTangents, useColors: hasColors })
+        vertexWgsl = generated.wgsl
+        vertexUniforms = [...boundsUniforms, ...generated.uniforms]
+      } else {
+        vertexWgsl = getPassthroughVertexWgsl()
+        vertexUniforms = boundsUniforms
+      }
+    }
+
+    // Store sprite config
+    this.sprites.set(spriteLevel, {
+      passes,
+      vertexData,
+      rawVerts,
+      vertexSource,
+      blendMode,
+      primitive,
+      vertexWgsl,
+      vertexUniforms,
+      hasCustomGeometry: rawVerts !== null,
+      has3D,
+      hasExplicitUVs,
+      hasFaceIds,
+      hasNormals,
+      hasTangents,
+      hasColors,
+      sprite
+    })
+
+    // Setup the pipeline in wgslHydra
+    await this.wgslHydra.setupSpriteChain(this.chanNum, spriteLevel, {
+      uniforms: pass.uniforms,
+      fragShader: pass.frag,
+      vertexWgsl,
+      vertexUniforms,
+      rawVerts,
+      blendMode,
+      primitive,
+      has3D,
+      hasExplicitUVs,
+      hasFaceIds,
+      hasNormals,
+      hasTangents,
+      hasColors,
+      uvs: vertexSource?.uvs,
+      faceIds: vertexSource?.faceIds,
+      normals: vertexSource?.normals,
+      tangents: vertexSource?.tangents,
+      colors: vertexSource?.colors,
+      sprite
+    })
+  }
+
+  // Legacy render method - registers at sprite level 0
+  async render(passes) {
+    // Clear existing sprites and register at level 0
+    this.clearSprites()
+    await this.registerSprite(0, { passes, vertexData: null, blendMode: 'normal' })
+  }
+
+  // Clear all sprites
+  clearSprites() {
+    this.sprites.clear()
+    if (this.wgslHydra.clearSpriteChains) {
+      this.wgslHydra.clearSpriteChains(this.chanNum)
+    }
+  }
+
+  tick(props) {
+    // Rendering handled by wgslHydra.animate
+  }
+
+  flipPingPong() {
+    let x = this.pingPongs === 0 ? 1 : 0
+    this.pingPongs = x
+  }
+
+  // This is called during setup and whenever canvas size changes
+  createTexturesAndViews(device, destTextureDescriptor) {
+    this.textures = new Array(2)
+    this.views = new Array(2)
+    for (let i = 0; i < 2; ++i) {
+      this.textures[i] = device.createTexture(destTextureDescriptor)
+      this.views[i] = this.textures[i].createView()
+    }
+  }
+
+  getCurrentTextureView() {
+    let p = this.pingPongs
+    return this.views[p]
+  }
+
+  getCurrentTexture() {
+    let p = this.pingPongs
+    return this.textures[p]
+  }
+
+  getOppositeTextureView() {
+    let p = this.pingPongs
+    let x = p === 0 ? 1 : 0
+    return this.views[x]
+  }
+}
+
+export { OutputWgsl, BLEND_MODES }

--- a/extensions/vertex/wgsl/utility-functions-wgsl.js
+++ b/extensions/vertex/wgsl/utility-functions-wgsl.js
@@ -1,0 +1,128 @@
+// functions that are only used within other functions
+
+export default {
+_mod: {
+    type: 'util',
+    wgsl: `fn _mod(x : f32, y: f32) -> f32 {
+				return x - y * floor(x / y);
+    }`
+  },
+_luminance: {
+    type: 'util',
+    wgsl: `fn _luminance(rgb : vec3<f32>) -> f32 {
+      const  W = vec3<f32>(0.2125, 0.7154, 0.0721);
+      return dot(rgb, W);
+    }`
+  },
+  _noise: {
+    type: 'util',
+    wgsl: `
+  fn mod4v(x : vec4<f32>, y : f32) -> vec4<f32> {
+  		return x - y * floor (x / y); // exact match for glsl
+  		// return x % y; // wgsl uses trunc instead of floor.
+  }
+
+// vec4 permute(vec4 x){return mod(((x*34.0)+1.0)*x, 289.0);}
+  fn permute(xp :vec4<f32>)->vec4<f32> {
+  		return  mod4v(((xp*34.0)+1.0)*xp, 289.0);
+  	}
+
+  fn taylorInvSqrt(r: vec4<f32>)->vec4<f32>{return 1.79284291400159 - 0.85373472095314 * r;}
+
+  fn _noise(v: vec3<f32>)-> f32 {
+    const  C = vec2<f32>(1.0/6.0, 1.0/3.0) ;
+    const  D = vec4<f32>(0.0, 0.5, 1.0, 2.0);
+
+  // First corner
+    var i : vec3<f32> = floor(v + dot(v, C.yyy) );
+    let x0 =   v - i + dot(i, C.xxx) ;
+
+  // Other corners
+    let g = step(x0.yzx, x0.xyz);
+    let l = 1.0 - g;
+    let i1 = min( g.xyz, l.zxy );
+    let i2 = max( g.xyz, l.zxy );
+
+    //  x0 = x0 - 0. + 0.0 * C
+    let x1 = x0 - i1 + 1.0 * C.xxx;
+    let x2 = x0 - i2 + 2.0 * C.xxx;
+    let x3 = x0 - 1. + 3.0 * C.xxx;
+
+  // Permutations
+    i.x = i.x % 289.0;
+    i.y = i.y % 289.0;
+    i.z = i.z % 289.0;
+    let p = permute( permute( permute(
+               i.z + vec4<f32>(0.0, i1.z, i2.z, 1.0 ))
+             + i.y + vec4<f32>(0.0, i1.y, i2.y, 1.0 ))
+             + i.x + vec4<f32>(0.0, i1.x, i2.x, 1.0 ));
+
+  // Gradients
+  // ( N*N points uniformly over a square, mapped onto an octahedron.)
+    let n_ = 1.0/7.0; // N=7
+    let ns = n_ * D.wyz - D.xzx;
+
+    let j = p - 49.0 * floor(p * ns.z *ns.z);  //  mod(p,N*N)
+
+    let x_ = floor(j * ns.z);
+    let y_ = floor(j - 7.0 * x_ );    // mod(j,N)
+
+    let x = x_ *ns.x + ns.yyyy;
+    let y = y_ *ns.x + ns.yyyy;
+    let h = 1.0 - abs(x) - abs(y);
+
+    let b0 = vec4<f32>( x.xy, y.xy );
+    let b1 = vec4<f32>( x.zw, y.zw );
+
+    let s0 = floor(b0)*2.0 + 1.0;
+    let s1 = floor(b1)*2.0 + 1.0;
+    let sh = -step(h, vec4<f32>(0.0));
+
+    let a0 = b0.xzyw + s0.xzyw*sh.xxyy ;
+    let a1 = b1.xzyw + s1.xzyw*sh.zzww ;
+
+    var p0 = vec3<f32>(a0.xy,h.x);
+    var p1 = vec3<f32>(a0.zw,h.y);
+    var p2 = vec3<f32>(a1.xy,h.z);
+    var p3 = vec3<f32>(a1.zw,h.w);
+
+  //Normalise gradients
+    let norm = taylorInvSqrt(vec4<f32>(dot(p0,p0), dot(p1,p1), dot(p2, p2), dot(p3,p3)));
+    p0 *= norm.x;
+    p1 *= norm.y;
+    p2 *= norm.z;
+    p3 *= norm.w;
+
+    var m = max(0.6 - vec4<f32>(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), vec4<f32>(0.0));
+    m = m * m;
+
+    return 42.0 * dot( m*m, vec4<f32>( dot(p0,x0), dot(p1,x1),
+                                  dot(p2,x2), dot(p3,x3) ) );
+  }`
+  },
+
+
+ _rgbToHsv: {
+    type: 'util',
+    wgsl: `fn _rgbToHsv(c: vec3<f32>) -> vec3<f32> {
+            let K = vec4<f32>(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+            let p = mix(vec4<f32>(c.bg, K.wz), vec4<f32>(c.gb, K.xy), step(c.b, c.g));
+            let q = mix(vec4<f32>(p.xyw, c.r), vec4<f32>(c.r, p.yzx), step(p.x, c.r));
+
+            let d = q.x - min(q.w, q.y);
+            let e = 1.0e-10;
+            return vec3<f32>(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+        }`
+  },
+ _hsvToRgb: {
+    type: 'util',
+    wgsl: `fn _hsvToRgb(c: vec3<f32>) -> vec3<f32> {
+        let K = vec4<f32>(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+        let p : vec3<f32> = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+        let cv : vec3<f32> = p - K.xxx;
+        let cvmin =  vec3<f32>(0.0, 0.0, 0.0);
+        let cvmax =  vec3<f32>(1.0, 1.0, 1.0);
+        return  vec3<f32> (c.z * mix(K.xxx, clamp(cv, cvmin, cvmax), c.y));
+    }`
+  }
+}

--- a/extensions/vertex/wgsl/wgsl-hydra.js
+++ b/extensions/vertex/wgsl/wgsl-hydra.js
@@ -1,0 +1,1383 @@
+import {FBOToCanvas} from "./FBOToCanvas.js";
+import {FBO4ToCanvas} from "./FBO4ToCanvas.js";
+import {BLEND_MODES} from "./outputWgsl.js";
+
+// Used to enable a single pass through the "animate" routine.
+// Used for testing to avoid a flood of console error messages.
+const oneShot = false;
+let fired = false;
+
+const trace = false;
+
+// ------------------------------------------------------------------------------
+// standard prefix strings for all shaders
+//
+const vertexPrefix = `
+	 struct VertexOutput {
+  	@builtin(position) position : vec4f,
+  	@location(0) texcoord : vec2f,
+  	@location(1) faceId : f32,
+  	// Vertex data for fragment shader
+  	@location(2) v_position : vec3f,
+  	@location(3) v_normal : vec3f,
+  	@location(4) v_worldNormal : vec3f,
+  	@location(5) v_tangent : vec3f,
+  	@location(6) v_bitangent : vec3f,
+  	@location(7) v_viewDir : vec3f,
+  	@location(8) v_depth : f32,
+  	@location(9) v_color : vec4f,
+	 };
+`;
+
+const fragPrefix = `
+   @group(0) @binding(0) var<uniform> time: f32;
+   @group(0) @binding(1) var<uniform> resolution: vec2<f32>;
+   @group(0) @binding(2) var<uniform> mouse: vec2<f32>;
+   @group(0) @binding(3) var<uniform> u_spriteUV: vec4<f32>;
+   @group(0) @binding(4) var<uniform> u_spriteGrid: vec2<f32>;
+`;
+
+// ------------------------------------------------------------------------------
+// standard vertex shader that sends position and uv for a quad
+// 
+ const vertexShaderCode = vertexPrefix + `
+    @vertex
+    fn main(@builtin(vertex_index) vertexIndex : u32) -> VertexOutput {
+      var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, 1.0),
+        vec2<f32>(1.0, -1.0),
+
+        vec2<f32>(1.0, -1.0),
+        vec2<f32>(-1.0, 1.0),
+        vec2<f32>(1.0, 1.0)
+      );
+
+     var output : VertexOutput;
+     output.position = vec4<f32>( positions[vertexIndex], 0.0, 1.0);
+     output.texcoord = positions[vertexIndex] / 2.0 + 0.5; // positions are -1 to 1, texcoords are 0
+     output.faceId = 0.0;
+
+     // Default vertex data for fullscreen quad
+     output.v_position = vec3f(positions[vertexIndex], 0.0);
+     output.v_normal = vec3f(0.0, 0.0, 1.0);
+     output.v_worldNormal = vec3f(0.0, 0.0, 1.0);
+     output.v_tangent = vec3f(1.0, 0.0, 0.0);
+     output.v_bitangent = vec3f(0.0, 1.0, 0.0);
+     output.v_viewDir = vec3f(0.0, 0.0, 1.0);
+     output.v_depth = 1.0;
+     output.v_color = vec4f(1.0, 1.0, 1.0, 1.0);
+
+     return output;
+    }
+`;
+
+// Per-sprite data for a sprite render pass
+class SpritePassEntry {
+	constructor(chan, level) {
+		this.chan = chan;
+		this.level = level;
+		this.reset();
+	}
+
+	reset() {
+		this.fragmentShaderSource = undefined;
+		this.fragmentShaderModule = undefined;
+		this.vertexShaderModule = undefined;
+		this.pipelineLayout = undefined;
+		this.pipeline = undefined;
+
+		this.uniformList = undefined;
+		this.channelUniforms = [];
+		this.textureUniforms = [];
+		this.valueUniforms = [];
+		this.bindGroupHeader = undefined;
+		this.bindGroupLayout = undefined;
+
+		this.hasValueUniforms = false;
+		this.structString = undefined;
+		this.valueStructView = undefined;
+		this.structUniformBuffer = undefined;
+
+		// Vertex buffer support
+		this.hasCustomGeometry = false;
+		this.vertexBuffer = undefined;
+		this.uvBuffer = undefined;
+		this.faceIdBuffer = undefined;
+		this.normalBuffer = undefined;
+		this.tangentBuffer = undefined;
+		this.colorBuffer = undefined;
+		this.vertexCount = 0;
+		this.vertexWgsl = undefined;
+		this.vertexUniforms = [];
+		this.vertexUniformBuffer = undefined;
+		this.vertexUniformView = undefined;
+		this.vertexBindGroupLayout = undefined;
+		this.vertexBindGroup = undefined;
+		this.hasExplicitUVs = false;
+		this.hasFaceIds = false;
+		this.hasNormals = false;
+		this.hasTangents = false;
+		this.hasColors = false;
+
+		// Blend mode
+		this.blendMode = 'normal';
+	}
+}
+
+// Per channel data - now holds multiple sprites
+class RenderPassEntry {
+	constructor(chan) {
+		this.chan = chan;
+		this.channelTexInfo = [];
+		// Map<spriteLevel, SpritePassEntry>
+		this.sprites = new Map();
+		this.reset();
+	}
+
+	reset() {
+		this.pingPongs = 0;
+
+		// Legacy single-pipeline fields (for backward compat with setupHydraChain)
+		this.fragmentShaderSource = undefined;
+		this.fragmentShaderModule = undefined
+		this.pipelineLayout = undefined;
+		this.pipeline = undefined;
+
+		this.uniformList = undefined;
+		this.channelUniforms = []; // all listEntries
+		this.textureUniforms = []; // all uniformTextureListEntries
+		this.valueUniforms = [];	 // all uniformValueListEntries
+		this.bindGroupHeader = undefined;
+		this.bindGroupLayout = undefined;
+
+		this.hasValueUniforms = false;
+		this.structString = undefined;
+		this.valueStructView = undefined;
+		this.structUniformBuffer = undefined;
+
+		// Clear sprites
+		this.sprites.clear();
+	}
+};
+
+// ------------------------------------------------------------------------------
+// wgslHydra manages a set of N "channels", each one driving a given output channel.
+// 
+class wgslHydra {
+	// externalDevice: optional GPUDevice for sharing textures between Hydra instances
+	constructor (hydra, canvas, numChannels = 4, externalDevice = null) {
+		this.hydra = hydra;
+		this.canvas = canvas;
+	  this.context = this.canvas.getContext("webgpu");
+	  this.externalDevice = externalDevice;  // If provided, use shared device
+
+	  this.aspect = this.canvas.width / this.canvas.height;
+
+	  this.numChannels =  numChannels ? numChannels : 4;
+
+		this.renderPassInfo = new Array(numChannels);
+		for (let i = 0; i < numChannels; ++i) this.renderPassInfo[i] = new RenderPassEntry(i);
+	  this.time = 0.0;
+	  this.mousePos = {x: 0, y: 0};
+	  this.showQuad = false;
+	  this.outChannel = 0;
+
+	}
+	
+	relayUniformInfo(mouse) {
+		this.mousePos = mouse;
+	}
+
+	// Changes the destination canvas size and the outputs too.
+	async resizeOutputsTo(width, height) {
+    this.canvas.width = Math.max(1, Math.min(width, this.device.limits.maxTextureDimension2D));
+    this.canvas.height = Math.max(1, Math.min(height, this.device.limits.maxTextureDimension2D));
+
+		this.createOutputTextures();
+
+		// Recreate depth texture if it exists (for 3D rendering)
+		if (this.depthTexture) {
+			this.depthTexture.destroy();
+			this.depthTexture = null;
+			this.depthTextureView = null;
+			this.ensureDepthTexture();
+		}
+
+// resize the renderers by making new ones.
+		 this.fboRenderer = new FBOToCanvas(this.canvas, this.device);
+		 this.fbo4Renderer = new FBO4ToCanvas(this.canvas, this.device);
+	   await this.fboRenderer.initializeFBOdrawing();
+	   await this.fbo4Renderer.initializeFBOdrawing();
+	}
+
+ 
+	 createOutputTextures() {
+	  this.outputChannelObjects = this.hydra.o;
+    this.destTextureDescriptor = {
+        size: {
+            width: this.canvas.width,
+            height: this.canvas.height
+        },
+        mipLevelCount: 1,
+        format: this.format,
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT
+    };
+
+		for (let chan = 0; chan < this.numChannels; ++chan) {
+			let outp = this.outputChannelObjects[chan];
+			outp.createTexturesAndViews(this.device, this.destTextureDescriptor);
+ 	 	}
+	 }
+
+	// Lazily create depth texture for 3D rendering
+	ensureDepthTexture() {
+		if (this.depthTexture) return;
+		this.depthTexture = this.device.createTexture({
+			label: 'depthTexture',
+			size: { width: this.canvas.width, height: this.canvas.height },
+			format: 'depth24plus',
+			usage: GPUTextureUsage.RENDER_ATTACHMENT
+		});
+		this.depthTextureView = this.depthTexture.createView();
+	}
+
+	async setupHydra() {
+			if (trace) console.timeStamp("setupHydra");
+	      // Step 1: Check for WebGPU support
+      if (!navigator.gpu) {
+        console.error("WebGPU is not supported on this browser.");
+        return;
+      }
+
+      // Step 2: Use external device if provided, otherwise create our own
+      if (this.externalDevice) {
+        this.device = this.externalDevice;
+        console.log("wgslHydra: Using shared external GPUDevice");
+      } else {
+        const adapter = await navigator.gpu.requestAdapter();
+        if (!adapter) {
+          console.error("Failed to get GPU adapter.");
+          return;
+        }
+
+        const hasBGRA8unormStorage = adapter.features.has('bgra8unorm-storage');
+        this.device = await adapter.requestDevice({
+          requiredFeatures: hasBGRA8unormStorage ? ['bgra8unorm-storage'] : [],
+        });
+      }
+
+			// The fboRenderer is used to copy the results of our efforts to the final display canvas.
+			this.fboRenderer = new FBOToCanvas(this.canvas, this.device);
+			this.fbo4Renderer = new FBO4ToCanvas(this.canvas, this.device);
+
+			// setup the WebGPU context this Hydra will use.
+      this.format = navigator.gpu.getPreferredCanvasFormat();
+      this.context.configure({
+        device: this.device,
+        format: this.format,
+        alphaMode: "opaque",   //premultiplied / opaque
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT
+      });
+
+    this.dummyTexture = await this.device.createTexture({
+    size: [320, 240],
+    format: this.format, // was "rgba8unorm"
+    usage:
+      GPUTextureUsage.TEXTURE_BINDING |
+      GPUTextureUsage.COPY_DST,
+  });
+
+		// ------------------------------------------------------------------------------
+		// create shared bind group layout for time, resolution, mouse, spriteUV, spriteGrid.
+		this.sharedBindGroupLayout = this.device.createBindGroupLayout({
+			label: "",
+  		entries: [
+    	{
+      	binding: 0, // Binding index for time.
+     	  visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+      	buffer: { type: "uniform" }, // Resource type
+    	},
+    	{
+      	binding: 1, // Binding index "resolution"
+     	  visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+      	buffer: { type: "uniform" }, // Resource type
+    	},
+    	{
+      	binding: 2, // Binding index "mouse"
+     	  visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+      	buffer: { type: "uniform" }, // Resource type
+    	},
+    	{
+      	binding: 3, // Binding index "u_spriteUV"
+     	  visibility: GPUShaderStage.FRAGMENT,
+      	buffer: { type: "uniform" },
+    	},
+    	{
+      	binding: 4, // Binding index "u_spriteGrid"
+     	  visibility: GPUShaderStage.FRAGMENT,
+      	buffer: { type: "uniform" },
+    	},
+  		],
+		});
+
+// Create the shared uniform buffer for time
+		this.timeUniformBuffer = this.device.createBuffer({
+  			label: "time uniform buffer",
+  			size: 4, // 32-bit float is 4 bytes
+  			usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+		});
+
+		// Create a typed array to hold the float value for time
+		this.timeUniformValues = new Float32Array(1); // Array of 1 float
+
+// Create the shared uniform buffer for resolution
+		this.resolutionUniformBuffer = this.device.createBuffer({
+  			label: "resolution uniform buffer",
+  			size: 8, // 2 x 32-bit float
+  			usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+		});
+		this.resolutionUniformValues = new Float32Array(2);
+
+// Create the shared uniform buffer for mouse
+		this.mouseUniformBuffer = this.device.createBuffer({
+  			label: "mouse uniform buffer",
+  			size: 8, // 2 x 32-bit float
+  			usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+		});
+		this.mouseUniformValues = new Float32Array(2); // Array of 2 float
+
+// Create the shared uniform buffer for spriteUV (vec4)
+		this.spriteUVUniformBuffer = this.device.createBuffer({
+  			label: "spriteUV uniform buffer",
+  			size: 16, // 4 x 32-bit float
+  			usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+		});
+		this.spriteUVUniformValues = new Float32Array([0, 0, 1, 1]); // Default: full texture
+
+// Create the shared uniform buffer for spriteGrid (vec2)
+		this.spriteGridUniformBuffer = this.device.createBuffer({
+  			label: "spriteGrid uniform buffer",
+  			size: 8, // 2 x 32-bit float
+  			usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+		});
+		this.spriteGridUniformValues = new Float32Array([1, 1]); // Default: 1x1 grid
+
+		this.sharedBindGroup = this.device.createBindGroup({
+			 label: "shared bind group",
+  	   layout: this.sharedBindGroupLayout,
+  		 entries: [
+    	{
+      binding: 0,
+      resource: { buffer: this.timeUniformBuffer }, // Resource for the binding
+    	},
+ 			{
+			binding: 1,
+      resource: { buffer: this.resolutionUniformBuffer }, // Resource for the binding
+			},
+      {
+      binding: 2,
+      resource: { buffer: this.mouseUniformBuffer }, // Resource for the binding
+    	},
+      {
+      binding: 3,
+      resource: { buffer: this.spriteUVUniformBuffer },
+    	},
+      {
+      binding: 4,
+      resource: { buffer: this.spriteGridUniformBuffer },
+    	}
+     ],
+		});
+
+
+
+		// ------------------------------------------------------------------------------
+		// Setup dest FBO and views for each channel:
+		//
+
+	 this.createOutputTextures();
+
+	 // create a vertex shader for all
+	 this.vertexShaderModule = this.device.createShaderModule({ label: "wgslvertex", code: vertexShaderCode });
+	 // Setup the renderer that goes from an fbo to final screen.
+	 await this.fboRenderer.initializeFBOdrawing();
+	 await this.fbo4Renderer.initializeFBOdrawing();
+
+	 if (trace) console.timeStamp("setup", "setupHydra", undefined, "wgsl-hydra", "hydra", "primary");
+
+	}
+
+
+		// ------------------------------------------------------------------------------
+		// set up a output render chain for a given channel number, uniforms list, and fragment shader string
+		//
+  async setupHydraChain(chan, uniforms, shader) {
+  		if (trace) console.timeStamp("setupHydraChain");
+			const rpe = this.renderPassInfo[chan];
+			rpe.reset();
+			rpe.outputObject = this.outputChannelObjects[chan];
+  		rpe.uniformList = uniforms;
+			this.generateUniformDeclarations(chan); // bindGroupHeader[chan]
+			rpe.fragmentShaderSource = vertexPrefix + fragPrefix + rpe.bindGroupHeader +  shader; //  + this.fragPrefix
+			
+			//console.log(this.fragmentShaderSource[chan]);
+
+      // Step 5: Create fragment shader module
+      rpe.fragmentShaderModule = this.device.createShaderModule({ label: "wgslsfrag", code: rpe.fragmentShaderSource });
+
+		// Create BindGroupLayouts for our each of our BindGroups
+
+		// We then use those BindGroupLayouts to concoct a Pipeline Layout we can give the Pipeline proper.
+   	   rpe.pipelineLayout = this.device.createPipelineLayout({
+          bindGroupLayouts: [this.sharedBindGroupLayout, rpe.bindGroupLayout],
+      });
+
+      // Step 6: Set up the render pipeline for this channel
+      	rpe.pipeline = this.device.createRenderPipeline({
+       	label: 'pipeline ' + chan,
+        vertex: {
+          module: this.vertexShaderModule,
+          entryPoint: "main",
+        },
+        fragment: {
+          module: rpe.fragmentShaderModule,
+          entryPoint: "main",
+          targets: [{ format: this.format }],
+        },
+        primitive: {
+          topology: "triangle-list",
+        },
+        layout: rpe.pipelineLayout
+      });
+
+			this.createSamplerOrBuffersForChan(chan);
+
+	    if (trace) console.timeStamp("hydraChain", "setupHydraChain", undefined, "wgsl-hydra", "hydra", "secondary-light");
+   }
+
+	// ------------------------------------------------------------------------------
+	// Setup a sprite render chain with optional custom geometry and vertex shader
+	//
+	async setupSpriteChain(chan, spriteLevel, config) {
+		if (trace) console.timeStamp("setupSpriteChain");
+		const { uniforms, fragShader, vertexWgsl, vertexUniforms, rawVerts, blendMode, primitive, has3D,
+			hasExplicitUVs, hasFaceIds, hasNormals, hasTangents, hasColors, uvs, faceIds, normals, tangents, colors, sprite } = config;
+
+		const rpe = this.renderPassInfo[chan];
+		rpe.outputObject = this.outputChannelObjects[chan];
+
+		// Create or get sprite entry
+		let spe = rpe.sprites.get(spriteLevel);
+		if (!spe) {
+			spe = new SpritePassEntry(chan, spriteLevel);
+			rpe.sprites.set(spriteLevel, spe);
+		} else {
+			spe.reset();
+		}
+
+		spe.uniformList = uniforms;
+		spe.blendMode = blendMode || 'normal';
+		spe.hasCustomGeometry = rawVerts !== null && rawVerts !== undefined;
+		spe.hasExplicitUVs = hasExplicitUVs || false;
+		spe.hasFaceIds = hasFaceIds || false;
+		spe.hasNormals = hasNormals || false;
+		spe.hasTangents = hasTangents || false;
+		spe.hasColors = hasColors || false;
+		spe.sprite = sprite || null;
+
+		// Generate uniform declarations for fragment shader
+		this.generateSpriteUniformDeclarations(spe);
+
+		// Build fragment shader source
+		spe.fragmentShaderSource = vertexPrefix + fragPrefix + spe.bindGroupHeader + fragShader;
+		spe.fragmentShaderModule = this.device.createShaderModule({
+			label: `frag_c${chan}_s${spriteLevel}`,
+			code: spe.fragmentShaderSource
+		});
+
+		// Setup vertex shader and buffer
+		if (spe.hasCustomGeometry && vertexWgsl) {
+			// Custom vertex shader with vertex buffer
+			spe.vertexWgsl = vertexWgsl;
+			spe.vertexUniforms = vertexUniforms || [];
+			spe.has3D = has3D || false;
+			spe.vertexShaderModule = this.device.createShaderModule({
+				label: `vert_c${chan}_s${spriteLevel}`,
+				code: vertexWgsl
+			});
+
+			// Create vertex buffer from raw vertices (reshape to vec3)
+			const verts = this.reshapeToVec3(rawVerts, spe.has3D);
+			spe.vertexCount = verts.length;
+			const vertexData = new Float32Array(verts.flat());
+			spe.vertexBuffer = this.device.createBuffer({
+				label: `vertbuf_c${chan}_s${spriteLevel}`,
+				size: vertexData.byteLength,
+				usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+			});
+			this.device.queue.writeBuffer(spe.vertexBuffer, 0, vertexData);
+
+			// Create UV buffer if explicit UVs provided
+			if (spe.hasExplicitUVs && uvs && uvs.length > 0) {
+				const uvData = new Float32Array(uvs);
+				spe.uvBuffer = this.device.createBuffer({
+					label: `uvbuf_c${chan}_s${spriteLevel}`,
+					size: uvData.byteLength,
+					usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+				});
+				this.device.queue.writeBuffer(spe.uvBuffer, 0, uvData);
+			}
+
+			// Create faceId buffer if faceIds provided
+			if (spe.hasFaceIds && faceIds && faceIds.length > 0) {
+				const faceIdData = new Float32Array(faceIds);
+				spe.faceIdBuffer = this.device.createBuffer({
+					label: `faceidbuf_c${chan}_s${spriteLevel}`,
+					size: faceIdData.byteLength,
+					usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+				});
+				this.device.queue.writeBuffer(spe.faceIdBuffer, 0, faceIdData);
+			}
+
+			// Create normal buffer if normals provided
+			if (spe.hasNormals && normals && normals.length > 0) {
+				const normalData = new Float32Array(normals);
+				spe.normalBuffer = this.device.createBuffer({
+					label: `normalbuf_c${chan}_s${spriteLevel}`,
+					size: normalData.byteLength,
+					usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+				});
+				this.device.queue.writeBuffer(spe.normalBuffer, 0, normalData);
+			}
+
+			// Create tangent buffer if tangents provided (vec4: xyz = tangent, w = handedness)
+			if (spe.hasTangents && tangents && tangents.length > 0) {
+				const tangentData = new Float32Array(tangents);
+				spe.tangentBuffer = this.device.createBuffer({
+					label: `tangentbuf_c${chan}_s${spriteLevel}`,
+					size: tangentData.byteLength,
+					usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+				});
+				this.device.queue.writeBuffer(spe.tangentBuffer, 0, tangentData);
+			}
+
+			// Create color buffer if colors provided (vec4: RGBA)
+			if (spe.hasColors && colors && colors.length > 0) {
+				const colorData = new Float32Array(colors);
+				spe.colorBuffer = this.device.createBuffer({
+					label: `colorbuf_c${chan}_s${spriteLevel}`,
+					size: colorData.byteLength,
+					usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+				});
+				this.device.queue.writeBuffer(spe.colorBuffer, 0, colorData);
+			}
+
+			// Setup vertex uniform buffer if needed
+			if (spe.vertexUniforms.length > 0) {
+				this.setupVertexUniforms(spe);
+			}
+		} else {
+			// Use default fullscreen vertex shader
+			spe.vertexShaderModule = this.vertexShaderModule;
+			spe.vertexCount = 6;
+		}
+
+		// Build pipeline layout
+		const bindGroupLayouts = [this.sharedBindGroupLayout, spe.bindGroupLayout];
+		if (spe.vertexBindGroupLayout) {
+			bindGroupLayouts.push(spe.vertexBindGroupLayout);
+		}
+		spe.pipelineLayout = this.device.createPipelineLayout({ bindGroupLayouts });
+
+		// Get blend state
+		const blendState = BLEND_MODES[spe.blendMode] || BLEND_MODES.normal;
+
+		// Create pipeline
+		const pipelineDescriptor = {
+			label: `pipeline_c${chan}_s${spriteLevel}`,
+			layout: spe.pipelineLayout,
+			vertex: {
+				module: spe.vertexShaderModule,
+				entryPoint: "main",
+			},
+			fragment: {
+				module: spe.fragmentShaderModule,
+				entryPoint: "main",
+				targets: [{
+					format: this.format,
+					blend: blendState
+				}],
+			},
+			primitive: {
+				topology: "triangle-list",
+			},
+		};
+
+		// Add vertex buffer layout if custom geometry
+		if (spe.hasCustomGeometry) {
+			const bufferLayouts = [{
+				arrayStride: 12, // 3 floats * 4 bytes (position)
+				attributes: [{
+					shaderLocation: 0,
+					offset: 0,
+					format: 'float32x3'
+				}]
+			}];
+
+			// Add UV buffer layout if explicit UVs
+			if (spe.hasExplicitUVs && spe.uvBuffer) {
+				bufferLayouts.push({
+					arrayStride: 8, // 2 floats * 4 bytes (texcoord)
+					attributes: [{
+						shaderLocation: 1,
+						offset: 0,
+						format: 'float32x2'
+					}]
+				});
+			}
+
+			// Add faceId buffer layout if faceIds
+			if (spe.hasFaceIds && spe.faceIdBuffer) {
+				bufferLayouts.push({
+					arrayStride: 4, // 1 float * 4 bytes (faceId)
+					attributes: [{
+						shaderLocation: 2,
+						offset: 0,
+						format: 'float32'
+					}]
+				});
+			}
+
+			// Add normal buffer layout if normals
+			if (spe.hasNormals && spe.normalBuffer) {
+				bufferLayouts.push({
+					arrayStride: 12, // 3 floats * 4 bytes (normal)
+					attributes: [{
+						shaderLocation: 3,
+						offset: 0,
+						format: 'float32x3'
+					}]
+				});
+			}
+
+			// Add tangent buffer layout if tangents (vec4: xyz = tangent, w = handedness)
+			if (spe.hasTangents && spe.tangentBuffer) {
+				bufferLayouts.push({
+					arrayStride: 16, // 4 floats * 4 bytes (tangent vec4)
+					attributes: [{
+						shaderLocation: 4,
+						offset: 0,
+						format: 'float32x4'
+					}]
+				});
+			}
+
+			// Add color buffer layout if colors (vec4: RGBA)
+			if (spe.hasColors && spe.colorBuffer) {
+				bufferLayouts.push({
+					arrayStride: 16, // 4 floats * 4 bytes (color vec4)
+					attributes: [{
+						shaderLocation: 5,
+						offset: 0,
+						format: 'float32x4'
+					}]
+				});
+			}
+
+			pipelineDescriptor.vertex.buffers = bufferLayouts;
+		}
+
+		// Add depth testing for 3D geometry
+		if (spe.has3D) {
+			this.ensureDepthTexture();
+			pipelineDescriptor.depthStencil = {
+				format: 'depth24plus',
+				depthWriteEnabled: true,
+				depthCompare: 'less'
+			};
+		}
+
+		spe.pipeline = this.device.createRenderPipeline(pipelineDescriptor);
+
+		// Create samplers/buffers for fragment uniforms
+		this.createSamplerOrBuffersForSprite(spe);
+
+		if (trace) console.timeStamp("spriteChain", "setupSpriteChain", undefined, "wgsl-hydra", "hydra", "secondary-light");
+	}
+
+	// Clear all sprite chains for a channel
+	clearSpriteChains(chan) {
+		const rpe = this.renderPassInfo[chan];
+		if (rpe.sprites) {
+			for (const [level, spe] of rpe.sprites) {
+				if (spe.vertexBuffer) {
+					spe.vertexBuffer.destroy();
+				}
+				if (spe.uvBuffer) {
+					spe.uvBuffer.destroy();
+				}
+				if (spe.faceIdBuffer) {
+					spe.faceIdBuffer.destroy();
+				}
+				if (spe.normalBuffer) {
+					spe.normalBuffer.destroy();
+				}
+				if (spe.tangentBuffer) {
+					spe.tangentBuffer.destroy();
+				}
+				if (spe.colorBuffer) {
+					spe.colorBuffer.destroy();
+				}
+				if (spe.vertexUniformBuffer) {
+					spe.vertexUniformBuffer.destroy();
+				}
+			}
+			rpe.sprites.clear();
+		}
+	}
+
+	// Reshape vertex data to vec3 format
+	// is3D: explicit flag indicating 3D data (required for ambiguous lengths divisible by both 2 and 3)
+	reshapeToVec3(flatArray, is3D = false) {
+		const len = flatArray.length;
+		const stride = is3D ? 3 : 2;
+		const verts = [];
+		for (let i = 0; i < len; i += stride) {
+			if (is3D) {
+				verts.push([flatArray[i], flatArray[i + 1], flatArray[i + 2]]);
+			} else {
+				verts.push([flatArray[i], flatArray[i + 1], 0.0]);
+			}
+		}
+		return verts;
+	}
+
+	// Setup vertex uniform buffer
+	setupVertexUniforms(spe) {
+		// Calculate buffer size with proper WGSL alignment
+		// f32 = 4 bytes (align 4), vec2f = 8 bytes (align 8), vec3f = 12 bytes (align 16)
+		let size = 0;
+		for (const u of spe.vertexUniforms) {
+			if (u.type === 'f32') {
+				// Align to 4 bytes
+				size = Math.ceil(size / 4) * 4;
+				size += 4;
+			} else if (u.type === 'vec2f') {
+				// Align to 8 bytes
+				size = Math.ceil(size / 8) * 8;
+				size += 8;
+			} else if (u.type === 'vec3f') {
+				// Align to 16 bytes (WGSL requirement)
+				size = Math.ceil(size / 16) * 16;
+				size += 12; // vec3f is 12 bytes but needs 16-byte alignment
+			}
+		}
+		// Align total to 16 bytes
+		size = Math.ceil(size / 16) * 16;
+
+		spe.vertexUniformBuffer = this.device.createBuffer({
+			label: `vtxunif_c${spe.chan}_s${spe.level}`,
+			size: Math.max(size, 16),
+			usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+		});
+
+		spe.vertexBindGroupLayout = this.device.createBindGroupLayout({
+			label: `vtxbgl_c${spe.chan}_s${spe.level}`,
+			entries: [{
+				binding: 0,
+				visibility: GPUShaderStage.VERTEX,
+				buffer: { type: "uniform" }
+			}]
+		});
+
+		spe.vertexBindGroup = this.device.createBindGroup({
+			label: `vtxbg_c${spe.chan}_s${spe.level}`,
+			layout: spe.vertexBindGroupLayout,
+			entries: [{
+				binding: 0,
+				resource: { buffer: spe.vertexUniformBuffer }
+			}]
+		});
+	}
+
+	// Generate uniform declarations for a sprite
+	generateSpriteUniformDeclarations(spe) {
+		let uniInfo = spe.uniformList;
+		let bindGroupEntry = "";
+		let i = 1;
+		let ui = 0;
+
+		spe.channelUniforms = [];
+
+		Object.keys(uniInfo).forEach(key => {
+			if (key === 'prevBuffer') return;
+			let uniEntry;
+			if (key.startsWith("tex")) {
+				uniEntry = new uniformTextureListEntry(spe.chan, i, key, uniInfo[key]);
+				spe.textureUniforms.push(uniEntry);
+				i += uniEntry.indexesUsed;
+			} else {
+				uniEntry = new uniformValueListEntry(spe.chan, ui, key, uniInfo[key], uniInfo);
+				spe.valueUniforms.push(uniEntry);
+				ui++;
+			}
+			spe.channelUniforms.push(uniEntry);
+		});
+
+		let ourValues = spe.valueUniforms;
+		spe.hasValueUniforms = ourValues.length > 0;
+		let bindings = "";
+		let bgLayoutentries = [];
+
+		if (spe.hasValueUniforms) {
+			let struct = `struct UF {\n`;
+			for (let j = 0; j < ourValues.length; ++j) {
+				struct = struct + ourValues[j].getStructLineItem();
+			}
+			struct = struct + `};\n@group(1) @binding(0) var<uniform> uf : UF;\n`;
+			spe.structString = struct;
+			bindings = struct;
+			bgLayoutentries = [{
+				binding: 0,
+				visibility: GPUShaderStage.FRAGMENT,
+				buffer: { type: "uniform" }
+			}];
+		}
+
+		let ourTextureUniforms = spe.textureUniforms;
+		for (let j = 0; j < ourTextureUniforms.length; ++j) {
+			let aUnif = ourTextureUniforms[j];
+			let bgs = aUnif.bindGroupString();
+			bindings = bindings + bgs;
+			bgLayoutentries.push(...aUnif.getBindGroupLayoutEntries());
+		}
+
+		spe.bindGroupLayout = this.device.createBindGroupLayout({
+			label: "sprite bg layout " + spe.chan + "_" + spe.level,
+			entries: bgLayoutentries
+		});
+		spe.bindGroupHeader = bindings;
+	}
+
+	// Create samplers/buffers for sprite
+	createSamplerOrBuffersForSprite(spe) {
+		if (spe.hasValueUniforms) {
+			spe.valueStructView = new Float32Array(spe.valueUniforms.length);
+			spe.valueStructBuffer = this.device.createBuffer({
+				size: spe.valueStructView.byteLength,
+				usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+			});
+		}
+		let ourUniforms = spe.textureUniforms;
+		for (let i = 0; i < ourUniforms.length; ++i) {
+			ourUniforms[i].createSamplerOrBuffers(this.device);
+		}
+	}
+
+	// Fill bind group for sprite
+	fillSpriteBindGroup(spe) {
+		let allUniforms = spe.channelUniforms;
+		if (!allUniforms || allUniforms.length === 0) {
+			return {
+				label: "spritebg" + spe.chan + "_" + spe.level,
+				layout: spe.bindGroupLayout,
+				entries: []
+			};
+		}
+
+		let bga;
+		if (spe.hasValueUniforms) {
+			this.setSpriteValueUniformValues(spe, this.time);
+			this.device.queue.writeBuffer(spe.valueStructBuffer, 0, spe.valueStructView);
+			bga = [{ binding: 0, resource: { buffer: spe.valueStructBuffer } }];
+		} else {
+			bga = [];
+		}
+
+		let ourUniforms = spe.textureUniforms;
+		for (let i = 0; i < ourUniforms.length; ++i) {
+			let aUniform = ourUniforms[i];
+			bga.push(...aUniform.getBindGroupEntries(this, this.time));
+		}
+
+		return {
+			label: "spritebg" + spe.chan + "_" + spe.level,
+			layout: spe.bindGroupLayout,
+			entries: bga
+		};
+	}
+
+	setSpriteValueUniformValues(spe, time) {
+		let ourUniforms = spe.valueUniforms;
+		for (let i = 0; i < ourUniforms.length; ++i) {
+			ourUniforms[i].setUniformValues(spe, time);
+		}
+	}
+
+	// Update vertex uniforms for a sprite
+	updateVertexUniforms(spe) {
+		if (!spe.vertexUniforms || spe.vertexUniforms.length === 0) return;
+
+		// Calculate total size with alignment (matches setupVertexUniforms)
+		let totalSize = 0;
+		for (const u of spe.vertexUniforms) {
+			if (u.type === 'f32') {
+				totalSize = Math.ceil(totalSize / 4) * 4;
+				totalSize += 4;
+			} else if (u.type === 'vec2f') {
+				totalSize = Math.ceil(totalSize / 8) * 8;
+				totalSize += 8;
+			} else if (u.type === 'vec3f') {
+				totalSize = Math.ceil(totalSize / 16) * 16;
+				totalSize += 12;
+			}
+		}
+		totalSize = Math.ceil(totalSize / 16) * 16;
+
+		// Create buffer with proper alignment
+		const floatData = new Float32Array(Math.max(totalSize / 4, 4));
+		let offset = 0;
+
+		for (const u of spe.vertexUniforms) {
+			let val = typeof u.value === 'function' ? u.value() : u.value;
+
+			if (u.type === 'f32') {
+				// Align to 4 bytes (1 float)
+				offset = Math.ceil(offset);
+				const v = Array.isArray(val) ? val[0] : val;
+				floatData[offset] = typeof v === 'function' ? v() : v;
+				offset += 1;
+			} else if (u.type === 'vec2f') {
+				// Align to 8 bytes (2 floats)
+				offset = Math.ceil(offset / 2) * 2;
+				const arr = Array.isArray(val) ? val : [val, val];
+				floatData[offset] = typeof arr[0] === 'function' ? arr[0]() : arr[0];
+				floatData[offset + 1] = typeof arr[1] === 'function' ? arr[1]() : arr[1];
+				offset += 2;
+			} else if (u.type === 'vec3f') {
+				// Align to 16 bytes (4 floats)
+				offset = Math.ceil(offset / 4) * 4;
+				const arr = Array.isArray(val) ? val : [val, val, val];
+				floatData[offset] = typeof arr[0] === 'function' ? arr[0]() : arr[0];
+				floatData[offset + 1] = typeof arr[1] === 'function' ? arr[1]() : arr[1];
+				floatData[offset + 2] = typeof arr[2] === 'function' ? arr[2]() : arr[2];
+				offset += 3;
+			}
+		}
+
+		this.device.queue.writeBuffer(spe.vertexUniformBuffer, 0, floatData);
+	}
+
+		// ------------------------------------------------------------------------------
+		// animate function
+		//
+		async animate(dT) {
+			if (trace) console.timeStamp("animate");
+			if(oneShot) {
+				 if(fired) return;
+			   console.log("One Shot is set for requestAnimationFrame");
+				 fired = true;
+			}
+		// Create a master command encoder.
+    const commandEncoder = this.device.createCommandEncoder();
+
+		// Setup the universal uniforms
+		this.timeUniformValues[0] = this.time += (dT / 1000.0);
+   	this.device.queue.writeBuffer(this.timeUniformBuffer, 0, this.timeUniformValues);
+
+		this.resolutionUniformValues[0] = this.canvas.width;
+		this.resolutionUniformValues[1] = this.canvas.height;
+		this.device.queue.writeBuffer(this.resolutionUniformBuffer, 0, this.resolutionUniformValues);
+
+		this.mouseUniformValues[0] = this.mousePos.x;
+		this.mouseUniformValues[1] = this.mousePos.y;
+		this.device.queue.writeBuffer(this.mouseUniformBuffer, 0, this.mouseUniformValues);
+
+		// Write sprite uniforms (defaults - could be updated per-sprite later)
+		this.device.queue.writeBuffer(this.spriteUVUniformBuffer, 0, this.spriteUVUniformValues);
+		this.device.queue.writeBuffer(this.spriteGridUniformBuffer, 0, this.spriteGridUniformValues);
+
+		// For each active channel...
+    for (let chan = 0; chan < this.numChannels; ++chan) {
+ 			const rpe = this.renderPassInfo[chan];
+
+			// Check if we have sprites or legacy pipeline
+			const hasSprites = rpe.sprites && rpe.sprites.size > 0;
+			const hasLegacyPipeline = rpe.pipeline;
+
+			if (!hasSprites && !hasLegacyPipeline) continue;
+
+		  rpe.outputObject.flipPingPong();
+
+			if (hasSprites) {
+				// Render sprites in level order
+				const levels = Array.from(rpe.sprites.keys()).sort((a, b) => a - b);
+				let depthCleared = false;  // Track if depth buffer has been cleared this frame
+
+				for (let i = 0; i < levels.length; i++) {
+					const level = levels[i];
+					const spe = rpe.sprites.get(level);
+
+					// Level 0 clears, others load
+					const loadOp = level === 0 ? "clear" : "load";
+
+					const renderPassDescriptor = {
+						label: `renderPass_c${chan}_s${level}`,
+						colorAttachments: [{
+							label: `attachment_c${chan}_s${level}`,
+							view: rpe.outputObject.getCurrentTextureView(),
+							clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+							loadOp: loadOp,
+							storeOp: "store",
+						}],
+					};
+
+					// Add depth attachment for 3D geometry
+					// Clear depth on first 3D sprite of the frame, regardless of level
+					if (spe.has3D && this.depthTextureView) {
+						const shouldClearDepth = !depthCleared;
+						depthCleared = true;
+						renderPassDescriptor.depthStencilAttachment = {
+							view: this.depthTextureView,
+							depthClearValue: 1.0,
+							depthLoadOp: shouldClearDepth ? 'clear' : 'load',
+							depthStoreOp: 'store'
+						};
+					}
+
+					// Fill bind group for fragment uniforms
+					let ubgData = this.fillSpriteBindGroup(spe);
+					let ubg = this.device.createBindGroup(ubgData);
+
+					// Update vertex uniforms if needed
+					if (spe.vertexUniforms && spe.vertexUniforms.length > 0) {
+						this.updateVertexUniforms(spe);
+					}
+
+					// Update spriteGrid uniform for this sprite
+					if (spe.sprite && spe.sprite.cols && spe.sprite.rows) {
+						this.spriteGridUniformValues[0] = spe.sprite.cols;
+						this.spriteGridUniformValues[1] = spe.sprite.rows;
+					} else {
+						this.spriteGridUniformValues[0] = 1;
+						this.spriteGridUniformValues[1] = 1;
+					}
+					this.device.queue.writeBuffer(this.spriteGridUniformBuffer, 0, this.spriteGridUniformValues);
+
+					if (trace) console.timeStamp("spritepass");
+					const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+					passEncoder.setPipeline(spe.pipeline);
+					passEncoder.setBindGroup(0, this.sharedBindGroup);
+					passEncoder.setBindGroup(1, ubg);
+
+					// Set vertex bind group if we have vertex uniforms
+					if (spe.vertexBindGroup) {
+						passEncoder.setBindGroup(2, spe.vertexBindGroup);
+					}
+
+					// Set vertex buffer if custom geometry
+					if (spe.hasCustomGeometry && spe.vertexBuffer) {
+						// Slot indices must match the order in bufferLayouts array
+						let slot = 0;
+						passEncoder.setVertexBuffer(slot++, spe.vertexBuffer);
+						// Set UV buffer if explicit UVs
+						if (spe.hasExplicitUVs && spe.uvBuffer) {
+							passEncoder.setVertexBuffer(slot++, spe.uvBuffer);
+						}
+						// Set faceId buffer if faceIds
+						if (spe.hasFaceIds && spe.faceIdBuffer) {
+							passEncoder.setVertexBuffer(slot++, spe.faceIdBuffer);
+						}
+						// Set normal buffer if normals
+						if (spe.hasNormals && spe.normalBuffer) {
+							passEncoder.setVertexBuffer(slot++, spe.normalBuffer);
+						}
+						// Set tangent buffer if tangents
+						if (spe.hasTangents && spe.tangentBuffer) {
+							passEncoder.setVertexBuffer(slot++, spe.tangentBuffer);
+						}
+						// Set color buffer if colors
+						if (spe.hasColors && spe.colorBuffer) {
+							passEncoder.setVertexBuffer(slot++, spe.colorBuffer);
+						}
+						passEncoder.draw(spe.vertexCount);
+					} else {
+						passEncoder.draw(6);
+					}
+
+					passEncoder.end();
+
+					if (trace) console.timeStamp("sprite draw", "spritepass", undefined, "wgsl-hydra", "hydra", "tertiary");
+				}
+			} else {
+				// Legacy single pipeline rendering
+				const renderPassDescriptor = {
+					label: "renderPassDescriptor",
+					colorAttachments: [{
+						label: "canvas textureView attachment " + chan,
+						view: rpe.outputObject.getCurrentTextureView(),
+						clearValue: { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
+						loadOp: "clear",
+						storeOp: "store",
+					}],
+				};
+
+				let ubgData = await this.fillBindGroup(chan);
+				let ubg = await this.device.createBindGroup(ubgData);
+
+				if (trace) console.timeStamp("pass");
+				const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+				passEncoder.setPipeline(rpe.pipeline);
+				passEncoder.setBindGroup(0, this.sharedBindGroup);
+				passEncoder.setBindGroup(1, ubg);
+				passEncoder.draw(6);
+				passEncoder.end();
+
+				if (trace) console.timeStamp("draw pass", "pass", undefined, "wgsl-hydra", "hydra", "tertiary");
+			}
+   } // end "chan" loop.
+   // Do all the channels now.
+    this.device.queue.submit([commandEncoder.finish()]);
+
+    await this.device.queue.onSubmittedWorkDone();
+ 
+    if (this.showQuad) {
+			await this.fbo4Renderer.refreshCanvases(
+				this.outputChannelObjects[0].getCurrentTexture(),
+				this.outputChannelObjects[1].getCurrentTexture(),
+				this.outputChannelObjects[2].getCurrentTexture(),
+				this.outputChannelObjects[3].getCurrentTexture()
+			);
+    	}
+    else {
+    	await this.fboRenderer.refreshCanvas(this.outputChannelObjects[this.outChannel].getCurrentTexture());
+		}
+    //await this.device.queue.onSubmittedWorkDone();
+		if (trace) console.timeStamp("animation", "animate", undefined, "wgsl-hydra", "hydra", "secondary");
+
+	}
+
+	generateUniformDeclarations(chan) {
+		const rpe = this.renderPassInfo[chan];
+		let uniInfo = rpe.uniformList;
+
+		let bindGroupEntry = "";
+		let i = 1;
+		let ui = 0;
+
+		rpe.channelUniforms = [];
+
+		Object.keys(uniInfo).forEach(key => {
+  			if (key === 'prevBuffer') return;
+  			let uniEntry;
+  			if (key.startsWith("tex")) {
+  				// constructor(chan, index, name, valCallback)
+  				uniEntry = new uniformTextureListEntry(chan, i, key, uniInfo[key]);
+  				rpe.textureUniforms.push(uniEntry);
+  				  			i += uniEntry.indexesUsed;
+  			}
+  			else {
+  				uniEntry = new uniformValueListEntry(chan, ui, key, uniInfo[key], uniInfo);
+  				rpe.valueUniforms.push(uniEntry);
+  				ui++;
+  			}
+  			rpe.channelUniforms.push(uniEntry);
+
+  		})
+
+ 		let ourUniforms = rpe.channelUniforms;
+ 		let ourValues = rpe.valueUniforms;
+		rpe.hasValueUniforms = ourValues.length > 0;
+		let bindings = "";
+		let bgLayoutentries = [];
+	if (rpe.hasValueUniforms) {
+    	// Create the binding struct for the uniform f32 values.
+    		let struct = `struct UF {
+`;
+    		for(let j = 0; j < ourValues.length; ++j) {
+    			struct = struct + ourValues[j].getStructLineItem();
+    		}
+    		struct = struct + `};
+    @group(1) @binding(0) var<uniform> uf : UF;
+`;
+    		rpe.structString = struct;
+    		bindings = struct;
+    		bgLayoutentries = [{
+    			binding: 0,
+    			visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+    			buffer: { type: "uniform" } // Resource type
+        }];
+	} // We had value uniforms
+
+		let ourTextureUniforms = rpe.textureUniforms;
+		for(let j = 0; j < ourTextureUniforms.length; ++ j) { // textureUniforms
+ 			let aUnif = ourTextureUniforms[j];
+ 			let bgs = aUnif.bindGroupString()
+ 			bindings = bindings + bgs;
+ 			bgLayoutentries.push(...aUnif.getBindGroupLayoutEntries());
+ 		}
+
+		rpe.bindGroupLayout = this.device.createBindGroupLayout({
+			label: "bg layout " + chan,
+  		entries: bgLayoutentries
+  	});
+		rpe.bindGroupHeader = bindings;
+	}
+
+// called once since we can reuse samplers between frames.
+	createSamplerOrBuffersForChan(chan) {
+		const rpe = this.renderPassInfo[chan];
+		// First handle the struct with the non-texture stuff
+		if (rpe.hasValueUniforms) {
+    		//rpe.structDefs = makeShaderDataDefinitions(rpe.structString);
+    		rpe.valueStructView = new Float32Array(rpe.valueUniforms.length);
+    		rpe.valueStructBuffer = this.device.createBuffer({
+      		size: rpe.valueStructView.byteLength,
+      		usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    		});
+		}
+		// Now make samplers, etc.
+		let ourUniforms = rpe.textureUniforms;
+		for (let i = 0; i < ourUniforms.length; ++i)
+				ourUniforms[i].createSamplerOrBuffers(this.device);
+	
+	}
+
+	fillBindGroup(chan) {
+		const rpe = this.renderPassInfo[chan];
+		let allUniforms = rpe.channelUniforms;
+		if (!allUniforms || allUniforms.length === 0) {
+			return {label: "bg" + chan,
+				layout: rpe.bindGroupLayout,
+				entries: []
+			};
+		}
+
+		let bga
+		if (rpe.hasValueUniforms) {
+			this.setAllValueUniformValues(chan, this.time);
+			this.device.queue.writeBuffer(rpe.valueStructBuffer, 0, rpe.valueStructView);
+			bga =[{binding: 0, resource: {buffer: rpe.valueStructBuffer}}];
+		} else bga = [];
+
+		let ourUniforms = rpe.textureUniforms;
+		for (let i = 0; i < ourUniforms.length; ++i) {
+			let aUniform = ourUniforms[i];
+			bga.push(...aUniform.getBindGroupEntries(this, this.time));
+		}
+		let bgd = {
+			label: "bg" + chan,
+			layout: rpe.bindGroupLayout,
+			entries: bga
+		}
+		return bgd;
+ }
+
+
+ 	setAllValueUniformValues(chan, time) {
+ 		const rpe = this.renderPassInfo[chan];
+ 		let ourUniforms = rpe.valueUniforms;
+ 		for (let i = 0; i < ourUniforms.length; ++i) {
+ 			ourUniforms[i].setUniformValues(rpe, time);
+ 		}
+ 	}
+}
+
+// classes to represent uniforms. textures or f32 values.
+class uniformTextureListEntry {
+	constructor(chan, index, name, valCallback) {
+		this.chan = chan;
+		this.index = index;
+		this.name = name;
+		this.valCallback = valCallback;
+		this.indexesUsed = 2;
+	}
+
+	indexesUsed() {
+		return 2;
+	}
+
+	bindGroupString() {
+				return `@group(1) @binding(${this.index}) var samp${this.name}: sampler;
+ @group(1) @binding(${this.index + 1}) var ${this.name}:  texture_2d<f32>;
+`;
+		}
+
+	getBindGroupLayoutEntries() {
+				let samp =  {
+				binding: this.index,
+				visibility: GPUShaderStage.FRAGMENT,
+					sampler: {
+          	type: "filtering",
+        	}
+    		 };
+    		 
+    	 let text = {
+       	binding: this.index + 1, // Binding index for texture.
+     	  visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+      	texture: {
+          sampleType: "float",
+          viewDimension: "2d",
+          multisampled: false,
+         },
+    		}
+				return [samp, text];
+		}
+
+	createSamplerOrBuffers(device) {
+			this.sampler = device.createSampler();
+			return this.sampler;
+	}
+	
+	getBindGroupEntries(renderer) {
+		this.cbValue = this.valCallback();
+		if (!this.cbValue) {
+			this.cbValue = renderer.dummyTexture.createView();
+		}
+		return [
+			{binding: this.index, resource: this.sampler},
+			{binding: this.index+1, resource: this.cbValue}
+		];
+	}
+}
+
+
+class uniformValueListEntry {
+	constructor(chan, index, name, valCallback) {
+		this.chan = chan;
+		this.index = index;
+		this.name = name;
+		this.valCallback = valCallback;
+		this.indexesUsed = 0;
+	}
+
+
+
+	getBindGroupLayoutEntries() {
+    return [{
+			binding: this.index,
+			visibility: GPUShaderStage.FRAGMENT, // Shader stages where this binding is used
+			buffer: { type: "uniform" } // Resource type
+    }]
+	}
+
+
+  getStructLineItem() {
+		return `${this.name} : f32,
+`;
+  }
+
+
+	setUniformValues(rpe, time) {
+		let argsToCB = {time: time, bpm: 120};
+	  this.cbValue = this.valCallback(undefined, argsToCB);
+	  if (!this.cbValue || this.cbValue === NaN) {
+	  	this.cbValue = 0.0;
+	   }
+		rpe.valueStructView[this.index] = this.cbValue;
+  }
+}
+
+
+export {wgslHydra}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-synth",
-  "version": "1.3.29",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-synth",
-      "version": "1.3.29",
+      "version": "1.4.0",
       "license": "AGPL",
       "dependencies": {
         "meyda": "^5.6.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
     "./src/glsl/glsl-functions.js": {
       "import": "./src/glsl/glsl-functions.js",
       "require": "./src/glsl/glsl-functions.js"
+    },
+    "./extensions/vertex": {
+      "import": "./extensions/vertex/index.js"
+    },
+    "./extensions/vertex/webgpu": {
+      "import": "./extensions/vertex/index-webgpu.js"
     }
   },
   "unpkg": "./dist/hydra-synth.js",

--- a/src/generator-factory.js
+++ b/src/generator-factory.js
@@ -6,13 +6,15 @@ class GeneratorFactory {
       defaultUniforms,
       defaultOutput,
       extendTransforms = [],
-      changeListener = (() => {})
+      changeListener = (() => {}),
+      renderer = null
     } = {}
     ) {
     this.defaultOutput = defaultOutput
     this.defaultUniforms = defaultUniforms
     this.changeListener = changeListener
     this.extendTransforms = extendTransforms
+    this.renderer = renderer
     this.generators = {}
     this.init()
   }

--- a/src/glsl-source.js
+++ b/src/glsl-source.js
@@ -68,7 +68,18 @@ GlslSource.prototype.compile = function (transforms) {
   var uniforms = {}
   shaderInfo.uniforms.forEach((uniform) => { uniforms[uniform.name] = uniform.value })
 
-  var frag = `
+  // Use renderer's buildShader hook if available (plugin architecture)
+  // Otherwise fall back to built-in GLSL generation
+  const renderer = this.synth && this.synth.renderer
+  var frag
+
+  if (renderer && typeof renderer.buildShader === 'function') {
+    frag = renderer.buildShader(shaderInfo, {
+      precision: this.defaultOutput.precision
+    })
+  } else {
+    // Fallback: built-in GLSL generation
+    frag = `
   precision ${this.defaultOutput.precision} float;
   ${Object.values(shaderInfo.uniforms).map((uniform) => {
     let type = uniform.type
@@ -105,6 +116,7 @@ GlslSource.prototype.compile = function (transforms) {
     gl_FragColor = c;
   }
   `
+  }
 
   return {
     frag: frag,

--- a/src/hydra-synth.js
+++ b/src/hydra-synth.js
@@ -1,7 +1,5 @@
 
-import Output from './output.js'
 import loop from 'raf-loop'
-import Source from './hydra-source.js'
 import MouseTools from './lib/mouse.js'
 import Audio from './lib/audio.js'
 import VidRecorder from './lib/video-recorder.js'
@@ -9,7 +7,7 @@ import ArrayUtils from './lib/array-utils.js'
 // import strudel from './lib/strudel.js'
 import Sandbox from './eval-sandbox.js'
 import Generator from './generator-factory.js'
-import regl from 'regl'
+import { WebGL1Renderer } from './renderer/index.js'
 // const window = global.window
 
 
@@ -99,7 +97,19 @@ class HydraRenderer {
 
     this.generator = undefined
 
-    this._initRegl()
+    // Initialize renderer
+    this.renderer = new WebGL1Renderer()
+    this.renderer.init(this.canvas, {
+      precision: this.precision,
+      width: this.width,
+      height: this.height,
+      pb: this.pb
+    })
+
+    // Expose renderer and regl for backward compatibility
+    this.regl = this.renderer.regl
+    this.synth.renderer = this.renderer
+
     this._initOutputs(numOutputs)
     this._initSources(numSources)
     this._generateGlslTransforms()
@@ -168,21 +178,13 @@ class HydraRenderer {
 
   setResolution(width, height) {
   //  console.log(width, height)
-    this.canvas.width = width
-    this.canvas.height = height
-    this.width = width // is this necessary?
-    this.height = height // ?
+    this.width = width
+    this.height = height
     this.sandbox.set('width', width)
     this.sandbox.set('height', height)
     console.log(this.width)
-    this.o.forEach((output) => {
-      output.resize(width, height)
-    })
-    this.s.forEach((source) => {
-      source.resize(width, height)
-    })
-    this.regl._refresh()
-     console.log(this.canvas.width)
+    this.renderer.resize(width, height)
+    console.log(this.canvas.width)
   }
 
   canvasToImage (callback) {
@@ -246,129 +248,14 @@ class HydraRenderer {
     }
   }
 
-  _initRegl () {
-    this.regl = regl({
-    //  profile: true,
-      canvas: this.canvas,
-      pixelRatio: 1//,
-      // extensions: [
-      //   'oes_texture_half_float',
-      //   'oes_texture_half_float_linear'
-      // ],
-      // optionalExtensions: [
-      //   'oes_texture_float',
-      //   'oes_texture_float_linear'
-     //]
-   })
-
-    // This clears the color buffer to black and the depth buffer to 1
-    this.regl.clear({
-      color: [0, 0, 0, 1]
-    })
-
-    this.renderAll = this.regl({
-      frag: `
-      precision ${this.precision} float;
-      varying vec2 uv;
-      uniform sampler2D tex0;
-      uniform sampler2D tex1;
-      uniform sampler2D tex2;
-      uniform sampler2D tex3;
-
-      void main () {
-        vec2 st = vec2(1.0 - uv.x, uv.y);
-        st*= vec2(2);
-        vec2 q = floor(st).xy*(vec2(2.0, 1.0));
-        int quad = int(q.x) + int(q.y);
-        st.x += step(1., mod(st.y,2.0));
-        st.y += step(1., mod(st.x,2.0));
-        st = fract(st);
-        if(quad==0){
-          gl_FragColor = texture2D(tex0, st);
-        } else if(quad==1){
-          gl_FragColor = texture2D(tex1, st);
-        } else if (quad==2){
-          gl_FragColor = texture2D(tex2, st);
-        } else {
-          gl_FragColor = texture2D(tex3, st);
-        }
-
-      }
-      `,
-      vert: `
-      precision ${this.precision} float;
-      attribute vec2 position;
-      varying vec2 uv;
-
-      void main () {
-        uv = position;
-        gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
-      }`,
-      attributes: {
-        position: [
-          [-2, 0],
-          [0, -2],
-          [2, 2]
-        ]
-      },
-      uniforms: {
-        tex0: this.regl.prop('tex0'),
-        tex1: this.regl.prop('tex1'),
-        tex2: this.regl.prop('tex2'),
-        tex3: this.regl.prop('tex3')
-      },
-      count: 3,
-      depth: { enable: false }
-    })
-
-    this.renderFbo = this.regl({
-      frag: `
-      precision ${this.precision} float;
-      varying vec2 uv;
-      uniform vec2 resolution;
-      uniform sampler2D tex0;
-
-      void main () {
-        gl_FragColor = texture2D(tex0, vec2(1.0 - uv.x, uv.y));
-      }
-      `,
-      vert: `
-      precision ${this.precision} float;
-      attribute vec2 position;
-      varying vec2 uv;
-
-      void main () {
-        uv = position;
-        gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
-      }`,
-      attributes: {
-        position: [
-          [-2, 0],
-          [0, -2],
-          [2, 2]
-        ]
-      },
-      uniforms: {
-        tex0: this.regl.prop('tex0'),
-        resolution: this.regl.prop('resolution')
-      },
-      count: 3,
-      depth: { enable: false }
-    })
-  }
-
   _initOutputs (numOutputs) {
     const self = this
     this.o = (Array(numOutputs)).fill().map((el, index) => {
-      var o = new Output({
-        regl: this.regl,
+      var o = this.renderer.createOutput(index, {
         width: this.width,
         height: this.height,
-        precision: this.precision,
         label: `o${index}`
       })
-    //  o.render()
-      o.id = index
       self.synth['o'+index] = o
       return o
     })
@@ -385,7 +272,11 @@ class HydraRenderer {
   }
 
   createSource (i) {
-    let s = new Source({regl: this.regl, pb: this.pb, width: this.width, height: this.height, label: `s${i}`})
+    let s = this.renderer.createSource(this.s.length, {
+      width: this.width,
+      height: this.height,
+      label: `s${i}`
+    })
     this.synth['s' + this.s.length] = s
     this.s.push(s)
     return s
@@ -397,6 +288,7 @@ class HydraRenderer {
       defaultOutput: this.o[0],
       defaultUniforms: this.o[0].uniforms,
       extendTransforms: this.extendTransforms,
+      renderer: this.renderer,
       changeListener: ({type, method, synth}) => {
           if (type === 'add') {
             self.synth[method] = synth.generators[method]
@@ -449,19 +341,9 @@ class HydraRenderer {
         })
       }
       if (this.isRenderingAll) {
-        this.renderAll({
-          tex0: this.o[0].getCurrent(),
-          tex1: this.o[1].getCurrent(),
-          tex2: this.o[2].getCurrent(),
-          tex3: this.o[3].getCurrent(),
-          resolution: [this.canvas.width, this.canvas.height]
-        })
+        this.renderer.renderAllToScreen(this.o)
       } else {
-
-        this.renderFbo({
-          tex0: this.output.getCurrent(),
-          resolution: [this.canvas.width, this.canvas.height]
-        })
+        this.renderer.renderToScreen(this.output)
       }
       if(this.synth.afterUpdate) {
         try { this.synth.afterUpdate(this.timeSinceLastUpdate) } catch (e) { console.log(e) }

--- a/src/renderer/RendererInterface.js
+++ b/src/renderer/RendererInterface.js
@@ -1,0 +1,211 @@
+/**
+ * Abstract Renderer Interface
+ *
+ * All rendering backends (WebGL1, WebGL2, WebGPU) must implement this interface.
+ * This allows Hydra core to remain renderer-agnostic.
+ *
+ * The renderer provides hooks for:
+ * - Shader generation (which language, how to build shader strings)
+ * - Output/Source management
+ * - Rendering execution
+ */
+
+export class RendererInterface {
+
+  /**
+   * Initialize the renderer with a canvas
+   * @param {HTMLCanvasElement} canvas - Target canvas
+   * @param {Object} options - Renderer options
+   * @param {string} options.precision - Float precision ('lowp', 'mediump', 'highp')
+   * @param {number} options.width - Initial width
+   * @param {number} options.height - Initial height
+   * @returns {void|Promise<void>} - May be sync (WebGL) or async (WebGPU)
+   */
+  init(canvas, options = {}) {
+    throw new Error('RendererInterface.init() must be implemented')
+  }
+
+  /**
+   * Clean up all resources
+   */
+  destroy() {
+    throw new Error('RendererInterface.destroy() must be implemented')
+  }
+
+  /**
+   * Resize all outputs and refresh context
+   * @param {number} width
+   * @param {number} height
+   */
+  resize(width, height) {
+    throw new Error('RendererInterface.resize() must be implemented')
+  }
+
+  // ============================================================
+  // Output Management
+  // ============================================================
+
+  /**
+   * Create an output buffer (o0, o1, o2, o3)
+   * @param {number} index - Output index
+   * @param {Object} options - { width, height, label }
+   * @returns {OutputBuffer} - Renderer-specific output buffer
+   */
+  createOutput(index, options = {}) {
+    throw new Error('RendererInterface.createOutput() must be implemented')
+  }
+
+  /**
+   * Get an output by index
+   * @param {number} index
+   * @returns {OutputBuffer}
+   */
+  getOutput(index) {
+    throw new Error('RendererInterface.getOutput() must be implemented')
+  }
+
+  // ============================================================
+  // Source Management
+  // ============================================================
+
+  /**
+   * Create a source for external input (video, image, canvas)
+   * @param {number} index - Source index
+   * @param {Object} options - { width, height, label }
+   * @returns {Source} - Renderer-specific source
+   */
+  createSource(index, options = {}) {
+    throw new Error('RendererInterface.createSource() must be implemented')
+  }
+
+  // ============================================================
+  // Rendering
+  // ============================================================
+
+  /**
+   * Render a compiled pass to an output
+   * Called by Output.render() internally
+   * @param {OutputBuffer} output - Target output
+   * @param {Object} pass - { frag, uniforms }
+   */
+  renderPass(output, pass) {
+    throw new Error('RendererInterface.renderPass() must be implemented')
+  }
+
+  /**
+   * Execute a tick on an output (runs the compiled draw command)
+   * @param {OutputBuffer} output
+   * @param {Object} props - { time, mouse, bpm, resolution }
+   */
+  tickOutput(output, props) {
+    throw new Error('RendererInterface.tickOutput() must be implemented')
+  }
+
+  /**
+   * Render a single output to the canvas
+   * @param {OutputBuffer} output - Source output to display
+   */
+  renderToScreen(output) {
+    throw new Error('RendererInterface.renderToScreen() must be implemented')
+  }
+
+  /**
+   * Render all 4 outputs in a 2x2 grid to the canvas
+   * @param {Array<OutputBuffer>} outputs - Array of 4 outputs
+   */
+  renderAllToScreen(outputs) {
+    throw new Error('RendererInterface.renderAllToScreen() must be implemented')
+  }
+
+  // ============================================================
+  // Capabilities & Info
+  // ============================================================
+
+  /**
+   * Get renderer capabilities
+   * @returns {Object} - { name, glslVersion, ... }
+   */
+  get capabilities() {
+    throw new Error('RendererInterface.capabilities must be implemented')
+  }
+
+  /**
+   * Get the underlying canvas
+   * @returns {HTMLCanvasElement}
+   */
+  get canvas() {
+    throw new Error('RendererInterface.canvas must be implemented')
+  }
+
+  /**
+   * Get current width
+   * @returns {number}
+   */
+  get width() {
+    throw new Error('RendererInterface.width must be implemented')
+  }
+
+  /**
+   * Get current height
+   * @returns {number}
+   */
+  get height() {
+    throw new Error('RendererInterface.height must be implemented')
+  }
+
+  // ============================================================
+  // Shader Generation Hooks
+  // ============================================================
+
+  /**
+   * Get the shader language this renderer uses.
+   * Used to select 'glsl' or 'wgsl' property from function dictionary.
+   * @returns {string} - 'glsl' or 'wgsl'
+   */
+  get shaderLanguage() {
+    return 'glsl'
+  }
+
+  /**
+   * Get utility functions in the renderer's shader language.
+   * @returns {Object} - Map of function name to shader code
+   */
+  getUtilityFunctions() {
+    throw new Error('RendererInterface.getUtilityFunctions() must be implemented')
+  }
+
+  /**
+   * Build a complete shader from transform info.
+   * @param {Object} shaderInfo - { fragColor, uniforms, glslFunctions }
+   * @param {Object} options - { precision }
+   * @returns {string} - Complete shader source code
+   */
+  buildShader(shaderInfo, options = {}) {
+    throw new Error('RendererInterface.buildShader() must be implemented')
+  }
+
+  // ============================================================
+  // Extension Points (optional overrides)
+  // ============================================================
+
+  /**
+   * Called before each frame
+   */
+  beginFrame() {}
+
+  /**
+   * Called after each frame
+   */
+  endFrame() {}
+
+  /**
+   * Hook called when a new transform function is registered.
+   * Allows renderer to add shader templates in its native language.
+   * @param {Object} transform - Transform definition
+   */
+  onTransformRegistered(transform) {
+    // Optional: renderer can add missing shader templates
+  }
+}
+
+export default RendererInterface

--- a/src/renderer/WebGL1Renderer.js
+++ b/src/renderer/WebGL1Renderer.js
@@ -1,0 +1,349 @@
+/**
+ * WebGL1 Renderer Implementation
+ *
+ * Wraps existing regl-based rendering code to implement the RendererInterface.
+ * This is the default renderer for hydra-synth.
+ */
+
+import { RendererInterface } from './RendererInterface.js'
+import Output from '../output.js'
+import Source from '../hydra-source.js'
+import regl from 'regl'
+import utilityGlsl from '../glsl/utility-functions.js'
+
+export class WebGL1Renderer extends RendererInterface {
+
+  constructor() {
+    super()
+    this._canvas = null
+    this._regl = null
+    this._width = 0
+    this._height = 0
+    this._precision = 'mediump'
+    this._outputs = []
+    this._sources = []
+
+    // Compiled regl commands for screen rendering
+    this._renderFboCommand = null
+    this._renderAllCommand = null
+  }
+
+  init(canvas, options = {}) {
+    const {
+      precision = 'mediump',
+      width = canvas.width || 1280,
+      height = canvas.height || 720,
+      pb = null
+    } = options
+
+    this._canvas = canvas
+    this._width = width
+    this._height = height
+    this._precision = precision
+    this._pb = pb
+
+    // Initialize regl context
+    this._regl = regl({
+      canvas: this._canvas,
+      pixelRatio: 1
+    })
+
+    // Clear to black
+    this._regl.clear({
+      color: [0, 0, 0, 1]
+    })
+
+    // Create the renderFbo command (single output to screen)
+    this._renderFboCommand = this._regl({
+      frag: `
+      precision ${this._precision} float;
+      varying vec2 uv;
+      uniform vec2 resolution;
+      uniform sampler2D tex0;
+
+      void main () {
+        gl_FragColor = texture2D(tex0, vec2(1.0 - uv.x, uv.y));
+      }
+      `,
+      vert: `
+      precision ${this._precision} float;
+      attribute vec2 position;
+      varying vec2 uv;
+
+      void main () {
+        uv = position;
+        gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
+      }`,
+      attributes: {
+        position: [
+          [-2, 0],
+          [0, -2],
+          [2, 2]
+        ]
+      },
+      uniforms: {
+        tex0: this._regl.prop('tex0'),
+        resolution: this._regl.prop('resolution')
+      },
+      count: 3,
+      depth: { enable: false }
+    })
+
+    // Create the renderAll command (4-up grid)
+    this._renderAllCommand = this._regl({
+      frag: `
+      precision ${this._precision} float;
+      varying vec2 uv;
+      uniform sampler2D tex0;
+      uniform sampler2D tex1;
+      uniform sampler2D tex2;
+      uniform sampler2D tex3;
+
+      void main () {
+        vec2 st = vec2(1.0 - uv.x, uv.y);
+        st*= vec2(2);
+        vec2 q = floor(st).xy*(vec2(2.0, 1.0));
+        int quad = int(q.x) + int(q.y);
+        st.x += step(1., mod(st.y,2.0));
+        st.y += step(1., mod(st.x,2.0));
+        st = fract(st);
+        if(quad==0){
+          gl_FragColor = texture2D(tex0, st);
+        } else if(quad==1){
+          gl_FragColor = texture2D(tex1, st);
+        } else if (quad==2){
+          gl_FragColor = texture2D(tex2, st);
+        } else {
+          gl_FragColor = texture2D(tex3, st);
+        }
+
+      }
+      `,
+      vert: `
+      precision ${this._precision} float;
+      attribute vec2 position;
+      varying vec2 uv;
+
+      void main () {
+        uv = position;
+        gl_Position = vec4(1.0 - 2.0 * position, 0, 1);
+      }`,
+      attributes: {
+        position: [
+          [-2, 0],
+          [0, -2],
+          [2, 2]
+        ]
+      },
+      uniforms: {
+        tex0: this._regl.prop('tex0'),
+        tex1: this._regl.prop('tex1'),
+        tex2: this._regl.prop('tex2'),
+        tex3: this._regl.prop('tex3')
+      },
+      count: 3,
+      depth: { enable: false }
+    })
+  }
+
+  destroy() {
+    if (this._regl) {
+      this._regl.destroy()
+      this._regl = null
+    }
+    this._outputs = []
+    this._sources = []
+  }
+
+  resize(width, height) {
+    this._width = width
+    this._height = height
+    this._canvas.width = width
+    this._canvas.height = height
+
+    // Resize all outputs
+    this._outputs.forEach(output => {
+      output.resize(width, height)
+    })
+
+    // Resize all sources
+    this._sources.forEach(source => {
+      source.resize(width, height)
+    })
+
+    // Refresh regl state
+    this._regl._refresh()
+  }
+
+  // ============================================================
+  // Output Management
+  // ============================================================
+
+  createOutput(index, options = {}) {
+    const output = new Output({
+      regl: this._regl,
+      width: options.width || this._width,
+      height: options.height || this._height,
+      precision: this._precision,
+      label: options.label || `o${index}`
+    })
+    output.id = index
+    this._outputs[index] = output
+    return output
+  }
+
+  getOutput(index) {
+    return this._outputs[index]
+  }
+
+  // ============================================================
+  // Source Management
+  // ============================================================
+
+  createSource(index, options = {}) {
+    const source = new Source({
+      regl: this._regl,
+      pb: this._pb,
+      width: options.width || this._width,
+      height: options.height || this._height,
+      label: options.label || `s${index}`
+    })
+    this._sources[index] = source
+    return source
+  }
+
+  // ============================================================
+  // Rendering
+  // ============================================================
+
+  renderPass(output, pass) {
+    // This delegates to Output.render() which sets up the draw command
+    output.render([pass])
+  }
+
+  tickOutput(output, props) {
+    output.tick(props)
+  }
+
+  renderToScreen(output) {
+    this._renderFboCommand({
+      tex0: output.getCurrent(),
+      resolution: [this._width, this._height]
+    })
+  }
+
+  renderAllToScreen(outputs) {
+    this._renderAllCommand({
+      tex0: outputs[0].getCurrent(),
+      tex1: outputs[1].getCurrent(),
+      tex2: outputs[2].getCurrent(),
+      tex3: outputs[3].getCurrent(),
+      resolution: [this._width, this._height]
+    })
+  }
+
+  // ============================================================
+  // Capabilities & Info
+  // ============================================================
+
+  get capabilities() {
+    const gl = this._regl._gl
+    return {
+      name: 'webgl1',
+      glslVersion: '100',
+      instancing: !!gl.getExtension('ANGLE_instanced_arrays'),
+      floatTextures: !!gl.getExtension('OES_texture_float'),
+      halfFloatTextures: !!gl.getExtension('OES_texture_half_float'),
+      maxTextureSize: gl.getParameter(gl.MAX_TEXTURE_SIZE),
+      maxTextureUnits: gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS)
+    }
+  }
+
+  get canvas() {
+    return this._canvas
+  }
+
+  get width() {
+    return this._width
+  }
+
+  get height() {
+    return this._height
+  }
+
+  // ============================================================
+  // Additional accessors for compatibility
+  // ============================================================
+
+  get regl() {
+    return this._regl
+  }
+
+  get precision() {
+    return this._precision
+  }
+
+  get outputs() {
+    return this._outputs
+  }
+
+  get sources() {
+    return this._sources
+  }
+
+  // ============================================================
+  // Shader Generation Hooks
+  // ============================================================
+
+  get shaderLanguage() {
+    return 'glsl'
+  }
+
+  getUtilityFunctions() {
+    return utilityGlsl
+  }
+
+  buildShader(shaderInfo, options = {}) {
+    const precision = options.precision || this._precision
+
+    return `
+  precision ${precision} float;
+  ${Object.values(shaderInfo.uniforms).map((uniform) => {
+    let type = uniform.type
+    switch (uniform.type) {
+      case 'texture':
+        type = 'sampler2D'
+        break
+    }
+    return `
+      uniform ${type} ${uniform.name};`
+  }).join('')}
+  uniform float time;
+  uniform vec2 resolution;
+  varying vec2 uv;
+  uniform sampler2D prevBuffer;
+
+  ${Object.values(utilityGlsl).map((transform) => {
+    return `
+            ${transform.glsl}
+          `
+  }).join('')}
+
+  ${shaderInfo.glslFunctions.map((transform) => {
+    const shaderCode = transform.transform[this.shaderLanguage] || transform.transform.glsl
+    return `
+            ${shaderCode}
+          `
+  }).join('')}
+
+  void main () {
+    vec2 st = gl_FragCoord.xy/resolution.xy;
+
+    ${shaderInfo.fragColor}
+    gl_FragColor = c;
+  }
+  `
+  }
+}
+
+export default WebGL1Renderer

--- a/src/renderer/WebGPURenderer.js
+++ b/src/renderer/WebGPURenderer.js
@@ -1,0 +1,327 @@
+/**
+ * WebGPU Renderer Implementation
+ *
+ * Wraps the existing wgslHydra and OutputWgsl from the vertex extension
+ * to implement the RendererInterface. This validates the interface design
+ * for WebGPU support.
+ *
+ * NOTE: This renderer requires the vertex extension's WebGPU infrastructure.
+ * It's a proof-of-concept to validate the interface, not a standalone WebGPU renderer.
+ */
+
+import { RendererInterface } from './RendererInterface.js'
+
+// Dynamic imports for WebGPU components (from vertex extension)
+let wgslHydra = null
+let OutputWgsl = null
+let Source = null
+
+export class WebGPURenderer extends RendererInterface {
+
+  constructor() {
+    super()
+    this._canvas = null
+    this._wgslHydra = null
+    this._width = 0
+    this._height = 0
+    this._precision = 'highp' // WebGPU uses high precision by default
+    this._outputs = []
+    this._sources = []
+    this._hydra = null // Reference to parent hydra instance
+    this._initialized = false
+  }
+
+  /**
+   * Initialize the WebGPU renderer
+   * Note: WebGPU initialization is async, so this returns a Promise
+   */
+  async init(canvas, options = {}) {
+    const {
+      precision = 'highp',
+      width = canvas.width || 1280,
+      height = canvas.height || 720,
+      numOutputs = 4,
+      hydra = null,
+      gpuDevice = null
+    } = options
+
+    this._canvas = canvas
+    this._width = width
+    this._height = height
+    this._precision = precision
+    this._hydra = hydra
+
+    // Check for WebGPU support
+    if (!navigator.gpu) {
+      throw new Error('WebGPU is not supported in this browser')
+    }
+
+    // Dynamically import WebGPU components from vertex extension
+    try {
+      const wgslModule = await import('../../extensions/vertex/wgsl/wgsl-hydra.js')
+      const outputModule = await import('../../extensions/vertex/wgsl/outputWgsl.js')
+      const sourceModule = await import('../../extensions/vertex/hydra-source.js')
+
+      wgslHydra = wgslModule.wgslHydra
+      OutputWgsl = outputModule.OutputWgsl
+      Source = sourceModule.default
+    } catch (e) {
+      throw new Error('WebGPU renderer requires vertex extension: ' + e.message)
+    }
+
+    // Create hydra shim - wgslHydra keeps a reference to this
+    // so when we add outputs to .o, wgslHydra can access them
+    const hydraShim = {
+      o: [],
+      synth: hydra?.synth || {
+        time: 0,
+        mouse: { x: 0, y: 0 },
+        width: width,
+        height: height
+      }
+    }
+    this._hydraShim = hydraShim
+
+    // Create the wgslHydra instance (holds reference to hydraShim)
+    this._wgslHydra = new wgslHydra(hydraShim, this._canvas, numOutputs, gpuDevice)
+
+    // Create output objects BEFORE setupHydra (it needs them for createOutputTextures)
+    for (let i = 0; i < numOutputs; i++) {
+      const output = new OutputWgsl({
+        wgslHydra: this._wgslHydra,
+        hydraSynth: hydra || hydraShim,
+        width: this._width,
+        height: this._height,
+        chanNum: i,
+        label: `o${i}`
+      })
+      output.id = i
+      output.precision = this._precision
+      hydraShim.o.push(output)
+      this._outputs[i] = output
+    }
+
+    // Now setup WebGPU context and pipelines (uses hydraShim.o for output textures)
+    await this._wgslHydra.setupHydra()
+
+    this._initialized = true
+  }
+
+  destroy() {
+    // WebGPU cleanup
+    if (this._wgslHydra) {
+      // Clear sprite chains
+      for (let i = 0; i < this._wgslHydra.numChannels; i++) {
+        if (this._wgslHydra.clearSpriteChains) {
+          this._wgslHydra.clearSpriteChains(i)
+        }
+      }
+      // Destroy output textures
+      this._outputs.forEach(output => {
+        if (output.textures) {
+          output.textures.forEach(tex => tex?.destroy?.())
+        }
+      })
+      // Destroy depth texture
+      if (this._wgslHydra.depthTexture) {
+        this._wgslHydra.depthTexture.destroy()
+      }
+      this._wgslHydra = null
+    }
+    this._outputs = []
+    this._sources = []
+    this._initialized = false
+  }
+
+  async resize(width, height) {
+    this._width = width
+    this._height = height
+    this._canvas.width = width
+    this._canvas.height = height
+
+    if (this._wgslHydra) {
+      await this._wgslHydra.resizeOutputsTo(width, height)
+    }
+
+    // Resize sources
+    this._sources.forEach(source => {
+      if (source.resize) source.resize(width, height)
+    })
+  }
+
+  // ============================================================
+  // Output Management
+  // ============================================================
+
+  createOutput(index, options = {}) {
+    // In WebGPU mode, outputs are created during init
+    // This method just returns the already-created output
+    if (this._outputs[index]) {
+      return this._outputs[index]
+    }
+
+    // Create a new output if needed
+    const output = new OutputWgsl({
+      wgslHydra: this._wgslHydra,
+      hydraSynth: this._hydra,
+      width: options.width || this._width,
+      height: options.height || this._height,
+      chanNum: index,
+      label: options.label || `o${index}`
+    })
+    output.id = index
+    output.precision = this._precision
+    this._outputs[index] = output
+    return output
+  }
+
+  getOutput(index) {
+    return this._outputs[index]
+  }
+
+  // ============================================================
+  // Source Management
+  // ============================================================
+
+  createSource(index, options = {}) {
+    const source = new Source({
+      regl: null,  // Not used in WebGPU mode
+      wgsl: this._wgslHydra,
+      hydraSynth: this._hydra,
+      pb: options.pb || null,
+      width: options.width || this._width,
+      height: options.height || this._height,
+      chanNum: index,
+      label: options.label || `s${index}`
+    })
+    this._sources[index] = source
+    return source
+  }
+
+  // ============================================================
+  // Rendering
+  // ============================================================
+
+  renderPass(output, pass) {
+    // In WebGPU, passes are registered via output.render()
+    // The actual rendering happens in tickOutput/animate
+    if (output.render) {
+      output.render([pass])
+    }
+  }
+
+  tickOutput(output, props) {
+    // WebGPU outputs don't have a separate tick - rendering happens in animate()
+    // But we can update any per-output state here
+    if (output.tick) {
+      output.tick(props)
+    }
+  }
+
+  renderToScreen(output) {
+    // In WebGPU, screen rendering is handled by animate()
+    // This sets which output to display
+    this._wgslHydra.showQuad = false
+    this._wgslHydra.outChannel = output.id
+  }
+
+  renderAllToScreen(outputs) {
+    // In WebGPU, 4-up rendering is handled by animate()
+    this._wgslHydra.showQuad = true
+  }
+
+  /**
+   * Main render call - executes all pending renders
+   * Called each frame after tickOutput calls
+   */
+  async render(time, mouse, resolution, isRenderingAll) {
+    if (!this._wgslHydra || !this._initialized) return
+
+    // Update mouse position
+    if (mouse) {
+      this._wgslHydra.relayUniformInfo(mouse)
+    }
+
+    // Execute the render
+    await this._wgslHydra.animate(time, mouse, resolution, isRenderingAll)
+  }
+
+  // ============================================================
+  // Capabilities & Info
+  // ============================================================
+
+  get capabilities() {
+    const limits = this._wgslHydra?.device?.limits || {}
+    return {
+      name: 'webgpu',
+      glslVersion: 'wgsl',
+      instancing: true,
+      floatTextures: true,
+      halfFloatTextures: true,
+      maxTextureSize: limits.maxTextureDimension2D || 8192,
+      maxTextureUnits: limits.maxSampledTexturesPerShaderStage || 16,
+      computeShaders: true,
+      storageTextures: true
+    }
+  }
+
+  get canvas() {
+    return this._canvas
+  }
+
+  get width() {
+    return this._width
+  }
+
+  get height() {
+    return this._height
+  }
+
+  // ============================================================
+  // Additional accessors for compatibility
+  // ============================================================
+
+  /**
+   * Get the underlying wgslHydra instance
+   */
+  get wgslHydra() {
+    return this._wgslHydra
+  }
+
+  /**
+   * Get the GPU device
+   */
+  get device() {
+    return this._wgslHydra?.device
+  }
+
+  /**
+   * Get precision setting
+   */
+  get precision() {
+    return this._precision
+  }
+
+  /**
+   * Get all outputs
+   */
+  get outputs() {
+    return this._outputs
+  }
+
+  /**
+   * Get all sources
+   */
+  get sources() {
+    return this._sources
+  }
+
+  /**
+   * Check if initialized
+   */
+  get initialized() {
+    return this._initialized
+  }
+}
+
+export default WebGPURenderer

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -1,0 +1,26 @@
+/**
+ * Renderer Module
+ *
+ * Exports the renderer interface and available implementations.
+ */
+
+export { RendererInterface } from './RendererInterface.js'
+export { WebGL1Renderer } from './WebGL1Renderer.js'
+
+// Default renderer
+export { WebGL1Renderer as default } from './WebGL1Renderer.js'
+
+/**
+ * Create a renderer by name
+ * @param {string} name - 'webgl1', 'webgl', or 'auto'
+ * @returns {RendererInterface}
+ */
+export function createRenderer(name = 'webgl1') {
+  switch (name.toLowerCase()) {
+    case 'webgl1':
+    case 'webgl':
+    case 'auto':
+    default:
+      return new WebGL1Renderer()
+  }
+}


### PR DESCRIPTION
## Summary

Introduces a renderer abstraction layer that allows different rendering backends to be used with hydra-synth. This enables future support for WebGPU and other rendering technologies without modifying core code.

- Add `RendererInterface` base class defining the renderer contract
- Add `WebGL1Renderer` implementing the interface using existing regl code
- Update core to use renderer for initialization and rendering
- Add `buildShader()` hook for custom shader generation

## Renderer Interface Hooks

The interface provides hooks for:
- **Output/source management** - `createOutput()`, `createSource()`
- **Screen rendering** - `renderToScreen()`, `renderAllToScreen()`
- **Shader generation** - `shaderLanguage`, `buildShader()`, `getUtilityFunctions()`
- **Transform registration** - `onTransformRegistered()` callback

## Backward Compatibility

- `this.regl` is still exposed for existing code
- No changes to the public API
- All existing Hydra sketches work unchanged

## Test plan

- [x] Basic patterns (`osc`, `noise`, `shape`)
- [x] Modulation (`modulate`, `modulateRotate`)
- [x] Color transforms (`color`, `saturate`, `contrast`)
- [x] Combining (`diff`, `blend`, `add`, `mult`)
- [x] Complex chains with multiple transforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)