### PR TITLE
Add ANGLE_instanced_arrays as optional extension

### DIFF
--- a/src/hydra-synth.js
+++ b/src/hydra-synth.js
@@ -250,15 +250,16 @@ class HydraRenderer {
     this.regl = regl({
     //  profile: true,
       canvas: this.canvas,
-      pixelRatio: 1//,
+      pixelRatio: 1,
       // extensions: [
       //   'oes_texture_half_float',
       //   'oes_texture_half_float_linear'
       // ],
-      // optionalExtensions: [
+      optionalExtensions: [
       //   'oes_texture_float',
-      //   'oes_texture_float_linear'
-     //]
+      //   'oes_texture_float_linear',
+        'ANGLE_instanced_arrays'
+      ]
    })
 
     // This clears the color buffer to black and the depth buffer to 1


### PR DESCRIPTION
## Summary

- Enable WebGL instanced rendering support by requesting the `ANGLE_instanced_arrays` extension when initializing regl
- Uses `optionalExtensions` so it won't break on browsers/devices where the extension isn't available

## Motivation

This allows extensions and custom code to use instanced drawing (regl's `instances` and `divisor` options) for efficiently rendering multiple copies of geometry. Use cases include:

- Particle systems
- Starfields
- Scatter/grid effects
- Any effect that renders many similar objects

Without this extension requested at regl initialization time, regl cannot use instanced rendering even if the browser supports it.

## Test plan

1. Open hydra.ojack.xyz
2. In console: `hydraSynth.regl.hasExtension('ANGLE_instanced_arrays')` should return `true`
3. Extensions using instanced rendering (like the [vertex extension](https://github.com/ojack/hydra-synth/discussions/294)) will now be able to use GPU instancing

🤖 Generated with [Claude Code](https://claude.com/claude-code)